### PR TITLE
feat: updates to codespace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,5 @@
 FROM us-docker.pkg.dev/elide-fw/tools/codespace:latest
+RUN go env -w GOPROXY=https://go.stage.pkg.st,direct
+COPY init.gradle.kts /home/dev/.gradle/init.gradle.kts
 ENTRYPOINT ["/usr/local/share/docker-init.sh"]
 CMD ["sleep", "infinity"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,23 @@
 FROM ghcr.io/elide-dev/codespace@sha256:4ee81688a0be011baeca66129ebd73b14e5fa0c8bb72ae5ac67d8696f413d24d
 
-RUN go env -w GOPROXY=https://go.stage.pkg.st,direct \
-    && chown -R dev /home/dev/.gradle \
-    && curl -sSL --tlsv1.2 "dl.elide.dev/cli/install.sh" | bash -s - \
-    && curl -sSL --tlsv1.2 "https://github.com/buildless/cli/releases/download/1.0.0-beta1/buildless.linux-amd64.tar.gz" > buildless.tar.gz \
-    && tar -xzvf buildless.tar.gz \
-    && mv buildless /usr/bin/buildless \
-    && rm -fv buildless.tar.gz;
+USER root
 
+RUN apt-get update && apt-get install -y uuid-runtime
+
+USER dev
+
+RUN go env -w GOPROXY=https://go.stage.pkg.st,direct;
+
+RUN curl -sSL --tlsv1.2 "dl.elide.dev/cli/install.sh" | bash -s -
+
+RUN curl -sSL --tlsv1.2 "https://github.com/buildless/cli/releases/download/1.0.0-beta1/buildless.linux-amd64.tar.gz" > buildless.tar.gz \
+    && tar -xzvf buildless.tar.gz \
+    && sudo mv buildless.linux-amd64/buildless /usr/local/bin/buildless \
+    && rm -frv buildless.tar.gz buildless.linux-amd64;
 
 ENV GRAALVM_HOME=/usr/lib/gvm
 
+COPY buildless.yaml /home/dev/.config/buildless/buildless.yaml
 COPY init.gradle.kts /home/dev/.gradle/init.gradle.kts
 ENTRYPOINT ["/usr/local/share/docker-init.sh"]
 CMD ["sleep", "infinity"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,16 @@
-FROM us-docker.pkg.dev/elide-fw/tools/codespace:latest
-RUN go env -w GOPROXY=https://go.stage.pkg.st,direct
+FROM ghcr.io/elide-dev/codespace@sha256:4ee81688a0be011baeca66129ebd73b14e5fa0c8bb72ae5ac67d8696f413d24d
+
+RUN go env -w GOPROXY=https://go.stage.pkg.st,direct \
+    && chown -R dev /home/dev/.gradle \
+    && curl -sSL --tlsv1.2 "dl.elide.dev/cli/install.sh" | bash -s - \
+    && curl -sSL --tlsv1.2 "https://github.com/buildless/cli/releases/download/1.0.0-beta1/buildless.linux-amd64.tar.gz" > buildless.tar.gz \
+    && tar -xzvf buildless.tar.gz \
+    && mv buildless /usr/bin/buildless \
+    && rm -fv buildless.tar.gz;
+
+
+ENV GRAALVM_HOME=/usr/lib/gvm
+
 COPY init.gradle.kts /home/dev/.gradle/init.gradle.kts
 ENTRYPOINT ["/usr/local/share/docker-init.sh"]
 CMD ["sleep", "infinity"]

--- a/.devcontainer/buildless.yaml
+++ b/.devcontainer/buildless.yaml
@@ -1,0 +1,1 @@
+debug: true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,11 @@
   },
   "runArgs": ["--init", "--privileged"],
   "overrideCommand": false,
+  "hostRequirements": {
+    "cpus": 16,
+    "memory": "32gb",
+    "storage": "128gb"
+  },
   "extensions": [
     "asf.apache-netbeans-java",
     "bazelbuild.vscode-bazel",
@@ -40,6 +45,19 @@
     "ghcr.io/devcontainers/features/go:1": {"version":  "1.19"},
     "ghcr.io/devcontainers/features/sshd:1": {"version": "latest"},
     "ghcr.io/devcontainers/features/docker-from-docker:1": {}
+  },
+  "customizations": {
+    "codespaces": {
+      "openFiles": [
+        "README.md"
+      ]
+    }
+  },
+  "secrets": {
+    "BUILDLESS_APIKEY": {
+      "description": "API key for build caching via Buildless.",
+      "documentationUrl": "https://docs.less.build/reference/intro/getting-started"
+    }
   },
   "updateContentCommand": "./gradlew dependencies --refresh-dependencies && ./gradlew tasks && git checkout kotlin-js-store || exit 0",
   "forwardPorts": [8080, 50051],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,6 @@
     "storage": "128gb"
   },
   "extensions": [
-    "asf.apache-netbeans-java",
     "bazelbuild.vscode-bazel",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
@@ -29,7 +28,6 @@
     "ms-vscode.vscode-typescript-tslint-plugin",
     "redhat.vscode-yaml",
     "naco-siren.gradle-language",
-    "vscjava.vscode-gradle",
     "bufbuild.vscode-buf",
     "sswg.swift-lang",
     "fwcd.kotlin",
@@ -46,8 +44,25 @@
     "ghcr.io/devcontainers/features/sshd:1": {"version": "latest"},
     "ghcr.io/devcontainers/features/docker-from-docker:1": {}
   },
+  "remoteEnv": {
+    "ELIDE_ENV": "codespace",
+    "TEST_EXCEPTIONS": "true",
+    "GRAALVM_HOME": "/usr/lib/gvm",
+    "GRAALVM_HOME": "/usr/lib/gvm"
+  },
   "customizations": {
+    "vscode": {
+      "settings": {}
+		},
     "codespaces": {
+      "repositories": {
+        "elide-dev/runtime": {
+          "permissions": {
+            "issues": "read",
+            "pull_requests": "read"
+          }
+        }
+      },
       "openFiles": [
         "README.md"
       ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -74,7 +74,8 @@
       "documentationUrl": "https://docs.less.build/reference/intro/getting-started"
     }
   },
-  "updateContentCommand": "./gradlew dependencies --refresh-dependencies && ./gradlew tasks && git checkout kotlin-js-store || exit 0",
+  "updateContentCommand": "./gradlew dependencies --refresh-dependencies && ./gradlew tasks && git checkout kotlin-js-store || exit 0 && sudo chown -R dev /home/dev/.gradle || echo 'Failed to set dev permissions'",
+  "postAttachCommand": "elide --help",
   "forwardPorts": [8080, 50051],
   "remoteUser": "dev"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,12 +3,6 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "settings": {
-    "netbeans.jdkhome": "/usr/lib/gvm",
-    "java.completion.enabled": true,
-    "java.debug.settings.enableRunDebugCodeLens": true,
-    "java.test.editor.enableShortcuts": true
-  },
   "runArgs": ["--init", "--privileged"],
   "overrideCommand": false,
   "hostRequirements": {
@@ -16,27 +10,6 @@
     "memory": "32gb",
     "storage": "128gb"
   },
-  "extensions": [
-    "bazelbuild.vscode-bazel",
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "mathiasfrohlich.kotlin",
-    "github.codespaces",
-    "github.copilot",
-    "ms-azuretools.vscode-docker",
-    "ms-vscode-remote.remote-containers",
-    "ms-vscode.vscode-typescript-tslint-plugin",
-    "redhat.vscode-yaml",
-    "naco-siren.gradle-language",
-    "bufbuild.vscode-buf",
-    "sswg.swift-lang",
-    "fwcd.kotlin",
-    "sourcegraph.sourcegraph",
-    "oracle-labs-graalvm.graalvm",
-    "oracle-labs-graalvm.graalvm-pack",
-    "oracle-labs-graalvm.micronaut",
-    "oracle-labs-graalvm.dashboard"
-  ],
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
@@ -47,12 +20,39 @@
   "remoteEnv": {
     "ELIDE_ENV": "codespace",
     "TEST_EXCEPTIONS": "true",
-    "GRAALVM_HOME": "/usr/lib/gvm",
     "GRAALVM_HOME": "/usr/lib/gvm"
   },
   "customizations": {
     "vscode": {
-      "settings": {}
+      "settings": {
+        "gradle.autoDetect": "off",
+        "netbeans.jdkhome": "/usr/lib/gvm",
+        "java.completion.enabled": true,
+        "java.debug.settings.enableRunDebugCodeLens": true,
+        "java.test.editor.enableShortcuts": true
+      },
+      "extensions": [
+        "asf.apache-netbeans-java",
+        "bazelbuild.vscode-bazel",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "mathiasfrohlich.kotlin",
+        "github.codespaces",
+        "github.copilot",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode-remote.remote-containers",
+        "ms-vscode.vscode-typescript-tslint-plugin",
+        "redhat.vscode-yaml",
+        "naco-siren.gradle-language",
+        "bufbuild.vscode-buf",
+        "sswg.swift-lang",
+        "fwcd.kotlin",
+        "sourcegraph.sourcegraph",
+        "oracle-labs-graalvm.graalvm",
+        "oracle-labs-graalvm.graalvm-pack",
+        "oracle-labs-graalvm.micronaut",
+        "oracle-labs-graalvm.dashboard"
+      ]
 		},
     "codespaces": {
       "repositories": {

--- a/.devcontainer/init.gradle.kts
+++ b/.devcontainer/init.gradle.kts
@@ -1,0 +1,7 @@
+val pkgst = true
+
+if (pkgst) allprojects {
+  repositories {
+    maven("https://maven.pkg.st/")
+  }
+}

--- a/.devcontainer/init.gradle.kts
+++ b/.devcontainer/init.gradle.kts
@@ -1,4 +1,4 @@
-val pkgst = true
+val pkgst = false
 
 if (pkgst) allprojects {
   repositories {


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Improvements and bugfixes for the main devcontainer / codespace.

## Changelog

- feat: recommended `BUILDLESS_APIKEY` secret
- feat: pkgst proxy for java and go deps
- feat: auto-open `README.md` on codespace open
- chore: upgrade gvm → `20.0.2`
- chore: set minimum machine size spec

### Known issues

- [x] dev user doesn't own `~/.gradle`
- [x] ~~gradle distributions don't use pkgst~~
- [x] ~~node distributions don't use pkgst~~
- [x] ~~upx isn't installed~~
- [x] elide isn't installed
- [x] graalvm is outdated
- [x] `export GRAALVM_HOME=/usr/lib/gvm` not working
- [x] GVM components: `graalvm,native-image` (only)
- [x] pkgst overwrites other repositories