### PR TITLE
feat: express middleware support

### DIFF
--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -411,7 +411,47 @@ public final synthetic class elide/runtime/gvm/internals/intrinsics/$ServiceIntr
 
 public final class elide/runtime/gvm/internals/intrinsics/js/JsProxy {
 	public static final field INSTANCE Lelide/runtime/gvm/internals/intrinsics/js/JsProxy;
+	public final fun build (Lkotlin/jvm/functions/Function1;)Lorg/graalvm/polyglot/proxy/ProxyObject;
 	public final fun wrap (Ljava/lang/Object;)Lelide/runtime/gvm/internals/intrinsics/js/JsProxy$PropertyProxy;
+}
+
+public final class elide/runtime/gvm/internals/intrinsics/js/JsProxy$MutableObjectProxy : org/graalvm/polyglot/proxy/ProxyObject {
+	public static final synthetic fun box-impl (Ljava/util/Map;)Lelide/runtime/gvm/internals/intrinsics/js/JsProxy$MutableObjectProxy;
+	public static synthetic fun constructor-impl$default (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)Ljava/util/Map;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/util/Map;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/util/Map;Ljava/util/Map;)Z
+	public fun getMember (Ljava/lang/String;)Ljava/lang/Object;
+	public static fun getMember-impl (Ljava/util/Map;Ljava/lang/String;)Ljava/lang/Object;
+	public fun getMemberKeys ()Ljava/lang/Object;
+	public static fun getMemberKeys-impl (Ljava/util/Map;)Ljava/lang/Object;
+	public fun hasMember (Ljava/lang/String;)Z
+	public static fun hasMember-impl (Ljava/util/Map;Ljava/lang/String;)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/util/Map;)I
+	public fun putMember (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public static fun putMember-impl (Ljava/util/Map;Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/util/Map;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/util/Map;
+}
+
+public final class elide/runtime/gvm/internals/intrinsics/js/JsProxy$MutableObjectProxy$Builder {
+	public static final synthetic fun box-impl (Ljava/util/Map;)Lelide/runtime/gvm/internals/intrinsics/js/JsProxy$MutableObjectProxy$Builder;
+	public static final fun build-Vf0lDTY (Ljava/util/Map;)Ljava/util/Map;
+	public static synthetic fun constructor-impl$default (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)Ljava/util/Map;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/util/Map;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/util/Map;Ljava/util/Map;)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/util/Map;)I
+	public static final fun put-impl (Ljava/util/Map;Ljava/lang/String;Ljava/lang/Object;)V
+	public static final fun putFunction-impl (Ljava/util/Map;Ljava/lang/String;Lorg/graalvm/polyglot/proxy/ProxyExecutable;)V
+	public static final fun putObject-impl (Ljava/util/Map;Ljava/lang/String;)V
+	public static final fun putObject-impl (Ljava/util/Map;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/util/Map;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/util/Map;
 }
 
 public final class elide/runtime/gvm/internals/intrinsics/js/JsProxy$PropertyProxy : org/graalvm/polyglot/proxy/ProxyObject {
@@ -1213,6 +1253,8 @@ public abstract interface class elide/runtime/intrinsics/js/express/ExpressApp {
 	public abstract fun options (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
 	public abstract fun post (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
 	public abstract fun put (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public abstract fun use (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public abstract fun use (Lorg/graalvm/polyglot/Value;)V
 }
 
 public abstract interface class elide/runtime/intrinsics/js/express/ExpressRequest {

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/express/ExpressAppIntrinsic.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/express/ExpressAppIntrinsic.kt
@@ -2,13 +2,20 @@ package elide.runtime.gvm.internals.intrinsics.js.express
 
 import io.netty.handler.codec.http.HttpMethod
 import org.graalvm.polyglot.Value
-import org.reactivestreams.Publisher
+import org.graalvm.polyglot.proxy.ProxyExecutable
+import org.graalvm.polyglot.proxy.ProxyObject
 import reactor.netty.http.server.HttpServer
 import reactor.netty.http.server.HttpServerRequest
-import reactor.netty.http.server.HttpServerResponse
-import reactor.netty.http.server.HttpServerRoutes
+import elide.runtime.Logging
 import elide.runtime.intrinsics.js.express.ExpressApp
 import elide.vm.annotations.Polyglot
+
+/**
+ * A function that tests whether an incoming [HttpServerRequest] should be passed to a handler, using a template string
+ * and optionally filtering by HTTP method. Path variables included in the template will be captured by the matcher and
+ * added to the request proxy.
+ */
+internal typealias ExpressPathMatcher = (path: String, method: String, proxy: ProxyObject) -> Boolean
 
 /**
  * An [ExpressApp] implemented as a wrapper around a Reactor Netty server.
@@ -17,40 +24,41 @@ import elide.vm.annotations.Polyglot
  * server to be built and bound to the specified port.
  */
 internal class ExpressAppIntrinsic(private val context: ExpressContext) : ExpressApp {
-  /** Represents a route handler registered by a guest script. */
-  private data class RouteHandler(
-    val method: HttpMethod,
-    val path: String,
-    val handler: Value,
+  /** Represents a route handler registered by guest code. */
+  private data class Handler(
+    val matches: ExpressPathMatcher,
+    val handle: Value,
   )
 
-  /** Internal collection of route handlers requested by guest scripts. */
-  private val routeRegistry = mutableSetOf<RouteHandler>()
+  private val logging by lazy { Logging.of(ExpressAppIntrinsic::class) }
 
-  @Polyglot override fun get(path: String, handler: Value) = registerRouteHandler(HttpMethod.GET, path, handler)
-  @Polyglot override fun post(path: String, handler: Value) = registerRouteHandler(HttpMethod.POST, path, handler)
-  @Polyglot override fun put(path: String, handler: Value) = registerRouteHandler(HttpMethod.PUT, path, handler)
-  @Polyglot override fun delete(path: String, handler: Value) = registerRouteHandler(HttpMethod.DELETE, path, handler)
-  @Polyglot override fun head(path: String, handler: Value) = registerRouteHandler(HttpMethod.HEAD, path, handler)
-  @Polyglot override fun options(path: String, handler: Value) = registerRouteHandler(HttpMethod.OPTIONS, path, handler)
+  /** Collection of ordered handlers registered by guest code, used to process incoming requests. */
+  private val pipeline = mutableListOf<Handler>()
+
+  @Polyglot override fun get(path: String, handler: Value) = registerHandler(handler, path, HttpMethod.GET)
+  @Polyglot override fun post(path: String, handler: Value) = registerHandler(handler, path, HttpMethod.POST)
+  @Polyglot override fun put(path: String, handler: Value) = registerHandler(handler, path, HttpMethod.PUT)
+  @Polyglot override fun delete(path: String, handler: Value) = registerHandler(handler, path, HttpMethod.DELETE)
+  @Polyglot override fun head(path: String, handler: Value) = registerHandler(handler, path, HttpMethod.HEAD)
+  @Polyglot override fun options(path: String, handler: Value) = registerHandler(handler, path, HttpMethod.OPTIONS)
+  @Polyglot override fun use(handler: Value) = registerHandler(handler)
+  @Polyglot override fun use(path: String, handler: Value) = registerHandler(handler, path)
 
   @Polyglot override fun listen(port: Int, callback: Value?) {
-    // configure all the route handlers, set the port and bind the socket
-    HttpServer.create().route { routes ->
-      for(route in routeRegistry) route.install(routes) { handler, req, res ->
-        // construct the wrappers
-        val request = ExpressRequestIntrinsic(req)
-        val response = ExpressResponseIntrinsic(res)
+    val server = HttpServer.create().handle { request, response ->
+      // construct the wrappers
+      val requestProxy = ExpressRequestIntrinsic.from(request)
+      val responseWrapper = ExpressResponseIntrinsic(response)
 
-        // invoke the JS handler
-        useCallback(handler) {
-          executeVoid(request, response)
-        }
+      // send over the pipeline
+      context.useGuest { handlePipelineStage(request, responseWrapper, requestProxy) }
 
-        // return the internal publisher handled by the wrapper
-        response.end()
-      }
-    }.port(port).bindNow()
+      // return the internal publisher handled by the wrapper
+      responseWrapper.end()
+    }
+
+    // set the port and bind the socket
+    server.port(port).bindNow()
 
     // prevent the JVM from exiting while the server is running
     context.pin()
@@ -59,23 +67,40 @@ internal class ExpressAppIntrinsic(private val context: ExpressContext) : Expres
     useCallback(callback) { executeVoid() }
   }
 
-  private fun registerRouteHandler( method: HttpMethod, path: String, handler: Value) {
-    routeRegistry.add(RouteHandler(method, mapExpressToReactorRoute(path), handler))
+  private fun registerHandler(handle: Value, path: String? = null, method: HttpMethod? = null) {
+    pipeline.add(Handler(
+      matches = requestMatcher(path, method?.name()),
+      handle,
+    ))
   }
 
-  private inline fun RouteHandler.install(
-    routes: HttpServerRoutes,
-    crossinline wrapper: (Value, HttpServerRequest, HttpServerResponse) -> Publisher<Void>
+  private fun handlePipelineStage(
+    incomingRequest: HttpServerRequest,
+    responseWrapper: ExpressResponseIntrinsic,
+    requestProxy: ProxyObject,
+    stage: Int = 0,
   ) {
-    // Reactor Netty does not have a generic route registration method, so we need to select the function manually
-    when(method) {
-      HttpMethod.GET -> routes.get(path) { req, res -> wrapper(handler, req, res) }
-      HttpMethod.POST -> routes.post(path) { req, res -> wrapper(handler, req, res) }
-      HttpMethod.PUT -> routes.put(path) { req, res -> wrapper(handler, req, res) }
-      HttpMethod.DELETE -> routes.delete(path) { req, res -> wrapper(handler, req, res) }
-      HttpMethod.HEAD -> routes.head(path) { req, res -> wrapper(handler, req, res) }
-      HttpMethod.OPTIONS -> routes.options(path) { req, res -> wrapper(handler, req, res) }
-      else -> error("Unsupported method $method")
+    logging.debug { "Handling pipeline stage: $stage" }
+
+    // get the next handler in the pipeline (or end if no more handlers remaining)
+    val handler = pipeline.getOrNull(stage) ?: return
+
+    if(handler.matches(incomingRequest.fullPath(), incomingRequest.method().name(), requestProxy)) {
+      logging.debug { "Handler condition matches request at stage $stage" }
+      // process this stage, giving the option to continue to the next stage
+      handler.handle.executeVoid(
+        requestProxy,
+        responseWrapper,
+        // "next" optional argument for express handlers
+        ProxyExecutable {
+          logging.debug { "Executable proxy for 'next' handler called from stage $stage" }
+          handlePipelineStage(incomingRequest, responseWrapper, requestProxy, stage + 1)
+        }
+      )
+    } else {
+      logging.debug { "Handler condition does not match request at stage $stage, bypassing" }
+      // skip this stage
+      handlePipelineStage(incomingRequest, responseWrapper, requestProxy, stage + 1)
     }
   }
 
@@ -89,11 +114,58 @@ internal class ExpressAppIntrinsic(private val context: ExpressContext) : Expres
   }
 
   companion object {
-    private val ExpressRouteParamRegex = Regex(":(?<param>\\w+)")
+    private const val MATCHER_NAME_GROUP = "name"
 
-    /** Map an Express route path specified to the format used by Reactor Netty. */
-    fun mapExpressToReactorRoute(expressRoute: String): String = expressRoute.replace(ExpressRouteParamRegex) {
-      "{${it.groups["param"]!!.value}}"
+    /** Regex matching path variable templates specified by a guest handler */
+    private val PathVariableRegex = Regex(":(?<$MATCHER_NAME_GROUP>\\w+)")
+
+    /**
+     * Returns a function that tests whether an incoming [HttpServerRequest] should be passed to a handler, using a
+     * [template] string and optionally filtering by HTTP [method]. Path variables included in the [template] will be
+     * captured by the matcher and added to the request proxy.
+     *
+     * @param template An optional template string used to match incoming request paths, can contain variable matchers
+     * in the format specified by the Express.js documentation. If not provided, all requests are matched regardless of
+     * the path, unless the [method] option is set.
+     * @param method An optional HTTP method filter. If not specified, requests are only filtered by path, as specified
+     * by the [template].
+     *
+     * @return A matcher function receiving two arguments: the [HttpServerRequest] to be tested, and a [Value] proxy
+     * to store the extracted variables.
+     */
+    fun requestMatcher(
+      template: String? = null,
+      method: String? = null
+    ): ExpressPathMatcher {
+      // keep a record of all path variables in the template
+      val variables = mutableListOf<String>()
+
+      // create a matching pattern using the provided path template
+      val pattern = template?.replace(PathVariableRegex) { result ->
+        // replace express path variable matchers with named capture groups
+        val paramName = result.groups[MATCHER_NAME_GROUP]?.value ?: error("Invalid path matcher")
+        variables.add(paramName)
+
+        "(?<$paramName>[^\\/]+)"
+      }?.let(::Regex)
+
+      return matcher@{ incomingPath, incomingMethod, proxy ->
+        // Filter by HTTP method
+        if(method != null && method != incomingMethod) return@matcher false
+
+        // if no matcher template is specified, accept all paths
+        if(pattern == null) return@matcher true
+
+        // otherwise return true when the pattern matches the requested path
+        pattern.matchEntire(incomingPath)?.also { match ->
+          val requestParams = proxy.getMember("params") as ProxyObject
+
+          // extract path variables and add them to the request
+          for(variable in variables) match.groups[variable]?.let {
+            requestParams.putMember(variable, Value.asValue(it.value))
+          }
+        } != null
+      }
     }
   }
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/express/ExpressResponseIntrinsic.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/express/ExpressResponseIntrinsic.kt
@@ -14,7 +14,7 @@ internal class ExpressResponseIntrinsic(
 ) : ExpressResponse {
   private val publisher = AtomicReference<NettyOutbound>()
 
-  /** Finish processing this response and return a [Publisher] to be returned from the oute handler */
+  /** Finish processing this response and return a [Publisher] to be returned from the outer handler */
   fun end(): Publisher<Void> = publisher.get() ?: response.send()
 
   private fun publish(next: NettyOutbound) {

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/express/ExpressApp.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/express/ExpressApp.kt
@@ -41,6 +41,18 @@ public interface ExpressApp {
    */
   @Polyglot public fun options(path: String, handler: Value)
 
+  /**
+   * Register a global middleware [handler]. The [handler] must be a function and will receive an [ExpressRequest], an
+   * [ExpressResponse], and a callable `next` value, which can be used to call the next handler in the pipeline.
+   */
+  @Polyglot public fun use(handler: Value)
+
+  /**
+   * Register a middleware [handler] at [path]. The [handler] must be a function and will receive an [ExpressRequest],
+   * an [ExpressResponse], and a callable `next` value, which can be used to call the next handler in the pipeline.
+   */
+  @Polyglot public fun use(path: String, handler: Value)
+
   /** Bind the server to a given [port]. */
   @Polyglot public fun listen(port: Int) {
     listen(port, null)

--- a/packages/graalvm/src/main/kotlin/module-info.java
+++ b/packages/graalvm/src/main/kotlin/module-info.java
@@ -25,6 +25,9 @@ module elide.graalvm {
     requires io.micronaut.http;
     requires io.micronaut.inject;
 
+    requires reactor.netty.http;
+    requires io.netty.codec.http;
+
     requires org.graalvm.sdk;
     requires org.graalvm.truffle;
 
@@ -33,6 +36,7 @@ module elide.graalvm {
     requires elide.ssr;
 
     exports elide.runtime.intrinsics.js;
+    exports elide.runtime.intrinsics.js.express;
     exports elide.runtime.gvm;
     exports elide.runtime.gvm.internals;
     exports elide.runtime.gvm.internals.intrinsics.js.base64;

--- a/packages/graalvm/src/test/kotlin/elide/runtime/gvm/internals/intrinsics/js/express/ExpressAppIntrinsicTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/gvm/internals/intrinsics/js/express/ExpressAppIntrinsicTest.kt
@@ -1,0 +1,113 @@
+package elide.runtime.gvm.internals.intrinsics.js.express
+
+import elide.runtime.gvm.internals.intrinsics.js.JsProxy
+import elide.testing.annotations.Test
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyObject
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ExpressAppIntrinsicTest {
+  @Test fun testRouteMatchers() {
+    // helper array used to generate test cases
+    val methods = arrayOf("GET", "POST", "PUT", "DELETE", "UPDATE", "PATCH", "OPTIONS", "HEAD")
+
+    fun emptyProxy(): ProxyObject = JsProxy.build { putObject("params") }
+    fun testAll(vararg paths: String, block: (path: String, method: String) -> Unit) {
+      methods.zip(paths).forEach { (method, path) -> block(path, method) }
+    }
+
+    // global matcher
+    val globalMatcher = ExpressAppIntrinsic.requestMatcher()
+    testAll("/", "/hello", "/hello/name") { path, method ->
+      assertTrue(
+        actual = globalMatcher(path, method, emptyProxy()),
+        message = "global matcher should match $path",
+      )
+    }
+    
+    // specific matcher
+    val basicMatcher = ExpressAppIntrinsic.requestMatcher("/hello")
+    testAll("/", "/abc", "/hello/nested") { path, method ->
+      assertFalse(
+        actual = basicMatcher(path, method, emptyProxy()),
+        message = "basic matcher should not match $path",
+      )
+    }
+    
+    testAll("/hello") { path, method ->
+      assertTrue(
+        actual = basicMatcher(path, method, emptyProxy()),
+        message = "basic matcher should match $path",
+      )
+    }
+    
+    // method matchers
+    methods.forEach { method ->
+      // method-specific matcher
+      val matcher = ExpressAppIntrinsic.requestMatcher(method = method)
+      
+      assertTrue(
+        actual = matcher("/", method, emptyProxy()),
+        message = "method matcher should match path '/' with method $method"
+      )
+      
+      // don't use an actual HTTP method, otherwise it will match in some cases
+      assertFalse(
+        actual = matcher("/", "TEST", emptyProxy()),
+        message = "method matcher not should match path '/' with method $method"
+      )
+    }
+    
+    // path + method matchers
+    methods.forEach { matcherMethod ->
+      val matcher = ExpressAppIntrinsic.requestMatcher("/hello", matcherMethod)
+      
+      testAll("/", "/abc", "/hello/nested") { path, method ->
+        assertFalse(
+          actual = matcher(path, method, emptyProxy()),
+          message = "compound matcher should not match $path",
+        )
+      }
+
+      testAll("/hello") { path, method ->
+        assertEquals(
+          expected = method == matcherMethod,
+          actual = matcher(path, method, emptyProxy()),
+          message = "should${if(method == matcherMethod) "" else " (not) "}match $path with method $method",
+        )
+      }
+    }
+    
+    // path variable matchers
+    val variableMatcher = ExpressAppIntrinsic.requestMatcher("/hello/:name")
+    testAll("/", "/hello", "/abc") { path, method ->
+      assertFalse(
+        actual = variableMatcher(path, method, emptyProxy()),
+        message = "variable matcher should not match $path",
+      )
+    }
+    
+    testAll("/hello/value") { path, method ->
+      val proxy = emptyProxy()
+      val params = proxy.getMember("params") as ProxyObject
+
+      assertTrue(
+        actual = variableMatcher(path, method, proxy),
+        message = "variable matcher should match $path",
+      )
+      
+      assertTrue(
+        actual = params.hasMember("name"),
+        message = "variable matcher should set the value in the proxy for path $path"
+      )
+      
+      assertEquals(
+        expected = "value",
+        actual = (params.getMember("name") as? Value)?.asString(),
+        message = "variable matcher should extract the value for path $path"
+      )
+    }
+  }
+}

--- a/packages/graalvm/src/test/kotlin/elide/runtime/gvm/internals/intrinsics/js/express/ExpressIntrinsicTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/gvm/internals/intrinsics/js/express/ExpressIntrinsicTest.kt
@@ -1,7 +1,6 @@
 package elide.runtime.gvm.internals.intrinsics.js.express
 
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -16,14 +15,6 @@ import elide.testing.annotations.TestCase
 
   override fun testInjectable() {
     assertNotNull(express) { "should be able to resolve express intrinsic via injection" }
-  }
-  
-  @Test fun testRouteMapping() {
-    assertEquals(
-      expected = "/hello/{name}",
-      actual = ExpressAppIntrinsic.mapExpressToReactorRoute("/hello/:name"),
-      message = "should replace path variable matchers"
-    )
   }
   
   @Test fun testInjectableGuest() = executeGuest {


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR improves Elide's Express.js feature:
* Middleware support including path-scoped handlers 🎉
* Request params are now writable (useful for parameter-mapping middleware)
* Request objects are now writable (useful for request-enhancing middleware)