### PR TITLE
feat: add initial issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,59 @@
+name: Bug Report
+description: File a bug report
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting an issue, please review the task list below before submitting the issue. Your issue report will be closed if the issue is incomplete and the below tasks not completed.
+
+        NOTE: If you are unsure about something and the issue is more of a question a better place to ask questions is on Github Discussions :arrow_up:, [Stack Overflow](https://stackoverflow.com/tags/elide) or [Discord](https://elide.dev/discord).
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+      placeholder: Tell us what should happen
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Actual Behaviour
+      description: A concise description of what you're experiencing.
+      placeholder: Tell us what happens instead
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Environment Information
+      description: Environment information where the problem occurs.
+      placeholder: |
+        - Operating System:
+        - JDK Version:
+    validations:
+      required: false
+  - type: input
+    id: example
+    attributes:
+      label: Example Application
+      description: Example application link.
+      placeholder: |
+        Link to GitHub repository with an example that reproduces the issue
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Elide version
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,10 @@
+contact_links:
+  - name: Elide Discussions
+    url: https://github.com/elide-dev/elide/discussions
+    about: Ask questions about Elide on Github
+  - name: Elide Discord
+    url: https://elide.dev/discord
+    about: Join the conversation on Discord
+  - name: Stack Overflow
+    url: https://stackoverflow.com/tags/elide
+    about: Ask questions on Stack Overflow

--- a/.github/ISSUE_TEMPLATE/new_feature.yaml
+++ b/.github/ISSUE_TEMPLATE/new_feature.yaml
@@ -1,0 +1,13 @@
+name: Feature request
+description: Create a new feature request
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the feature you want for Elide, and please check if there is already an existing issue.
+  - type: textarea
+    attributes:
+      label: Feature description
+      placeholder: Tell us about your idea, feature, or module
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/other.yaml
+++ b/.github/ISSUE_TEMPLATE/other.yaml
@@ -1,0 +1,8 @@
+name: Other
+description: Something different
+body:
+  - type: textarea
+    attributes:
+      label: Issue description
+    validations:
+      required: true


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds issue templates to the Elide repository, which will be used in upcoming CLI features.

- [x] Add `bug_report` issue template
- [x] Add `new_feature` issue template
- [x] Add default `config` for issues