### PR TITLE
fix: avoid duplicate javadoc artifacts in publications.

### DIFF
--- a/tools/elide-build/build.gradle.kts
+++ b/tools/elide-build/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
   implementation(libs.plugin.sonar)
   implementation(libs.plugin.sigstore)
   implementation(libs.plugin.redacted)
-  compileOnly(libs.plugin.ksp)
+  implementation(libs.plugin.ksp)
 
   // embedded Kotlin plugins
   implementation(embeddedKotlin("allopen"))

--- a/tools/elide-build/src/main/kotlin/elide/internal/conventions/ElideConventionPlugin.kt
+++ b/tools/elide-build/src/main/kotlin/elide/internal/conventions/ElideConventionPlugin.kt
@@ -106,9 +106,9 @@ public abstract class ElideConventionPlugin : Plugin<Project> {
       if (JVM in kotlinTarget) {
         conventions.jvm.requested = true
 
-        // for KMP projects including a JVM target, these two features need to be
-        // configured separately, since the java plugin is not applied
-        if(kotlinTarget is Multiplatform) conventions.java.apply {
+        // for Kotlin projects, these two features need to be configured separately,
+        // since the java plugin is not always applied
+        conventions.java.apply {
            includeJavadoc = false
            includeSources = false
         }

--- a/tools/processor/build.gradle.kts
+++ b/tools/processor/build.gradle.kts
@@ -17,7 +17,7 @@ import elide.internal.conventions.publishing.publish
 
 plugins {
   kotlin("jvm")
-  alias(libs.plugins.ksp)
+  id("com.google.devtools.ksp")
 
   id("elide.internal.conventions")
 }


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

This PR amends the work from #414 on `javadoc` artifacts in Maven publications.