### PR TITLE
feat(cli): use new DSL API for context acquisition.

### DIFF
--- a/packages/cli/build.gradle.kts
+++ b/packages/cli/build.gradle.kts
@@ -163,6 +163,9 @@ val ktCompilerArgs = listOf(
   "-Xjvm-default=all",
   "-Xjavac-arguments=${jvmCompileArgs.joinToString(",")}}",
 
+  // opt-in to Elide's delicate runtime API
+  "-opt-in=elide.runtime.core.DelicateElideApi",
+
   // Fix: Suppress Kotlin version compatibility check for Compose plugin (applied by Mosaic)
   "-P=plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=1.9.20-Beta",
 )
@@ -259,6 +262,12 @@ dependencies {
   if (enableRuby) implementation(projects.packages.graalvmRb)
   if (enableEspresso) implementation(projects.packages.graalvmKt)
   if (enableWasm) implementation(projects.packages.graalvmWasm)
+
+  // Runtime engines
+  implementation(projects.packages.runtimeCore)
+  implementation(projects.packages.runtimeJs)
+  implementation(projects.packages.runtimePy)
+  implementation(projects.packages.runtimeRb)
 
   api(libs.picocli)
   api(libs.slf4j)

--- a/packages/cli/src/main/kotlin/elide/tool/extensions/Intrinsics.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/extensions/Intrinsics.kt
@@ -1,0 +1,22 @@
+package elide.tool.extensions
+
+import elide.runtime.intrinsics.GuestIntrinsic.MutableIntrinsicBindings
+import elide.runtime.intrinsics.IntrinsicsResolver
+import elide.runtime.plugins.AbstractLanguageConfig
+import elide.runtime.gvm.GuestLanguage as LegacyGuestLanguage
+
+/**
+ * Install globally resolved intrinsics into this language plugin. The [intrinsics] resolver is used to load all
+ * intrinsics for the given [language] (note that this language is provided by the 'graalvm' module).
+ */
+internal fun AbstractLanguageConfig.installIntrinsics(
+  intrinsics: IntrinsicsResolver,
+  language: LegacyGuestLanguage
+) = bindings {
+  // create an intermediate container to obtain the bindings
+  val container = MutableIntrinsicBindings.Factory.create()
+  intrinsics.resolve(language).forEach { it.install(container) }
+
+  // transfer the bindings to the language plugin configuration
+  container.entries.forEach { (key, value) -> put(key.symbol, value) }
+}

--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -676,6 +676,11 @@ public abstract interface class elide/runtime/gvm/internals/GuestVFS$VFSConfigur
 	public fun image ()Lelide/runtime/gvm/internals/AbstractVMEngine$RuntimeVFS;
 }
 
+public final class elide/runtime/gvm/internals/IntrinsicsManager {
+	public fun <init> (Ljava/util/List;)V
+	public final fun resolver ()Lelide/runtime/intrinsics/IntrinsicsResolver;
+}
+
 public abstract interface class elide/runtime/gvm/internals/VMProperty : java/lang/Comparable {
 	public fun active ()Z
 	public fun compareTo (Lelide/runtime/gvm/internals/VMProperty;)I

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/IntrinsicsManager.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/IntrinsicsManager.kt
@@ -20,12 +20,12 @@ import elide.runtime.intrinsics.IntrinsicsResolver
 
 /** Resolves intrinsics for use with guest VMs. */
 @Suppress("MnInjectionPoints")
-@Context @Singleton internal class IntrinsicsManager (resolvers: List<IntrinsicsResolver>) {
+@Context @Singleton public class IntrinsicsManager (resolvers: List<IntrinsicsResolver>) {
   private val compound = CompoundIntrinsicsResolver.of(resolvers)
 
   /** Resolver stub. */
-  inner class GlobalResolver: IntrinsicsResolver by compound
+  internal inner class GlobalResolver: IntrinsicsResolver by compound
 
   /** @return Global resolver stub. */
-  internal fun resolver(): IntrinsicsResolver = GlobalResolver()
+  public fun resolver(): IntrinsicsResolver = GlobalResolver()
 }

--- a/packages/runtime-core/api/runtime-core.api
+++ b/packages/runtime-core/api/runtime-core.api
@@ -132,6 +132,7 @@ public abstract interface class elide/runtime/core/PolyglotContext {
 	public abstract fun enter ()V
 	public abstract fun evaluate (Lorg/graalvm/polyglot/Source;)Lorg/graalvm/polyglot/Value;
 	public abstract fun leave ()V
+	public abstract fun parse (Lorg/graalvm/polyglot/Source;)Lorg/graalvm/polyglot/Value;
 }
 
 public final class elide/runtime/core/PolyglotContextKt {

--- a/packages/runtime-core/api/runtime-core.api
+++ b/packages/runtime-core/api/runtime-core.api
@@ -108,6 +108,10 @@ public final class elide/runtime/core/HostPlatform$OperatingSystem : java/lang/E
 	public static fun values ()[Lelide/runtime/core/HostPlatform$OperatingSystem;
 }
 
+public final class elide/runtime/core/HostPlatformKt {
+	public static final fun isUnix (Lelide/runtime/core/HostPlatform$OperatingSystem;)Z
+}
+
 public abstract interface class elide/runtime/core/PluginRegistry {
 	public abstract fun install (Lelide/runtime/core/EnginePlugin;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static synthetic fun install$default (Lelide/runtime/core/PluginRegistry;Lelide/runtime/core/EnginePlugin;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
@@ -246,6 +250,33 @@ public final class elide/runtime/plugins/AbstractLanguagePlugin$LanguagePluginMa
 
 public final class elide/runtime/plugins/AbstractLanguagePlugin$LanguagePluginManifest$EmbeddedResource$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class elide/runtime/plugins/debug/Debug {
+	public static final field Plugin Lelide/runtime/plugins/debug/Debug$Plugin;
+	public synthetic fun <init> (Lelide/runtime/plugins/debug/DebugConfig;Lelide/runtime/core/HostPlatform;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getConfig ()Lelide/runtime/plugins/debug/DebugConfig;
+}
+
+public final class elide/runtime/plugins/debug/Debug$Plugin : elide/runtime/core/EnginePlugin {
+	public fun getKey-wLvarY0 ()Ljava/lang/String;
+	public fun install (Lelide/runtime/core/EnginePlugin$InstallationScope;Lkotlin/jvm/functions/Function1;)Lelide/runtime/plugins/debug/Debug;
+	public synthetic fun install (Lelide/runtime/core/EnginePlugin$InstallationScope;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class elide/runtime/plugins/debug/DebugConfig {
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getSourcePaths ()Ljava/util/List;
+	public final fun getSuspend ()Z
+	public final fun getWaitAttached ()Z
+	public final fun setPath (Ljava/lang/String;)V
+	public final fun setSourcePaths (Ljava/util/List;)V
+	public final fun setSuspend (Z)V
+	public final fun setWaitAttached (Z)V
+}
+
+public final class elide/runtime/plugins/debug/DebugPluginKt {
+	public static final fun debug (Lelide/runtime/core/PolyglotEngineConfiguration;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class elide/runtime/plugins/vfs/Vfs {

--- a/packages/runtime-core/api/runtime-core.api
+++ b/packages/runtime-core/api/runtime-core.api
@@ -169,6 +169,10 @@ public final class elide/runtime/core/extensions/ContextBuilderKt {
 	public static final fun setOptions (Lorg/graalvm/polyglot/Context$Builder;[Lkotlin/Pair;)V
 }
 
+public final class elide/runtime/core/extensions/ExecutionListenerKt {
+	public static final fun attach (Lorg/graalvm/polyglot/management/ExecutionListener$Builder;Lelide/runtime/core/PolyglotEngine;)Lorg/graalvm/polyglot/management/ExecutionListener;
+}
+
 public abstract class elide/runtime/plugins/AbstractLanguageConfig {
 	public fun <init> ()V
 	protected final fun applyBindings (Lelide/runtime/core/PolyglotContext;Lelide/runtime/core/GuestLanguage;)V

--- a/packages/runtime-core/src/main/kotlin/elide/runtime/core/HostPlatform.kt
+++ b/packages/runtime-core/src/main/kotlin/elide/runtime/core/HostPlatform.kt
@@ -1,5 +1,7 @@
 package elide.runtime.core
 
+import elide.runtime.core.HostPlatform.OperatingSystem.*
+
 /**
  * Provides read-only information about the Host platform, which can be used by plugins to run platform-specific
  * code.
@@ -85,3 +87,10 @@ package elide.runtime.core
     }
   }
 }
+
+/** Whether this OS family is UNIX-based. Returns true for [LINUX] and [DARWIN] enum entries. */
+@DelicateElideApi public inline val HostPlatform.OperatingSystem.isUnix: Boolean
+  get() = when (this) {
+    LINUX, DARWIN -> true
+    WINDOWS -> false
+  }

--- a/packages/runtime-core/src/main/kotlin/elide/runtime/core/PolyglotContext.kt
+++ b/packages/runtime-core/src/main/kotlin/elide/runtime/core/PolyglotContext.kt
@@ -34,6 +34,17 @@ import org.graalvm.polyglot.Source
   public fun bindings(language: GuestLanguage? = null): PolyglotValue
 
   /**
+   * Parse the given [source] without evaluating it, possibly throwing an exception if a syntax error is found.
+   * Sources processed in this way may also be cached and reused by later invocations of [parse] or [evaluate].
+   *
+   * The returned [PolyglotValue] only supports [execute][org.graalvm.polyglot.Value.execute] without arguments.
+   *
+   * @param source The guest code to be parsed.
+   * @return A [PolyglotValue] representing the parsed source, possibly ready for execution.
+   */
+  public fun parse(source: Source): PolyglotValue
+  
+  /**
    * Evaluate the given [source], returning the result of the execution. Depending on the configuration of the context,
    * this method may fail if the selected language is not enabled in the underlying engine.
    *

--- a/packages/runtime-core/src/main/kotlin/elide/runtime/core/extensions/ExecutionListener.kt
+++ b/packages/runtime-core/src/main/kotlin/elide/runtime/core/extensions/ExecutionListener.kt
@@ -1,0 +1,18 @@
+package elide.runtime.core.extensions
+
+import org.graalvm.polyglot.management.ExecutionListener
+import elide.runtime.core.DelicateElideApi
+import elide.runtime.core.PolyglotEngine
+import elide.runtime.core.internals.graalvm.GraalVMEngine
+
+/**
+ * Attaches this [builder][ExecutionListener.Builder] to a GraalVM-backed [PolyglotEngine].
+ *
+ * @param engine A [PolyglotEngine] to attach this listener to.
+ * @throws IllegalArgumentException If the provided [engine] is not backed by a GraalVM implementation and does not
+ * otherwise support execution listeners.
+ */
+@DelicateElideApi public fun ExecutionListener.Builder.attach(engine: PolyglotEngine): ExecutionListener {
+  require(engine is GraalVMEngine) { "The provided engine does not support GraalVM execution listeners." }
+  return attach(engine.unwrap())
+}

--- a/packages/runtime-core/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMContext.kt
+++ b/packages/runtime-core/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMContext.kt
@@ -15,6 +15,10 @@ import elide.runtime.core.PolyglotValue
     return language?.let { context.getBindings(it.languageId) } ?: context.polyglotBindings
   }
 
+  override fun parse(source: Source): PolyglotValue {
+    return context.parse(source)
+  }
+
   override fun evaluate(source: Source): PolyglotValue {
     return context.eval(source)
   }

--- a/packages/runtime-core/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMEngine.kt
+++ b/packages/runtime-core/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMEngine.kt
@@ -32,6 +32,17 @@ import elide.runtime.core.internals.graalvm.GraalVMEngine.Companion.create
     ALLOW_IO, ALLOW_NONE -> EnvironmentAccess.NONE
   }
 
+  /**
+   * Returns the underlying GraalVM [Engine] used by this instance.
+   *
+   * This method is considered delicate even for internal use within the Elide runtime, since it breaks the
+   * encapsulation provided by the core API; it should be used only in select cases where accessing the GraalVM engine
+   * directly is less complex than implementing a new abstraction for the desired feature.
+   */
+  internal fun unwrap(): Engine {
+    return engine
+  }
+
   /** Create a new [GraalVMContext], triggering lifecycle events to allow customization. */
   private fun createContext(): GraalVMContext {
     // build a new context using the shared engine

--- a/packages/runtime-core/src/main/kotlin/elide/runtime/plugins/AbstractLanguageConfig.kt
+++ b/packages/runtime-core/src/main/kotlin/elide/runtime/plugins/AbstractLanguageConfig.kt
@@ -12,7 +12,7 @@ import elide.runtime.core.PolyglotContext
  */
 @DelicateElideApi public abstract class AbstractLanguageConfig {
   /** Mutable counterpart to [intrinsicBindings]. */
-  private val mutableBindings: MutableMap<String, Any> get() = mutableMapOf()
+  private val mutableBindings: MutableMap<String, Any> = mutableMapOf()
 
   /** An immutable map of the intrinsics defined using the [bindings] function. */
   protected val intrinsicBindings: Map<String, Any> get() = mutableBindings

--- a/packages/runtime-core/src/main/kotlin/elide/runtime/plugins/debug/DebugConfig.kt
+++ b/packages/runtime-core/src/main/kotlin/elide/runtime/plugins/debug/DebugConfig.kt
@@ -1,0 +1,26 @@
+package elide.runtime.plugins.debug
+
+import elide.runtime.core.DelicateElideApi
+
+/**
+ * Defines configuration options for the built-in implementation of the Chrome DevTools Protocol, and the
+ * Debug Adapter Protocol.
+ *
+ * This container is meant to be used by the [Debug].
+ */
+@DelicateElideApi public class DebugConfig internal constructor() {
+  /** A custom path to be used as connection URL for the debugger. */
+  public var path: String? = null
+
+  /**
+   * A list of directories or ZIP/JAR files representing the source path, used to resolve relative references in
+   * inspected code.
+   */
+  public var sourcePaths: List<String>? = null
+
+  /** Whether to suspend execution at the first source line. Defaults to `true` */
+  public var suspend: Boolean = true
+
+  /** Whether to wait until the debugger is attached before executing any code. Defaults to `false`. */
+  public var waitAttached: Boolean = false
+}

--- a/packages/runtime-core/src/main/kotlin/elide/runtime/plugins/debug/DebugPlugin.kt
+++ b/packages/runtime-core/src/main/kotlin/elide/runtime/plugins/debug/DebugPlugin.kt
@@ -1,0 +1,61 @@
+package elide.runtime.plugins.debug
+
+import elide.runtime.core.*
+import elide.runtime.core.EngineLifecycleEvent.ContextCreated
+import elide.runtime.core.EnginePlugin.InstallationScope
+import elide.runtime.core.EnginePlugin.Key
+import elide.runtime.core.extensions.enableOption
+
+/**
+ * Engine plugin providing debug and inspection features for guest code.
+ *
+ * @see debug
+ * @see DebugConfig 
+ */
+@DelicateElideApi public class Debug private constructor(
+  public val config: DebugConfig,
+  private val platform: HostPlatform,
+) {
+  /** Apply debug [config] to a context [builder] during the [ContextCreated] event. */
+  internal fun onContextCreated(builder: PolyglotContextBuilder): Unit = with(builder) {
+    config.path?.let { path -> option("inspect.Path", path) }
+
+    // source path delimiters are platform-specific
+    config.sourcePaths?.let { paths ->
+      option(
+        /* key = */ "inspect.SourcePath",
+        /* value = */ paths.joinToString(if (platform.os.isUnix) UNIX_SOURCE_DELIMITER else WINDOWS_SOURCE_DELIMITER),
+      )
+    }
+
+    if (config.waitAttached) enableOption("inspect.WaitAttached")
+    if (config.suspend) enableOption("inspect.Suspend")
+  }
+
+  /** Identifier for the [Debug] plugin, which provides debugging options for embedded languages. */
+  public companion object Plugin : EnginePlugin<DebugConfig, Debug> {
+    /** Delimiter used to separate source paths in UNIX-based systems. */
+    private const val UNIX_SOURCE_DELIMITER = ":"
+
+    /** Delimiter used to separate source paths in Windows systems. */
+    private const val WINDOWS_SOURCE_DELIMITER = ";"
+
+    override val key: Key<Debug> = Key("Debug")
+
+    override fun install(scope: InstallationScope, configuration: DebugConfig.() -> Unit): Debug {
+      // apply the configuration and create the plugin instance
+      val config = DebugConfig().apply(configuration)
+      val instance = Debug(config, scope.configuration.hostPlatform)
+
+      // subscribe to lifecycle events
+      scope.lifecycle.on(ContextCreated, instance::onContextCreated)
+
+      return instance
+    }
+  }
+}
+
+/** Configure the [Debug] plugin, installing it if not already present. */
+@DelicateElideApi public fun PolyglotEngineConfiguration.debug(configure: DebugConfig.() -> Unit) {
+  plugin(Debug)?.config?.apply(configure) ?: install(Debug, configure)
+}

--- a/packages/runtime-js/src/main/kotlin/elide/runtime/plugins/js/JavaScript.kt
+++ b/packages/runtime-js/src/main/kotlin/elide/runtime/plugins/js/JavaScript.kt
@@ -92,6 +92,17 @@ import elide.runtime.plugins.js.JavaScriptVersion.*
       "js.v8-compat" to config.v8,
     )
 
+    if(config.wasm) {
+      enableOptions(
+        "wasm.Memory64",
+        "wasm.MultiValue",
+        "wasm.UseUnsafeMemory",
+        "wasm.BulkMemoryAndRefTypes",
+      )
+
+      option("wasm.Builtins", WASI_STD)
+    }
+
     if (config.npmConfig.enabled) {
       val replacement = config.builtinModulesConfig.replacements().entries.joinToString(",") {
         "${it.key}:${it.value}"
@@ -109,6 +120,7 @@ import elide.runtime.plugins.js.JavaScriptVersion.*
     private const val JS_LANGUAGE_ID = "js"
     private const val JS_PLUGIN_ID = "JavaScript"
 
+    private const val WASI_STD = "wasi_snapshot_preview1"
     private const val FUNCTION_CONSTRUCTOR_CACHE_SIZE: String = "256"
     private const val UNHANDLED_REJECTIONS: String = "handler"
     private const val DEBUG_GLOBAL: String = "__ElideDebug__"


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

This PR adopts the new runtime configuration API in the Elide CLI, and introduces some additional changes to the `runtime-core` module to support this migration:
- New `Debug` engine plugin, used to configure inspection and debugging options.
- GraalVM execution listeners can now be attached to a `PolyglotEngine` using an extension, without accessing the underlying GraalVM Engine.
- New `PolyglotContext.parse` method (mirroring the `Context.parse` method in GraalVM's API).
- The `JavaScript` runtime language plugin now correctly applies WASM-related options.
- A bug in the `AbstractLanguageConfig` class was fixed; it prevented language bindings from being applied correctly.