### PR TITLE
feat: new runtime info API

### DIFF
--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -112,6 +112,17 @@ public final class elide/runtime/core/HostPlatformKt {
 	public static final fun isUnix (Lelide/runtime/core/HostPlatform$OperatingSystem;)Z
 }
 
+public abstract interface class elide/runtime/core/HostRuntime {
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getVariant ()Ljava/lang/String;
+	public abstract fun getVersion ()Lelide/runtime/core/Version;
+}
+
+public final class elide/runtime/core/HostRuntimeKt {
+	public static final fun on (Lelide/runtime/core/HostRuntime;Lelide/runtime/core/Version$Range;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun on (Lelide/runtime/core/HostRuntime;Lelide/runtime/core/Version;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
 public abstract interface class elide/runtime/core/PluginRegistry {
 	public abstract fun install (Lelide/runtime/core/EnginePlugin;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static synthetic fun install$default (Lelide/runtime/core/PluginRegistry;Lelide/runtime/core/EnginePlugin;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
@@ -149,6 +160,7 @@ public abstract class elide/runtime/core/PolyglotEngineConfiguration : elide/run
 	public final fun getEnvironment ()Ljava/util/Map;
 	public final fun getHostAccess ()Lelide/runtime/core/PolyglotEngineConfiguration$HostAccess;
 	public final fun getHostPlatform ()Lelide/runtime/core/HostPlatform;
+	public abstract fun getHostRuntime ()Lelide/runtime/core/HostRuntime;
 	public final fun setHostAccess (Lelide/runtime/core/PolyglotEngineConfiguration$HostAccess;)V
 }
 
@@ -160,6 +172,55 @@ public final class elide/runtime/core/PolyglotEngineConfiguration$HostAccess : j
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lelide/runtime/core/PolyglotEngineConfiguration$HostAccess;
 	public static fun values ()[Lelide/runtime/core/PolyglotEngineConfiguration$HostAccess;
+}
+
+public final class elide/runtime/core/Version : java/lang/Comparable {
+	public static final field Companion Lelide/runtime/core/Version$Companion;
+	public fun <init> (III)V
+	public synthetic fun <init> (IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun compareTo (Lelide/runtime/core/Version;)I
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (III)Lelide/runtime/core/Version;
+	public static synthetic fun copy$default (Lelide/runtime/core/Version;IIIILjava/lang/Object;)Lelide/runtime/core/Version;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMajor ()I
+	public final fun getMinor ()I
+	public final fun getPatch ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/runtime/core/Version$Companion {
+	public final fun getZero ()Lelide/runtime/core/Version;
+	public final fun parse (Ljava/lang/String;)Lelide/runtime/core/Version;
+}
+
+public final class elide/runtime/core/Version$Range {
+	public fun <init> ()V
+	public fun <init> (Lelide/runtime/core/Version;Lelide/runtime/core/Version;ZZ)V
+	public synthetic fun <init> (Lelide/runtime/core/Version;Lelide/runtime/core/Version;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lelide/runtime/core/Version;
+	public final fun component2 ()Lelide/runtime/core/Version;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun contains (Lelide/runtime/core/Version;)Z
+	public final fun copy (Lelide/runtime/core/Version;Lelide/runtime/core/Version;ZZ)Lelide/runtime/core/Version$Range;
+	public static synthetic fun copy$default (Lelide/runtime/core/Version$Range;Lelide/runtime/core/Version;Lelide/runtime/core/Version;ZZILjava/lang/Object;)Lelide/runtime/core/Version$Range;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeMax ()Z
+	public final fun getIncludeMin ()Z
+	public final fun getMax ()Lelide/runtime/core/Version;
+	public final fun getMin ()Lelide/runtime/core/Version;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/runtime/core/VersionKt {
+	public static final fun andHigher (Lelide/runtime/core/Version;)Lelide/runtime/core/Version$Range;
+	public static final fun andLower (Lelide/runtime/core/Version;)Lelide/runtime/core/Version$Range;
 }
 
 public final class elide/runtime/core/extensions/ContextBuilderKt {
@@ -184,6 +245,28 @@ public final class elide/runtime/core/extensions/EngineBuilderKt {
 
 public final class elide/runtime/core/extensions/ExecutionListenerKt {
 	public static final fun attach (Lorg/graalvm/polyglot/management/ExecutionListener$Builder;Lelide/runtime/core/PolyglotEngine;)Lorg/graalvm/polyglot/management/ExecutionListener;
+}
+
+public final class elide/runtime/core/internals/graalvm/GraalVMRuntime : elide/runtime/core/HostRuntime {
+	public static final field Companion Lelide/runtime/core/internals/graalvm/GraalVMRuntime$Companion;
+	public static final field VARIANT_JVM Ljava/lang/String;
+	public static final field VARIANT_NATIVE Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Lelide/runtime/core/Version;Ljava/lang/String;)V
+	public synthetic fun <init> (Lelide/runtime/core/Version;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Ljava/lang/String;
+	public final fun getNative ()Z
+	public fun getVariant ()Ljava/lang/String;
+	public fun getVersion ()Lelide/runtime/core/Version;
+}
+
+public final class elide/runtime/core/internals/graalvm/GraalVMRuntime$Companion {
+	public final fun getGVM_23 ()Lelide/runtime/core/Version;
+	public final fun getGVM_23_1 ()Lelide/runtime/core/Version;
+}
+
+public final class elide/runtime/core/internals/graalvm/GraalVMRuntimeKt {
+	public static final fun isNativeImage (Lelide/runtime/core/HostRuntime;)Z
 }
 
 public abstract interface class elide/runtime/feature/FrameworkFeature : org/graalvm/nativeimage/hosted/Feature {

--- a/packages/graalvm/src/main/kotlin/elide/runtime/core/HostRuntime.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/core/HostRuntime.kt
@@ -1,0 +1,29 @@
+package elide.runtime.core
+
+/** Provides information about the runtime hosting the application. */
+@DelicateElideApi public interface HostRuntime {
+  /** The name of this runtime, which is used in string representations and for debugging purposes. */
+  public val name: String
+
+  /** The version spec of this runtime, wrapped to allow version comparisons using regular operators. */
+  public val version: Version?
+
+  /** An optional variant name for this runtime. Some engines like GraalVM differentiate between runtime variants. */
+  public val variant: String?
+}
+
+/**
+ * Execute a [block] and return its result if this runtime's is running the provided [version], otherwise return
+ * `null`. If this runtime's version can't be detected, `null` will be returned. 
+ */
+@DelicateElideApi public inline fun <R> HostRuntime.on(version: Version, block: () -> R): R? {
+  return if (this.version == version) block() else null
+}
+
+/**
+ * Execute a [block] and return its result if this runtime's version is in the provided [range], otherwise return
+ * `null`. If this runtime's version can't be detected, `null` will be returned.
+ */
+@DelicateElideApi public inline fun <R> HostRuntime.on(range: Version.Range, block: () -> R): R? {
+  return version?.takeIf { it in range }?.let { block() }
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/core/HostRuntime.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/core/HostRuntime.kt
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2023 Elide Ventures, LLC.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
 package elide.runtime.core
 
 /** Provides information about the runtime hosting the application. */

--- a/packages/graalvm/src/main/kotlin/elide/runtime/core/PolyglotEngineConfiguration.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/core/PolyglotEngineConfiguration.kt
@@ -44,12 +44,15 @@ import elide.runtime.core.PolyglotEngineConfiguration.HostAccess.ALLOW_NONE
     /** Restrict all access to the host environment. */
     ALLOW_NONE,
   }
+  
+  /** The access granted to guest code over host resources, such as environment variables and the file system. */
+  public var hostAccess: HostAccess = ALLOW_NONE
 
   /** Information about the platform hosting the runtime. */
   public val hostPlatform: HostPlatform = HostPlatform.resolve()
 
-  /** The access granted to guest code over host resources, such as environment variables and the file system. */
-  public var hostAccess: HostAccess = ALLOW_NONE
+  /** Information about the runtime engine. */
+  public abstract val hostRuntime: HostRuntime
 
   /** Environment to apply to the context. */
   public val environment: MutableMap<String, String> = ConcurrentSkipListMap()

--- a/packages/graalvm/src/main/kotlin/elide/runtime/core/Version.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/core/Version.kt
@@ -1,0 +1,99 @@
+package elide.runtime.core
+
+import elide.runtime.core.Version.Companion.parse
+import elide.runtime.core.Version.Range
+
+/**
+ * Represents a semantic version that can be compared with others or used to form a version range. Version objects are
+ * used to enable version-aware behavior in engine plugins.
+ *
+ * Use [toString] if a full version string is required instead of separate components.
+ *
+ * @see parse
+ */
+@DelicateElideApi public data class Version(
+  /** Major version component. */
+  public val major: Int,
+  /** Minor version component. */
+  public val minor: Int = 0,
+  /** Patch version component. */
+  public val patch: Int = 0,
+) : Comparable<Version> {
+
+  /**
+   * A range of [versions][Version], which can be [queried][contains] to see if a [Version] falls in a specific
+   * range. Use the normal range operators or extensions to create version ranges.
+   *
+   * By default, a range includes every valid version (from [Zero] onwards).
+   */
+  @DelicateElideApi public data class Range(
+    public val min: Version = Zero,
+    public val max: Version? = null,
+    public val includeMin: Boolean = true,
+    public val includeMax: Boolean = true,
+  ) {
+    public operator fun contains(version: Version): Boolean {
+      val minResult = min.compareTo(version)
+      val maxResult = max?.compareTo(version)
+
+      return when (includeMin) {
+        true -> when (includeMax) {
+          true -> minResult >= 0 && (maxResult == null || maxResult <= 0)
+          false -> minResult >= 0 && (maxResult == null || maxResult < 0)
+        }
+
+        false -> when (includeMax) {
+          true -> minResult > 0 && (maxResult == null || maxResult <= 0)
+          false -> minResult > 0 && (maxResult == null || maxResult < 0)
+        }
+      }
+    }
+  }
+
+  public override operator fun compareTo(other: Version): Int {
+    major.compareTo(other.major).takeIf { it != 0 }?.let { return it }
+    minor.compareTo(other.minor).takeIf { it != 0 }?.let { return it }
+    patch.compareTo(other.patch).takeIf { it != 0 }?.let { return it }
+    return 0
+  }
+
+  override fun toString(): String {
+    return "$major.$minor.$patch"
+  }
+
+  public companion object {
+    /** Number of segments required in a semantic version string (major and minor, patch defaults to 0). */
+    private const val MIN_SEGMENTS = 2
+
+    /** Regular expression used to replace characters with version separators. */
+    private val SpecRegex = Regex("[-_]")
+
+    /** A placeholder "zero" version provided for convenience. */
+    public val Zero: Version by lazy { Version(0, 0, 0) }
+
+
+    /** Parse a string [spec] and return a rich [Version] object. */
+    public fun parse(spec: String): Version {
+      // replace '-' and '_' with '.', then split and check for basic contraints
+      val parts = spec.replace(SpecRegex, ".").split('.').takeIf { it.size >= MIN_SEGMENTS }
+        ?: error("Invalid semantic version '$spec'")
+
+      // parse the digits, only major and minor components are required
+      return Version(
+        major = parts.getOrNull(0)?.toIntOrNull() ?: error("Invalid semantic version '$spec'"),
+        minor = parts.getOrNull(1)?.toIntOrNull() ?: error("Invalid semantic version '$spec'"),
+        patch = parts.getOrNull(2)?.toIntOrNull() ?: 0,
+      )
+    }
+  }
+}
+
+/** Returns a [version range][Range] including this and every higher version. */
+@DelicateElideApi public fun Version.andHigher(): Range {
+  return Range(this)
+}
+
+/** Returns a [version range][Range] including this and every lower version. */
+@DelicateElideApi public fun Version.andLower(): Range {
+  return Range(max = this)
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/core/Version.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/core/Version.kt
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2023 Elide Ventures, LLC.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
 package elide.runtime.core
 
 import elide.runtime.core.Version.Companion.parse

--- a/packages/graalvm/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMConfiguration.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMConfiguration.kt
@@ -43,6 +43,9 @@ import elide.runtime.core.internals.MutableEngineLifecycle
   /** A set of languages enabled for use in the engine. */
   internal val languages: Set<GuestLanguage> get() = langs
 
+  /** Runtime info, resolved from GraalVM static properties. */
+  override val hostRuntime: HostRuntime = GraalVMRuntime()
+
   override fun <C : Any, I : Any> install(plugin: EnginePlugin<C, I>, configure: C.() -> Unit): I {
     require(plugin.key.id !in plugins) { "A plugin with the provided key is already registered" }
 

--- a/packages/graalvm/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMRuntime.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMRuntime.kt
@@ -1,0 +1,95 @@
+package elide.runtime.core.internals.graalvm
+
+import org.graalvm.nativeimage.ImageInfo
+import elide.runtime.core.DelicateElideApi
+import elide.runtime.core.HostRuntime
+import elide.runtime.core.Version
+import elide.runtime.core.internals.graalvm.GraalVMRuntime.Companion.VARIANT_JVM
+import elide.runtime.core.internals.graalvm.GraalVMRuntime.Companion.VARIANT_NATIVE
+
+/**
+ * Implementation of the [HostRuntime] information for GraalVM-based engines.
+ *
+ * A GraalVM Runtime has two known variants: ["native"][VARIANT_NATIVE], when running from a Native Image, and
+ * ["jvm"][VARIANT_JVM], when running on a regular GraalVM JDK.
+ *
+ * When running in JVM mode, the [version] is resolved from the host JDK, while on a Native Image, the version is
+ * translated from the current SubstrateVM release.
+ *
+ * @see isNativeImage
+ */
+@DelicateElideApi public class GraalVMRuntime(
+  override val version: Version? = resolveVersion(),
+  override val variant: String? = resolveVariant(),
+) : HostRuntime {
+  override val name: String = RUNTIME_NAME
+
+  /** Whether this runtime is being executed from native compiled code. */
+  public inline val native: Boolean get() = variant == VARIANT_NATIVE
+
+  public companion object {
+    /** Name of the system property that provides the current JVM version. */
+    private const val SYSTEM_JVM_VERSION: String = "java.vm.version"
+
+    /**
+     * Internal map used to resolve a known GraalVM version from a SubstrateVM version. The keys represent SubstrateVM
+     * versions and the values are the corresponding GraalVM release.
+     */
+    private val SubstrateVersionMap = sortedMapOf(
+      "35" to "23.1.0",
+    )
+
+    /** Constant value used to provide the [HostRuntime.name] property for the [GraalVMRuntime]. */
+    internal const val RUNTIME_NAME: String = "graalvm"
+
+    /** Constant value representing a [GraalVMRuntime] variant running from a Native Image.*/
+    public const val VARIANT_NATIVE: String = "native"
+
+    /** Constant value representing a [GraalVMRuntime] variant running on a JDK.*/
+    public const val VARIANT_JVM: String = "jvm"
+
+    /** Version constant for GraalVM 23.0 */
+    public val GVM_23: Version = Version(23)
+
+    /** Version constant for GraalVM 23.1 */
+    public val GVM_23_1: Version = Version(23, 1)
+
+    /**
+     * Detect the current runtime version and return it as a comparable [Version] object. When running from a
+     * Native Image, the resolved version will be mapped to a known GraalVM version.
+     *
+     * @param source The source of the version to be resolved, defaults to using system properties.
+     * @return The version of the current runtime, or `null` if the "java.vm.version" property value is not recognized
+     * as a valid version or the current SubstrateVM version cannot be mapped to a known GraalVM version.
+     */
+    internal fun resolveVersion(source: String = System.getProperty(SYSTEM_JVM_VERSION)): Version? {
+      // in a native image, we'll need to translate the SVM release to a known SDK release
+      if (ImageInfo.inImageCode()) source.split("+").lastOrNull()?.let { svm ->
+        return Version.parse(SubstrateVersionMap[svm] ?: return null)
+      }
+
+      // running on GraalVM JVM (e.g. 20.0.2+9-jvmci-23.0-b14)
+      if (source.contains("jvmci")) source.split("-").getOrNull(2)?.let { jvm ->
+        return Version.parse(jvm)
+      }
+
+      // unknown version
+      return null
+    }
+
+    /**
+     * Detect the active runtime variant: [VARIANT_NATIVE] if running from a Native Image, or [VARIANT_JVM] if running
+     * on a GraalVM JDK.
+     *
+     * @return The [VARIANT_NATIVE] constant if running from a native image, or [VARIANT_JVM] if running on a JDK.
+     */
+    internal fun resolveVariant(): String {
+      if (ImageInfo.inImageCode()) return VARIANT_NATIVE
+      return VARIANT_JVM
+    }
+  }
+}
+
+/** Whether this runtime is hosted from a GraalVM Native Image. */
+@DelicateElideApi public inline val HostRuntime.isNativeImage: Boolean
+  get() = this is GraalVMRuntime && this.native

--- a/packages/graalvm/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMRuntime.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMRuntime.kt
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2023 Elide Ventures, LLC.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
 package elide.runtime.core.internals.graalvm
 
 import org.graalvm.nativeimage.ImageInfo

--- a/packages/graalvm/src/test/kotlin/elide/runtime/core/VersionTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/core/VersionTest.kt
@@ -1,0 +1,74 @@
+package elide.runtime.core
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+@OptIn(DelicateElideApi::class)
+class VersionTest {
+  @Test fun testParseValidVersion() {
+    val cases = arrayOf(
+      "1.1.5" to Version(1, 1, 5),
+      "5.1" to Version(5, 1, 0),
+      "2.0.0-SNAPSHOT" to Version(2, 0, 0),
+      "1-1-1" to Version(1, 1, 1),
+      "0_4_1" to Version(0, 4, 1),
+      "19-2_1" to Version(19, 2, 1),
+    )
+
+    for ((source, expected) in cases) assertEquals(
+      expected,
+      actual = Version.parse(source),
+      message = "should parse valid version '$source'",
+    )
+  }
+
+  @Test fun testParseInvalidVersion() {
+    val cases = arrayOf(
+      "1",
+      "a5.1",
+      "a.b.c",
+      "1.5.c",
+    )
+
+    for (source in cases) assertThrows<IllegalArgumentException>("should reject invalid version '$source'") {
+      Version.parse(source)
+    }
+  }
+
+  @Test fun testCompareVersions() {
+    val cases = arrayOf(
+      Triple("1.5.0", "1.5.1", -1),
+      Triple("1.5", "1.5.1", -1),
+      Triple("1.5", "1.6.1", -1),
+      Triple("1.5", "2.5", -1),
+      Triple("1.5", "2.5.1", -1),
+      Triple("1.5.0", "1.5.0", 0),
+      Triple("1.5", "1.5.0", 0),
+      Triple("1.5.0", "1.4.9", 1),
+      Triple("2.5.0", "1.5.9", 1),
+    )
+
+    for ((left, right, result) in cases) assertEquals(
+      expected = result,
+      actual = Version.parse(left) compareTo Version.parse(right),
+      message = "should compare correctly: '$left' vs '$right')",
+    )
+  }
+
+  @Test fun testVersionInRange() {
+    val range = Version(1, 2, 3).andHigher()
+    val cases = arrayOf(
+      "0.1" to false,
+      "1.2.2" to false,
+      "1.2.3" to true,
+      "4.1" to true,
+    )
+
+    for ((source, result) in cases) assertEquals(
+      expected = result,
+      actual = Version.parse(source) in range,
+      message = "should return $result for '$source' in '$range'",
+    )
+  }
+}

--- a/packages/graalvm/src/test/kotlin/elide/runtime/core/VersionTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/core/VersionTest.kt
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2023 Elide Ventures, LLC.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
 package elide.runtime.core
 
 import org.junit.jupiter.api.Test

--- a/packages/graalvm/src/test/kotlin/elide/runtime/core/internals/graalvm/GraalVMRuntimeTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/core/internals/graalvm/GraalVMRuntimeTest.kt
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2023 Elide Ventures, LLC.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
 package elide.runtime.core.internals.graalvm
 
 import org.junit.jupiter.api.Test

--- a/packages/graalvm/src/test/kotlin/elide/runtime/core/internals/graalvm/GraalVMRuntimeTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/core/internals/graalvm/GraalVMRuntimeTest.kt
@@ -1,0 +1,21 @@
+package elide.runtime.core.internals.graalvm
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import elide.runtime.core.DelicateElideApi
+
+@OptIn(DelicateElideApi::class)
+class GraalVMRuntimeTest {
+  @Test fun testResolveVersion() {
+    val cases = arrayOf(
+      "20.0.2+9-jvmci-23.0-b14" to GraalVMRuntime.GVM_23,
+      "21+35-jvmci-23.1-b15" to GraalVMRuntime.GVM_23_1,
+    )
+    
+    for ((source, version) in cases) assertEquals(
+      expected = version,
+      actual = GraalVMRuntime.resolveVersion(source),
+      message = "should resolve version $version from '$source'",
+    )
+  }
+}


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

This PR introduces the `HostRuntime` API, which provides information about the runtime to engine plugins. Use the `PolyglotEngineConfiguration.hostRuntime` property to access it:

```kotlin
/** Provides information about the runtime hosting the application. */
@DelicateElideApi public interface HostRuntime {
  /** The name of this runtime, which is used in string representations and for debugging purposes. */
  public val name: String

  /** The version spec of this runtime, wrapped to allow version comparisons using regular operators. */
  public val version: Version?

  /** An optional variant name for this runtime. Some engines like GraalVM differentiate between runtime variants. */
  public val variant: String?
}
```

The `HostRuntime.on` extension provides conditional execution of code based on the version of the current runtime, compared with the specified target version (or version range). The `GraalVMRuntime` companion provides a few version constants representing known GraalVM versions (`GVM_23` and `GVM_23_1`):

```kotlin
fun configureOptions(configuration: PolyglotEngineConfiguration) {
  // enable some options only for GraalVM 23.0 and previous versions
  configuration.hostRuntime.on(GVM_23.andLower()) {
    enableOption("engine.Inlining")
  }
}
```