### PR TITLE
Pre-release Hotfixes: `alpha7`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "google-protobuf": "3.21.2",
     "postcss": "8.4.30",
     "preact": "10.17.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "typescript": "4.9.5",
     "web-streams-polyfill": "3.2.1"
   },

--- a/packages/cli/src/main/kotlin/elide/tool/engine/NativeEngine.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/engine/NativeEngine.kt
@@ -33,6 +33,7 @@ import elide.tool.io.WorkdirManager
  * Provides utilities for loading native portions of Elide early in the boot lifecycle.
  */
 object NativeEngine {
+  private const val loadEager = false
   private const val DEFAULT_NATIVES_PATH = "META-INF/native/"
   private val nativeTransportAvailable: AtomicBoolean = AtomicBoolean(false)
   private val errHolder: AtomicReference<Throwable?> = AtomicReference(null)
@@ -260,7 +261,7 @@ object NativeEngine {
       System.setProperty(it.first, it.second)
     }
 
-    if (ImageInfo.inImageRuntimeCode()) {
+    if (loadEager) {
       loadAllNatives(platform, natives.toFile(), this::class.java.classLoader)
     }
 

--- a/packages/cli/src/main/kotlin/elide/tool/io/RuntimeWorkdirManager.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/io/RuntimeWorkdirManager.kt
@@ -22,13 +22,10 @@ import java.util.SortedSet
 import java.util.concurrent.ConcurrentSkipListMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
-import java.util.function.Supplier
 import jakarta.inject.Provider
 import kotlin.io.path.absolute
-import kotlin.io.path.absolutePathString
 import kotlin.io.path.exists
 import elide.annotations.Context
-import elide.annotations.Eager
 import elide.annotations.Factory
 import elide.annotations.Singleton
 import elide.runtime.core.DelicateElideApi

--- a/packages/cli/src/main/resources/META-INF/native-image/resource-config.json
+++ b/packages/cli/src/main/resources/META-INF/native-image/resource-config.json
@@ -19,8 +19,6 @@
   }, {
     "pattern":"\\Q(netty_transport_native_kqueue_aarch_64, META-INF/nativelibnetty_transport_native_kqueue_aarch_64.dylib\\E"
   }, {
-    "pattern":"\\QMETA-INF/elide/**/*.*"
-  }, {
     "pattern":"\\QMETA-INF/elide/embedded/runtime/js/facade.js\\E"
   }, {
     "pattern":"\\QMETA-INF/elide/embedded/runtime/js/js.modules.tar.gz\\E"
@@ -37,13 +35,9 @@
   }, {
     "pattern":"\\QMETA-INF/elide/embedded/runtime/jvm/runtime.json\\E"
   }, {
-    "pattern":"\\QMETA-INF/elide/embedded/runtime/python/python-darwin-aarch64.tar.xz\\E"
-  }, {
     "pattern":"\\QMETA-INF/elide/embedded/runtime/python/runtime.json.gz\\E"
   }, {
     "pattern":"\\QMETA-INF/elide/embedded/runtime/python/runtime.json\\E"
-  }, {
-    "pattern":"\\QMETA-INF/elide/embedded/runtime/ruby/ruby-darwin-aarch64.tar.gz\\E"
   }, {
     "pattern":"\\QMETA-INF/elide/embedded/runtime/ruby/runtime.json.gz\\E"
   }, {
@@ -56,8 +50,6 @@
     "pattern":"\\QMETA-INF/elide/v4/embedded/runtime/js/polyfills.js\\E"
   }, {
     "pattern":"\\QMETA-INF/elide/v4/embedded/runtime/js/runtime.json\\E"
-  }, {
-    "pattern":"\\QMETA-INF/elide/v4/embedded/runtime/ruby/ruby-darwin-aarch64.tar.gz\\E"
   }, {
     "pattern":"\\QMETA-INF/elide/v4/embedded/runtime/ruby/runtime.json\\E"
   }, {
@@ -552,6 +544,10 @@
     "pattern":"\\Qlogback.xml\\E"
   }, {
     "pattern":"\\Qmicronaut-version.properties\\E"
+  }, {
+    "pattern":"\\Qorg/fusesource/jansi/*.*"
+  }, {
+    "pattern":"\\Qorg/fusesource/jansi/**/*.*"
   }, {
     "pattern":"\\Qorg/fusesource/jansi/internal/native/Mac/arm64/libjansi.jnilib\\E"
   }, {

--- a/packages/cli/src/main/resources/elide.yml
+++ b/packages/cli/src/main/resources/elide.yml
@@ -33,3 +33,5 @@ micronaut.server.netty.use-native-transport: true
 micronaut.server.netty.parent.prefer-native-transport: true
 micronaut.server.netty.worker.prefer-native-transport: true
 micronaut.netty.event-loops.default.prefer-native-transport: true
+micronaut.netty.event-loops.default.num-threads: 2
+micronaut.netty.event-loops.parent.num-threads: 2

--- a/packages/cli/src/main/resources/logback.xml
+++ b/packages/cli/src/main/resources/logback.xml
@@ -1,10 +1,11 @@
 <configuration debug="false">
-  <contextName>elide</contextName>
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
   <variable name="APPENDER" value="${log.file.root:-ASYNC_LAZY}" />
   <variable name="ROOT_LOGLEVEL" value="${elide.logging.root.level:-warn}" />
-  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
   <serializeModel file="src/main/resources/logback.scmo"/>
+  <contextName>elide</contextName>
 
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <target>System.out</target>
     <encoder>

--- a/packages/graalvm/src/main/kotlin/elide/runtime/feature/engine/NativeTransportFeature.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/feature/engine/NativeTransportFeature.kt
@@ -19,6 +19,9 @@ import elide.annotations.internal.VMFeature
 
 /** Registers native transport libraries for static JNI. */
 @VMFeature internal class NativeTransportFeature : AbstractStaticNativeLibraryFeature() {
+  companion object {
+    const val enabled = false
+  }
   override fun getDescription(): String = "Registers native transport libraries"
 
   override fun isInConfiguration(access: IsInConfigurationAccess): Boolean {
@@ -29,7 +32,7 @@ import elide.annotations.internal.VMFeature
     )
   }
 
-  override fun nativeLibs(access: BeforeAnalysisAccess) = listOf(
+  override fun nativeLibs(access: BeforeAnalysisAccess) = if (enabled) listOf(
     // Native Transport: Linux
     nativeLibrary(linux = libraryNamed("netty_transport_native_epoll")),
     nativeLibrary(linux = libraryNamed("netty_quiche_linux")),
@@ -38,5 +41,5 @@ import elide.annotations.internal.VMFeature
     nativeLibrary(darwin = libraryNamed("netty_transport_native_kqueue")),
     nativeLibrary(darwin = libraryNamed("netty_resolver_dns_native_macos")),
     nativeLibrary(darwin = libraryNamed("netty_quiche_osx")),
-  )
+  ) else emptyList()
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/server/http/HttpServerAgent.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/server/http/HttpServerAgent.kt
@@ -71,7 +71,7 @@ import elide.runtime.intrinsics.server.http.netty.NettyServerEngine
     context.evaluate(entrypoint)
 
     // automatically start if requested
-    if(config.autoStart) engine.start()
+    if (config.autoStart) engine.start()
   }
 
   /**

--- a/packages/server/src/main/kotlin/elide/server/Application.kt
+++ b/packages/server/src/main/kotlin/elide/server/Application.kt
@@ -13,6 +13,7 @@
 
 package elide.server
 
+import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Context
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.runtime.Micronaut
@@ -122,7 +123,7 @@ public interface Application {
   }
 
   /** Application startup listener and callback trigger. */
-  @Context @Eager public class AppStartupListener : ApplicationEventListener<ServerStartupEvent> {
+  @Bean public class AppStartupListener : ApplicationEventListener<ServerStartupEvent> {
     override fun onApplicationEvent(event: ServerStartupEvent): Unit = runBlocking {
       Initialization.trigger(
         Initialization.CallbackStage.INIT
@@ -163,7 +164,6 @@ public interface Application {
     Micronaut
       .build()
       .eagerInitConfiguration(true)
-      .eagerInitSingletons(true)
       .eagerInitAnnotated(Eager::class.java, Context::class.java)
       .args(*args)
       .start()

--- a/packages/server/src/main/kotlin/elide/server/cfg/ServerConfigurator.kt
+++ b/packages/server/src/main/kotlin/elide/server/cfg/ServerConfigurator.kt
@@ -149,7 +149,7 @@ import elide.server.annotations.Eager
       System.setProperty(entry.key, entry.value)
     }
     // basics
-    builder.eagerInitSingletons(true)
+    builder
       .banner(false)
       .deduceEnvironment(true)
       .enableDefaultPropertySources(true)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,12 @@ importers:
       preact:
         specifier: 10.17.1
         version: registry.npmjs.org/preact@10.17.1
+      react:
+        specifier: 18.2.0
+        version: registry.npmjs.org/react@18.2.0
+      react-dom:
+        specifier: 18.2.0
+        version: registry.npmjs.org/react-dom@18.2.0(react@18.2.0)
       typescript:
         specifier: 4.9.5
         version: registry.npmjs.org/typescript@4.9.5
@@ -3997,6 +4003,19 @@ packages:
       unpipe: registry.npmjs.org/unpipe@1.0.0
     dev: false
 
+  registry.npmjs.org/react-dom@18.2.0(react@18.2.0):
+    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==, registry: https://npm.pkg.st/, tarball: https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz}
+    id: registry.npmjs.org/react-dom/18.2.0
+    name: react-dom
+    version: 18.2.0
+    peerDependencies:
+      react: ^18.2.0
+    dependencies:
+      loose-envify: registry.npmjs.org/loose-envify@1.4.0
+      react: registry.npmjs.org/react@18.2.0
+      scheduler: registry.npmjs.org/scheduler@0.23.0
+    dev: false
+
   registry.npmjs.org/react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==, registry: https://npm.pkg.st/, tarball: https://registry.npmjs.org/react/-/react-18.2.0.tgz}
     name: react
@@ -4127,6 +4146,14 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==, registry: https://npm.pkg.st/, tarball: https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz}
     name: safer-buffer
     version: 2.1.2
+    dev: false
+
+  registry.npmjs.org/scheduler@0.23.0:
+    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==, registry: https://npm.pkg.st/, tarball: https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz}
+    name: scheduler
+    version: 0.23.0
+    dependencies:
+      loose-envify: registry.npmjs.org/loose-envify@1.4.0
     dev: false
 
   registry.npmjs.org/schema-utils@3.3.0:

--- a/samples/fullstack/react-ssr/server/src/main/kotlin/fullstack/reactssr/App.kt
+++ b/samples/fullstack/react-ssr/server/src/main/kotlin/fullstack/reactssr/App.kt
@@ -40,7 +40,6 @@ object App : Application {
     @Get("/") suspend fun indexPage(request: HttpRequest<*>) = ssr(request) {
       head {
         title { +"Hello, Elide!" }
-//        stylesheet(asset("styles.base"))
         stylesheet("/styles/base.css")
         stylesheet("/styles/main.css")
         script("/scripts/ui.js", defer = true)

--- a/tools/scripts/express.js
+++ b/tools/scripts/express.js
@@ -11,7 +11,6 @@
  * License for the specific language governing permissions and limitations under the License.
  */
 
-const express = require('express')
 const app = express()
 const port = 3000
 


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Omnibus package of hotfixes before `alpha7` release. This suite of fixes constitutes a bunch of individual bugfixes which, individually, don't really qualify for a full-blown PR, and must land before release (ideally). Merging as part of #445.

## Changelog

- fix: add `react` and `react-dom` dependencies
- fix: disable eager loading of native libs in cli tool
- fix: reduce default event-loop threads
- fix: startup-friendly server changes (don't eagerly init singletons)
- fix: initialize dispatcher at runtime (not statically)
- fix: include all jansi resources
- fix: logback configuration tweaks
- fix: native terminal init steps
- chore: general sample and import cleanup