### PR TITLE
feat: decouple env plugin from language runtimes

### DIFF
--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
@@ -387,7 +387,7 @@ import elide.tool.project.ProjectManager
 
     /** Apply these settings to created execution contexts. */
     @Suppress("KotlinConstantConditions")
-    internal fun apply(project: ProjectInfo, config: PolyglotEngineConfiguration) = config.environment {
+    internal fun apply(project: ProjectInfo?, config: PolyglotEngineConfiguration) = config.environment {
       val effectiveInjectedEnv = TreeMap<String, EnvVar>()
 
       // inject `NODE_ENV`
@@ -397,8 +397,8 @@ import elide.tool.project.ProjectManager
         "production"
       })
 
-      // apply project-level environment variables first
-      project.env?.vars?.forEach {
+      // apply project-level environment variables first (if applicable)
+      project?.env?.vars?.forEach {
         if (it.value.isPresent) {
           if (it.value.source == DOTENV && !dotenv) {
             return@forEach  // skip .env vars if so instructed
@@ -1485,9 +1485,11 @@ import elide.tool.project.ProjectManager
     if (project != null) logging.debug("Resolved project info: $project")
 
     // conditionally apply debugging settings
-    if (project != null) appEnvironment.apply(project, this)
     if (debug) debugger.apply(this)
     inspector.apply(this)
+
+    // configure environment variables
+    appEnvironment.apply(project, this)
 
     // configure VFS with user-specified bundles
     vfs {

--- a/packages/cli/src/main/kotlin/elide/tool/project/DefaultProjectManager.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/project/DefaultProjectManager.kt
@@ -143,10 +143,10 @@ import elide.tool.project.struct.nodepkg.NodePackage
       val env = readDotEnv(dir)
 
       return when (mainConfig) {
-        null -> if (env != null) ProjectInfo.of(
+        null -> ProjectInfo.of(
           root = rootPath,
           env = env,
-        ) else null
+        )
 
         else -> ProjectInfo.of(
           name = mainConfig.name,

--- a/packages/graalvm-py/src/main/resources/META-INF/elide/embedded/runtime/python/environment.py
+++ b/packages/graalvm-py/src/main/resources/META-INF/elide/embedded/runtime/python/environment.py
@@ -27,12 +27,9 @@ class _Elide_ApplicationEnvironment(object):
     __virtual_env = {}
 
     def __init__(self):
-        try:
-            import polyglot
-            data = (polyglot.import_value("elide_app_environment") or (lambda: {}))()
-            self.__app_environ = {x: data[x] for x in data}
-        except Exception:
-            pass  # silent fail
+        import polyglot
+        data = polyglot.import_value("__Elide_app_env__")
+        self.__app_environ = {x: data[x] for x in data}
 
     def contains_key(self, item):
         return item in self.__app_environ or item in self.__virtual_env

--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -157,7 +157,6 @@ public abstract interface class elide/runtime/core/PolyglotEngine {
 
 public abstract class elide/runtime/core/PolyglotEngineConfiguration : elide/runtime/core/PluginRegistry {
 	public abstract fun enableLanguage (Lelide/runtime/core/GuestLanguage;)V
-	public final fun getEnvironment ()Ljava/util/Map;
 	public final fun getHostAccess ()Lelide/runtime/core/PolyglotEngineConfiguration$HostAccess;
 	public final fun getHostPlatform ()Lelide/runtime/core/HostPlatform;
 	public abstract fun getHostRuntime ()Lelide/runtime/core/HostRuntime;

--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -2292,6 +2292,7 @@ public final class elide/runtime/plugins/env/EnvConfig$AppEnvConfig {
 	public final fun getEnabled ()Z
 	public final fun getIsolatedEnvironmentVariables ()Ljava/util/Map;
 	public final fun setEnabled (Z)V
+	public final fun setEnv (Ljava/lang/String;Lelide/runtime/plugins/env/EnvConfig$EnvVar;)V
 }
 
 public abstract interface class elide/runtime/plugins/env/EnvConfig$EnvVar {
@@ -2404,6 +2405,7 @@ public final class elide/runtime/plugins/env/Environment {
 	public static final field Plugin Lelide/runtime/plugins/env/Environment$Plugin;
 	public synthetic fun <init> (Lelide/runtime/plugins/env/EnvConfig;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getConfig ()Lelide/runtime/plugins/env/EnvConfig;
+	public final fun install (Lelide/runtime/core/PolyglotContext;Lelide/runtime/core/GuestLanguage;)V
 }
 
 public final class elide/runtime/plugins/env/Environment$Plugin : elide/runtime/core/EnginePlugin {
@@ -2419,7 +2421,7 @@ public final class elide/runtime/plugins/js/ExtensionsKt {
 
 public final class elide/runtime/plugins/js/JavaScript {
 	public static final field Plugin Lelide/runtime/plugins/js/JavaScript$Plugin;
-	public synthetic fun <init> (Lelide/runtime/plugins/js/JavaScriptConfig;Lelide/runtime/plugins/AbstractLanguagePlugin$LanguagePluginManifest;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lelide/runtime/plugins/js/JavaScriptConfig;Lelide/runtime/plugins/AbstractLanguagePlugin$LanguagePluginManifest;Lelide/runtime/plugins/env/Environment;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class elide/runtime/plugins/js/JavaScript$Plugin : elide/runtime/plugins/AbstractLanguagePlugin {

--- a/packages/graalvm/src/main/kotlin/elide/runtime/core/PolyglotEngineConfiguration.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/core/PolyglotEngineConfiguration.kt
@@ -54,9 +54,6 @@ import elide.runtime.core.PolyglotEngineConfiguration.HostAccess.ALLOW_NONE
   /** Information about the runtime engine. */
   public abstract val hostRuntime: HostRuntime
 
-  /** Environment to apply to the context. */
-  public val environment: MutableMap<String, String> = ConcurrentSkipListMap()
-
   /** Enables support for the specified [language] on all contexts created by the engine. */
   public abstract fun enableLanguage(language: GuestLanguage)
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/plugins/env/EnvPlugin.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/plugins/env/EnvPlugin.kt
@@ -14,56 +14,52 @@
 package elide.runtime.plugins.env
 
 import org.graalvm.polyglot.Value
-import org.graalvm.polyglot.proxy.*
-import java.util.concurrent.ConcurrentSkipListMap
-import java.util.concurrent.atomic.AtomicReference
+import org.graalvm.polyglot.proxy.ProxyHashMap
+import org.graalvm.polyglot.proxy.ProxyIterable
+import org.graalvm.polyglot.proxy.ProxyIterator
+import org.graalvm.polyglot.proxy.ProxyObject
 import elide.runtime.core.*
-import elide.runtime.core.EngineLifecycleEvent.*
+import elide.runtime.core.EngineLifecycleEvent.ContextCreated
+import elide.runtime.core.EngineLifecycleEvent.ContextInitialized
 import elide.runtime.core.EnginePlugin.InstallationScope
 import elide.runtime.core.EnginePlugin.Key
-import elide.runtime.gvm.internals.GraalVMGuest
-import elide.runtime.gvm.internals.intrinsics.js.struct.map.JsMap
-import elide.runtime.plugins.env.Environment.Plugin.APP_ENV_ACCESSOR
-import elide.runtime.plugins.env.Environment.Plugin.APP_ENV_SYMBOL
 import elide.vm.annotations.Polyglot
 
 /**
  * Engine plugin providing isolated application environment.
  *
+ * In order to correctly support all languages, this plugin is cooperative: a language plugin may opt into
+ * using it by [installing][install] the env map binding into a context.
+ *
  * @see EnvConfig
  */
-@DelicateElideApi public class Environment private constructor (public val config: EnvConfig) {
-  private val effectiveEnvironment: AtomicReference<MutableMap<String, String?>> = AtomicReference(null)
-  private val languageSupport: MutableMap<String, Boolean> = ConcurrentSkipListMap()
-
-  // Maybe inject an environment variable, otherwise run `or`.
-  private fun maybeInjectedVar(variable: String, or: () -> Any?) : Any? {
-    return when (variable.lowercase().trim()) {
-      nodeEnvVariable -> "production"
-      else -> or.invoke()
-    }
+@DelicateElideApi public class Environment private constructor(public val config: EnvConfig) {
+  /** Collect the configured environment variables and keep the ones currently present. */
+  private val effectiveEnvironment: Map<String, String?> by lazy {
+    config.app.isolatedEnvironmentVariables.filter { it.value.isPresent }.mapValues { it.value.value }
   }
 
-  // Build proxied map for guest language access to env; it should not be mutable.
+  /** A proxied map for guest language access to env; it should not be mutable. */
   private val proxiedEnvMap: ProxyHashMap by lazy {
-    val jsMap = JsMap.of(effectiveEnvironment.get() ?: error("Could not resolve effective environment"))
-    object: ProxyHashMap, ProxyIterable, ProxyObject {
-      @Polyglot override fun getHashSize(): Long = jsMap.size.toLong() + injectedVariableCount
-      @Polyglot override fun hasHashEntry(key: Value): Boolean = jsMap.has(key.asString())
-      @Polyglot override fun getHashValue(key: Value): Any? = jsMap[key.asString()]
-      @Polyglot override fun getHashEntriesIterator(): Any = jsMap.entries()
-      @Polyglot override fun putHashEntry(key: Value, value: Value) =
+    object : ProxyHashMap, ProxyIterable, ProxyObject {
+      @Polyglot override fun getHashSize(): Long = effectiveEnvironment.size.toLong()
+      @Polyglot override fun hasHashEntry(key: Value): Boolean = effectiveEnvironment.contains(key.asString())
+      @Polyglot override fun getHashValue(key: Value): Any? = effectiveEnvironment[key.asString()]
+      @Polyglot override fun getHashEntriesIterator(): Any = effectiveEnvironment.entries
+      @Polyglot override fun putHashEntry(key: Value, value: Value) {
         throw UnsupportedOperationException("Elide forbids writes to `process.env` after VM boot")
+      }
 
-      @Polyglot override fun getMember(key: String): Any? = jsMap[key]
-      @Polyglot override fun getMemberKeys(): Any = jsMap.keys.toTypedArray()
-      @Polyglot override fun hasMember(key: String): Boolean = jsMap.has(key)
-      @Polyglot override fun putMember(key: String, value: Value?) =
+      @Polyglot override fun getMember(key: String): Any? = effectiveEnvironment[key]
+      @Polyglot override fun getMemberKeys(): Any = effectiveEnvironment.keys.toTypedArray()
+      @Polyglot override fun hasMember(key: String): Boolean = effectiveEnvironment.contains(key)
+      @Polyglot override fun putMember(key: String, value: Value?) {
         throw UnsupportedOperationException("Elide forbids writes to `process.env` after VM boot")
+      }
 
       @Polyglot override fun getIterator(): Any {
-        val iterator = jsMap.keys.iterator()
-        return object: ProxyIterator {
+        val iterator = effectiveEnvironment.keys.iterator()
+        return object : ProxyIterator {
           override fun hasNext(): Boolean = iterator.hasNext()
           override fun getNext(): Any = iterator.next()
         }
@@ -73,79 +69,39 @@ import elide.vm.annotations.Polyglot
 
   /** Apply an environment [config] to a context [builder] during the [ContextCreated] event. */
   internal fun onContextCreate(builder: PolyglotContextBuilder) {
-    if (config.app.enabled) {
-      config.app.isolatedEnvironmentVariables.filterValues {
-        it.isPresent
-      }.mapValues {
-        it.value.value
-      }.toMutableMap().let { effective ->
-        // apply configured app environment
-        effectiveEnvironment.set(effective)
-        builder.environment(effective)
-      }
-    }
+    if (!config.app.enabled) return
+
+    // apply configured app environment
+    builder.environment(effectiveEnvironment)
   }
 
-  /** Install universal application environment symbols. */
-  internal fun installPolyglotBinding(context: PolyglotContext) = effectiveEnvironment.get()?.let { envMap ->
-    context.bindings().putMember(APP_ENV_ACCESSOR, ProxyExecutable {
-      proxiedEnvMap
-    })
-  }
-
-  /** Install JS-specific application environment symbols. */
-  internal fun installJsAppEnvBinding(context: PolyglotContext) = effectiveEnvironment.get()?.let { envMap ->
-    context.bindings(object: GuestLanguage {
-      override val languageId: String get() = GraalVMGuest.JAVASCRIPT.engine
-    }).putMember(
-      APP_ENV_SYMBOL,
-      proxiedEnvMap,
-    )
-  }
-
-  /** Install Ruby-specific application environment symbols. */
-  internal fun installRubyAppEnvAccessors(context: PolyglotContext) = effectiveEnvironment.get()?.let { envMap ->
-    // nothing at this time
-  }
-
-  /** Check [language] support and run [do] if enabled. */
-  private fun ifLangSupported(language: String, `do`: () -> Unit) {
-    if (languageSupport[language] == true) {
-      `do`.invoke()
-    }
-  }
-
-  /** Install language-specific bindings for injected application environment. */
+  /** Inject the environment polyglot bindings into a [context]. */
   internal fun onContextInitialize(context: PolyglotContext) {
-    installPolyglotBinding(context)
-    ifLangSupported(GraalVMGuest.JAVASCRIPT.engine) { installJsAppEnvBinding(context) }
-    ifLangSupported(GraalVMGuest.RUBY.engine) { installRubyAppEnvAccessors(context) }
+    context.bindings().putMember(APP_ENV_BIND_PATH, proxiedEnvMap)
+  }
+
+  /**
+   * Install the application environment bindings into the target [context] for a given [language]. This is only
+   * necessary if polyglot bindings are not accessible in the target language.
+   *
+   * This method should be used by language plugins to opt into using the virtual environment support, and should be
+   * called during the [ContextInitialized][elide.runtime.core.EngineLifecycleEvent.ContextInitialized] event.
+   */
+  public fun install(context: PolyglotContext, language: GuestLanguage) {
+    context.bindings(language).putMember(APP_ENV_BIND_PATH, proxiedEnvMap)
   }
 
   /** Identifier for the [Environment] plugin, which provides isolated application environment. */
   public companion object Plugin : EnginePlugin<EnvConfig, Environment> {
-    private const val injectedVariableCount = 1L
-    private const val nodeEnvVariable = "NODE_ENV"
-    private const val APP_ENV_SYMBOL = "__Elide_app_env__"
-    private const val APP_ENV_ACCESSOR = "elide_app_environment"
+    /** Binding path for the env container. */
+    private const val APP_ENV_BIND_PATH = "__Elide_app_env__"
+
     override val key: Key<Environment> = Key("Environment")
 
     override fun install(scope: InstallationScope, configuration: EnvConfig.() -> Unit): Environment {
       // apply the configuration and create the plugin instance
       val config = EnvConfig().apply(configuration)
       val instance = Environment(config)
-
-      // @TODO: graceful language detection
-      val engine = org.graalvm.polyglot.Engine.create()
-      listOf(
-        GraalVMGuest.JAVASCRIPT.engine,
-        GraalVMGuest.PYTHON.engine,
-        GraalVMGuest.RUBY.engine,
-        GraalVMGuest.JVM.engine,
-        GraalVMGuest.WASM.engine,
-      ).forEach {
-        instance.languageSupport[it] = engine.languages.containsKey(it)
-      }
 
       // subscribe to lifecycle events
       scope.lifecycle.on(ContextCreated, instance::onContextCreate)


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

This PR updates the `Environment` plugin to remove dependencies on language plugins.

The env variables proxy is injected through polyglot bindings by default. Languages without support for polyglot bindings may install the env proxy manually to language-scoped bindings using `Environment.install(PolyglotContext, GuestLanguage)`.