### PR TITLE
feat(dev): add `bash` and `elide` containers

### DIFF
--- a/tools/images/base/Dockerfile
+++ b/tools/images/base/Dockerfile
@@ -20,6 +20,6 @@ RUN apt-get update \
   && apt-get autoremove \
   && rm -rf /var/lib/apt/lists/*
 
-ENV LC_CTYPE=en_US.UTF-8 \
-  LC_ALL=en_US.UTF-8 \
-  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/lib/gvm/bin:/sbin:/bin
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US \
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/lib/gvm/bin:/sbin:/bin

--- a/tools/images/bash/Dockerfile
+++ b/tools/images/bash/Dockerfile
@@ -1,0 +1,31 @@
+FROM --platform=linux/amd64 debian:stable-slim AS base
+
+LABEL org.opencontainers.image.vendor=Elide
+LABEL org.opencontainers.image.title="Elide Runtime with Bash"
+LABEL org.opencontainers.image.description="Elide runtime CLI as a container image, with Bash and several tools"
+LABEL org.opencontainers.image.version=1.0.0-alpha7
+LABEL org.opencontainers.image.url=https://github.com/elide-dev/elide
+LABEL org.opencontainers.image.base.name=ghcr.io/elide-dev/base
+LABEL org.opencontainers.image.base.digest=sha256:ce2fe9474ca168eebfd35b0c7682db11045b0f10418ec46ae9b0c7610c295913
+LABEL org.opencontainers.image.source=https://github.com/elide-dev/elide/blob/main/tools/images/bash/Dockerfile
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+      bash \
+      ca-certificates \
+      curl \
+      uuid-runtime \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd elide \
+    && useradd dev -g elide -m -s /bin/bash \
+    && ln -s /home/dev/elide/elide /bin/elide
+
+USER dev
+
+RUN echo "Installing Elide..." \
+    && curl -sSL elide.sh | bash -s - \
+    && which elide \
+    && elide --help \
+    && elide selftest \
+    && elide info \
+    && echo "Elide/Bash container image ready."

--- a/tools/images/bash/Makefile
+++ b/tools/images/bash/Makefile
@@ -1,0 +1,16 @@
+
+#
+# Elide: Docker Images
+# -----------------------
+# Image: Elide with Bash
+#
+
+IMAGE ?= bash
+PROVENANCE ?= yes
+PUB_IMAGE ?= $(IMAGE)
+REPOSITORY ?= tools/$(IMAGE)
+PUB_IMAGE_PATH ?= ghcr.io/elide-dev/$(IMAGE):$(VERSION)
+ORIGIN_IMAGE ?= $(PUB_IMAGE_PATH)
+PLATFORMS = linux/amd64
+
+include ../Docker.mk

--- a/tools/images/bash/cloudbuild.yaml
+++ b/tools/images/bash/cloudbuild.yaml
@@ -1,0 +1,31 @@
+steps:
+  - name: "gcr.io/cloud-builders/docker"
+    args: [
+      "run",
+      "--rm",
+      "--privileged",
+      "tonistiigi/binfmt",
+      "--install",
+      "all"
+    ]
+  - name: "gcr.io/cloud-builders/docker"
+    args: [
+      "buildx",
+      "create",
+      "--name", "multiarch",
+      "--driver", "docker-container",
+      "--use"
+    ]
+  - name: "gcr.io/cloud-builders/docker"
+    dir: "tools/images/elide"
+    args: [
+      "buildx",
+      "build",
+      "--push",
+      "--platform", "linux/arm64,linux/amd64",
+      "--tag", "us-docker.pkg.dev/elide-fw/tools/bash",
+      "."
+    ]
+options:
+  logging: CLOUD_LOGGING_ONLY
+projectId: elide-fw

--- a/tools/images/elide/Dockerfile
+++ b/tools/images/elide/Dockerfile
@@ -1,0 +1,56 @@
+FROM --platform=linux/amd64 debian:stable-slim AS builder
+
+RUN apt-get update \
+    && apt-get install -y \
+      bash \
+      ca-certificates \
+      curl \
+      uuid-runtime \
+    && groupadd elide \
+    && useradd dev -g elide -m -s /bin/bash \
+    && rm -rf /var/lib/apt/lists/*
+
+USER dev
+RUN echo "Installing Elide..." && curl -sSL elide.sh | bash -s -
+
+FROM --platform=linux/amd64 debian:stable-slim AS runtime
+
+LABEL org.opencontainers.image.vendor=Elide
+LABEL org.opencontainers.image.title="Elide Runtime"
+LABEL org.opencontainers.image.description="Elide runtime CLI as a container image"
+LABEL org.opencontainers.image.version=1.0.0-alpha7
+LABEL org.opencontainers.image.url=https://github.com/elide-dev/elide
+LABEL org.opencontainers.image.base.name=ghcr.io/elide-dev/base
+LABEL org.opencontainers.image.base.digest=sha256:ce2fe9474ca168eebfd35b0c7682db11045b0f10418ec46ae9b0c7610c295913
+LABEL org.opencontainers.image.source=https://github.com/elide-dev/elide/blob/main/tools/images/elide/Dockerfile
+
+RUN groupadd elide \
+    && useradd dev -g elide -m -s /bin/bash \
+    && ln -s /home/dev/elide/elide /bin/elide \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+      libc6 \
+      zlib1g \
+      bash \
+      ca-certificates \
+      curl \
+      uuid-runtime;
+
+COPY --from=builder --chown=dev:elide /home/dev/elide /home/dev/elide
+COPY entrypoint.sh /home/dev/elide/entrypoint.sh
+USER dev
+
+RUN echo "Setting up Elide..." \
+    && mkdir -p /home/dev/.elide /home/dev/workdir \
+    && touch /home/dev/.env \
+    && echo '{}' > /home/dev/package.json \
+    && which elide \
+    && elide --help \
+    && elide selftest \
+    && elide info \
+    && echo "Elide container image ready."
+
+STOPSIGNAL SIGTERM
+VOLUME /home/dev/workdir
+WORKDIR /home/dev/workdir
+ENTRYPOINT ["bash", "/home/dev/elide/entrypoint.sh"]

--- a/tools/images/elide/Makefile
+++ b/tools/images/elide/Makefile
@@ -1,0 +1,16 @@
+
+#
+# Elide: Docker Images
+# -----------------------
+# Image: Elide
+#
+
+IMAGE ?= elide
+PROVENANCE ?= yes
+PUB_IMAGE ?= $(IMAGE)
+REPOSITORY ?= tools/$(IMAGE)
+PUB_IMAGE_PATH ?= ghcr.io/elide-dev/$(IMAGE):$(VERSION)
+ORIGIN_IMAGE ?= $(PUB_IMAGE_PATH)
+PLATFORMS = linux/amd64
+
+include ../Docker.mk

--- a/tools/images/elide/cloudbuild.yaml
+++ b/tools/images/elide/cloudbuild.yaml
@@ -1,0 +1,31 @@
+steps:
+  - name: "gcr.io/cloud-builders/docker"
+    args: [
+      "run",
+      "--rm",
+      "--privileged",
+      "tonistiigi/binfmt",
+      "--install",
+      "all"
+    ]
+  - name: "gcr.io/cloud-builders/docker"
+    args: [
+      "buildx",
+      "create",
+      "--name", "multiarch",
+      "--driver", "docker-container",
+      "--use"
+    ]
+  - name: "gcr.io/cloud-builders/docker"
+    dir: "tools/images/elide"
+    args: [
+      "buildx",
+      "build",
+      "--push",
+      "--platform", "linux/arm64,linux/amd64",
+      "--tag", "us-docker.pkg.dev/elide-fw/tools/elide",
+      "."
+    ]
+options:
+  logging: CLOUD_LOGGING_ONLY
+projectId: elide-fw

--- a/tools/images/elide/entrypoint.sh
+++ b/tools/images/elide/entrypoint.sh
@@ -1,0 +1,16 @@
+
+#
+# Copyright (c) 2023 Elide Ventures, LLC.
+#
+# Licensed under the MIT license (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   https://opensource.org/license/mit/
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under the License.
+#
+
+# shellcheck disable=SC2086
+exec /bin/elide "$@"


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds two new containers produced by the Elide project:
- `ghcr.io/elide-dev/bash`: Bash terminal with Elide pre-installed.
- `ghcr.io/elide-dev/elide`: Direct use of Elide as a container entrypoint.

Use examples:
```
docker run --platform linux/amd64 --rm -it ghcr.io/elide-dev/bash
> elide --version
1.0.0-alpha7
```
```
docker run --platform linux/amd64 --rm -it ghcr.io/elide-dev/elide --version
1.0.0-alpha7
```