### PR TITLE
chore: add homebrew install to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ You can also use Elide in a container, or in a GitHub Codespace.
 docker run --platform linux/amd64 --rm -it ghcr.io/elide-dev/elide --help
 ```
 
+### Using Elide via Homebrew
+
+```
+brew tap elide-dev/elide
+brew install elide
+```
+```
+elide --help
+```
+
 ### Using Elide via GitHub Codespaces
 
 We provide a [GitHub Codespace](https://github.com/features/codespaces) with Elide pre-installed. You can click below to try it out, right from your browser:


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adding support for installation of binary Elide through Homebrew. New directions added to README are tested on macOS:
```
brew tap elide-dev/elide
brew install elide
```

## Changelog

- chore: add homebrew install to readme