### PR TITLE
fix(cli): avoid crashing when no user config directory is present.

### DIFF
--- a/packages/cli/src/main/kotlin/elide/tool/io/RuntimeWorkdirManager.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/io/RuntimeWorkdirManager.kt
@@ -283,12 +283,10 @@ internal class RuntimeWorkdirManager : WorkdirManager {
       defaultPath,
     )
 
-    (userConfigPaths.first {
+    (userConfigPaths.firstOrNull {
       // the first one that exists, wins, and if nothing exists, the default path is used
       it.toAbsolutePath().exists()
-    } ?: defaultPath).let {
-      it.toFile()
-    }
+    } ?: defaultPath).toFile()
   }
 
   // Root directory for the current project, as applicable.


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

This PR solves the crash that happens when no `~/.elide` directory is present.

Fixes #469