### PR TITLE
chore: add buildless github action to ci

### DIFF
--- a/.github/workflows/build.ci.yml
+++ b/.github/workflows/build.ci.yml
@@ -37,6 +37,8 @@ jobs:
           egress-policy: audit
       - name: "Setup: Checkout"
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: "Setup: Buildless"
+        uses: buildless/setup@e51979b463df4f1b4483420d9a97f78d8f46dd36 # v1
       - name: "Setup: GraalVM (Java 20)"
         uses: elide-dev/setup-graalvm@0711c08964f86c1721bebb824b2ac856457e0f55 # custom
         with:


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds the new [Buildless Github Action][0] to Elide's CI.

[0]: https://github.com/buildless/setup