### PR TITLE
fix(cli): correctly add nanorc resources to native image

### DIFF
--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
@@ -1017,7 +1017,12 @@ import elide.tool.project.ProjectManager
           logging.debug("Syntax file '$it' already exists. Skipping...")
           return@forEach
         }
-        val fileStream = ToolShellCommand::class.java.getResourceAsStream("/nanorc/$it") ?: return@forEach
+        val fileStream = ToolShellCommand::class.java.getResourceAsStream("/nanorc/$it")
+        if (fileStream == null) {
+          logging.warn("Failed to locate nanorc config file from resources: $it")
+          return@forEach
+        }
+
         val contents = IOUtils.readText(fileStream.bufferedReader(StandardCharsets.UTF_8))
 
         try {

--- a/packages/cli/src/main/resources/META-INF/native-image/resource-config.json
+++ b/packages/cli/src/main/resources/META-INF/native-image/resource-config.json
@@ -3956,6 +3956,30 @@
     "pattern":"org/jline/utils/.*caps$"
   }, {
     "pattern":"org/jline/utils/capabilities\\.txt$"
+  }, {
+    "pattern":"\\Qnanorc/args.nanorc\\E"
+  }, {
+    "pattern":"\\Qnanorc/command.nanorc\\E"
+  }, {
+    "pattern":"\\Qnanorc/dark.nanorctheme\\E"
+  }, {
+    "pattern":"\\Qnanorc/java.nanorc\\E"
+  }, {
+    "pattern":"\\Qnanorc/javascript.nanorc\\E"
+  }, {
+    "pattern":"\\Qnanorc/json.nanorc\\E"
+  }, {
+    "pattern":"\\Qnanorc/kotlin.nanorc\\E"
+  }, {
+    "pattern":"\\Qnanorc/light.nanorctheme\\E"
+  }, {
+    "pattern":"\\Qnanorc/nanorctheme.template\\E"
+  }, {
+    "pattern":"\\Qnanorc/python.nanorc\\E"
+  }, {
+    "pattern":"\\Qnanorc/ruby.nanorc\\E"
+  }, {
+    "pattern":"\\Qnanorc/ts.nanorc\\E"
   }]},
   "bundles":[{
     "name":"ElideTool",


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

This PR fixes a bug in native distributions of Elide, where the `nanorc` configuration directory would not be unpacked correctly due to missing resource configuration entries in the GraalVM native image metadata, breaking syntax highlighting on most machines (specifically, those devices where `$ELIDE_HOME/nanorc` was empty or didn't exist).

### Hindsight

The issue was not obvious because the code that handled unpacking the default `nanorc` files skipped entries that were not present in the resources, without raising any errors or logging messages.

A new warning log has been added to prevent this in the future.

## Changelog

- fix(cli): add `nanorc` resources to `resources-config.json`.
- feat(cli): log a warning if a required `nanorc` configuration file is not found in the bundled resources.