### PR TITLE
fix: typescript support

### DIFF
--- a/packages/graalvm-ts/api/graalvm-ts.api
+++ b/packages/graalvm-ts/api/graalvm-ts.api
@@ -5,6 +5,7 @@ public class elide/runtime/lang/typescript/TypeScriptLanguage : com/oracle/truff
 	public static final field MODULE_MIME_TYPE Ljava/lang/String;
 	public static final field NAME Ljava/lang/String;
 	public static final field TEXT_MIME_TYPE Ljava/lang/String;
+	public static final field TYPESCRIPT_VERSION Ljava/lang/String;
 	public fun <init> ()V
 	protected fun createContext (Lcom/oracle/truffle/api/TruffleLanguage$Env;)Lcom/oracle/truffle/js/runtime/JSRealm;
 	protected synthetic fun createContext (Lcom/oracle/truffle/api/TruffleLanguage$Env;)Ljava/lang/Object;

--- a/packages/graalvm-ts/src/main/kotlin/elide/runtime/plugins/typescript/TypeScript.kt
+++ b/packages/graalvm-ts/src/main/kotlin/elide/runtime/plugins/typescript/TypeScript.kt
@@ -27,7 +27,7 @@ import elide.runtime.plugins.AbstractLanguagePlugin.LanguagePluginManifest
 ) {
   @Suppress("unused", "unused_parameter")
   private fun configureContext(builder: PolyglotContextBuilder) {
-    // nothing yet
+    // nothing at this time
   }
 
   public companion object Plugin : AbstractLanguagePlugin<TypeScriptConfig, TypeScript>() {

--- a/packages/graalvm-ts/src/test/kotlin/elide/runtime/lang/typescript/TypeScriptLanguageTest.kt
+++ b/packages/graalvm-ts/src/test/kotlin/elide/runtime/lang/typescript/TypeScriptLanguageTest.kt
@@ -1,19 +1,24 @@
 package elide.runtime.lang.typescript
 
 import org.graalvm.polyglot.Context
+import org.graalvm.polyglot.Engine
 import org.graalvm.polyglot.PolyglotAccess
 import org.graalvm.polyglot.Source
+import org.graalvm.polyglot.io.IOAccess
 import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.*
 
 /** Basic tests for [TypeScriptLanguage]. */
 class TypeScriptLanguageTest {
-  private fun ctx(): Context = Context.newBuilder()
+  private val engine: Engine = Engine.newBuilder("js", "ts").build()
+  private fun ctx(): Context = Context.newBuilder("js", "ts")
     .allowInnerContextOptions(true)
     .allowPolyglotAccess(PolyglotAccess.ALL)
+    .allowIO(IOAccess.ALL)
     .allowExperimentalOptions(true)
     .allowValueSharing(true)
     .allowAllAccess(true)
+    .engine(engine)
     .build()
 
   private fun language() = TypeScriptLanguage()
@@ -39,6 +44,7 @@ class TypeScriptLanguageTest {
 
     val ctx = ctx()
     ctx.initialize("js")
+    ctx.initialize("ts")
     ctx.enter()
     val parsed = ctx.parse(jsSrc)
     ctx.leave()
@@ -61,7 +67,6 @@ class TypeScriptLanguageTest {
       assertNotNull(it)
     }
 
-    ctx.initialize("ts")
     ctx.enter()
     ctx.parse(src)
     ctx.leave()

--- a/packages/graalvm/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMEngine.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMEngine.kt
@@ -92,7 +92,7 @@ import org.graalvm.polyglot.HostAccess as PolyglotHostAccess
       .allowPolyglotAccess(PolyglotAccess.ALL)
       .allowValueSharing(true)
       .allowHostAccess(contextHostAccess)
-      .allowInnerContextOptions(false)
+      .allowInnerContextOptions(true)
       .allowCreateThread(true)
       .allowCreateProcess(true)  // @TODO(sgammon): needs policy enforcement
       .allowHostClassLoading(true)

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/sqlite/SqliteModule.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/sqlite/SqliteModule.kt
@@ -94,13 +94,7 @@ internal class SqliteModule : SQLiteAPI {
     private const val SQLITE3_LIBRARY: String = "sqlite"
 
     init {
-      // on SVM, we should load the library directly using our own tools; this is because sqlite3 may be built into the
-      // binary statically, and loaded via our own facilities at build-time.
-      if (ImageInfo.inImageCode()) NativeLibraries.resolve(SQLITE3_LIBRARY) {
-        org.sqlite.SQLiteJDBCLoader.initialize()
-      } else {
-        // otherwise, on JVM, we should load the library through regular SQLite3 JDBC mechanisms; this will unpack the
-        // library to a temporary location, load it, and then clean up after itself.
+      NativeLibraries.resolve(SQLITE3_LIBRARY) {
         org.sqlite.SQLiteJDBCLoader.initialize()
       }
     }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/plugins/js/JavaScript.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/plugins/js/JavaScript.kt
@@ -51,6 +51,7 @@ import elide.runtime.plugins.js.JavaScriptVersion.*
   private fun configureContext(builder: PolyglotContextBuilder): Unit = with(builder) {
     enableOptions(
       "js.allow-eval",
+      "js.annex-b",
       "js.async-context",
       "js.async-iterator-helpers",
       "js.async-stack-traces",
@@ -79,7 +80,6 @@ import elide.runtime.plugins.js.JavaScriptVersion.*
     )
 
     disableOptions(
-      "js.annex-b",
       "js.console",
       "js.graal-builtin",
       "js.interop-complete-promises",
@@ -96,7 +96,7 @@ import elide.runtime.plugins.js.JavaScriptVersion.*
 
     setOptions(
       "js.charset" to config.charset.name(),
-      "js.commonjs-require-cwd" to config.npmConfig.modulesPath,
+      "js.commonjs-require-cwd" to (config.npmConfig.modulesPath?.ifBlank { null } ?: "."),
       "js.debug-property-name" to DEBUG_GLOBAL,
       "js.ecmascript-version" to config.language.symbol(),
       "js.function-constructor-cache-size" to FUNCTION_CONSTRUCTOR_CACHE_SIZE,

--- a/packages/graalvm/src/main/kotlin/elide/runtime/plugins/js/JavaScriptConfig.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/plugins/js/JavaScriptConfig.kt
@@ -35,7 +35,7 @@ import elide.runtime.plugins.js.JavaScriptVersion.ES2022
      * `/my_modules` *and* `/my_modules/node_modules`, as well as other pre-defined locations, according to
      * [the Node.js specification](https://nodejs.org/api/modules.html#modules_all_together).
      */
-    public var modulesPath: String = "."
+    public var modulesPath: String? = null
   }
 
   public inner class BuiltInModulesConfig {

--- a/tools/scripts/hello.ts
+++ b/tools/scripts/hello.ts
@@ -1,0 +1,2 @@
+const x: number = 42;
+console.log(`Hello from TypeScript! The answer is ${x}`);


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Fixes TypeScript support from the entrypoint; fixes the TypeScript module patcher which allows for TypeScript-native imports.

- Fixes #910 
- Relates to #824 

## Changelog

- fix: typescript compiler and js realm/context use
- fix: invocation of typescript from entrypoint
- fix: module loader requires access to disk