### PR TITLE
fix: dangling `wrappers` project (unused)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -253,7 +253,6 @@ include(
   ":packages:transport:transport-uring",
   ":tools:umbrella",
   ":tools:reports",
-  ":tools:wrappers",
 )
 
 val buildDeprecated: String by settings


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

There is no longer a `wrappers` project, which is confusing Sonar.