### PR TITLE
fix(runtime): jna on non-macOS operating systems

### DIFF
--- a/packages/runtime/src/config/resource-config-darwin-aarch64.json
+++ b/packages/runtime/src/config/resource-config-darwin-aarch64.json
@@ -10,7 +10,8 @@
       {"pattern":"\\Q(netty_tcnative_osx_aarch_64, META-INF/native/libnetty_tcnative_osx_aarch_64.jnilib)\\E"},
       {"pattern":"\\Q(netty_tcnative_osx_aarch_64, META-INF/nativelibnetty_tcnative_osx_aarch_64.dylib\\E"},
       {"pattern":"\\Q(netty_transport_native_kqueue_aarch_64, META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib)\\E"},
-      {"pattern":"\\Q(netty_transport_native_kqueue_aarch_64, META-INF/nativelibnetty_transport_native_kqueue_aarch_64.dylib\\E"}
+      {"pattern":"\\Q(netty_transport_native_kqueue_aarch_64, META-INF/nativelibnetty_transport_native_kqueue_aarch_64.dylib\\E"},
+      {"pattern":"\\Qcom/sun/jna/darwin-aarch64/libjnidispatch.jnilib\\E"}
     ],
     "excludes": [
       {"pattern":"linux"},

--- a/packages/runtime/src/config/resource-config-darwin-amd64.json
+++ b/packages/runtime/src/config/resource-config-darwin-amd64.json
@@ -2,7 +2,8 @@
   "resources":{
     "includes": [
       {"pattern":"\\QMETA-INF/services/jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory\\E"},
-      {"pattern":"\\QMETA-INF/services/jdk.vm.ci.services.JVMCIServiceLocator\\E"}
+      {"pattern":"\\QMETA-INF/services/jdk.vm.ci.services.JVMCIServiceLocator\\E"},
+      {"pattern":"\\Qcom/sun/jna/darwin-x86-64/libjnidispatch.jnilib\\E"}
     ],
     "excludes": [
       {"pattern":"linux"},

--- a/packages/runtime/src/config/resource-config-linux-aarch64.json
+++ b/packages/runtime/src/config/resource-config-linux-aarch64.json
@@ -2,7 +2,8 @@
   "resources":{
     "includes": [
       {"pattern":"\\QMETA-INF/services/jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory\\E"},
-      {"pattern":"\\QMETA-INF/services/jdk.vm.ci.services.JVMCIServiceLocator\\E"}
+      {"pattern":"\\QMETA-INF/services/jdk.vm.ci.services.JVMCIServiceLocator\\E"},
+      {"pattern":"\\Qcom/sun/jna/linux-aarch64/libjnidispatch.so\\E"}
     ],
     "excludes": [
       {"pattern":"macos"},

--- a/packages/runtime/src/config/resource-config-linux-amd64.json
+++ b/packages/runtime/src/config/resource-config-linux-amd64.json
@@ -2,7 +2,8 @@
   "resources":{
     "includes": [
       {"pattern":"\\QMETA-INF/services/jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory\\E"},
-      {"pattern":"\\QMETA-INF/services/jdk.vm.ci.services.JVMCIServiceLocator\\E"}
+      {"pattern":"\\QMETA-INF/services/jdk.vm.ci.services.JVMCIServiceLocator\\E"},
+      {"pattern":"\\Qcom/sun/jna/linux-x86-64/libjnidispatch.so\\E"}
     ],
     "excludes": [
       {"pattern":"macos"},

--- a/packages/runtime/src/config/resource-config-windows-aarch64.json
+++ b/packages/runtime/src/config/resource-config-windows-aarch64.json
@@ -2,7 +2,8 @@
   "resources":{
     "includes": [
       {"pattern":"\\QMETA-INF/services/jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory\\E"},
-      {"pattern":"\\QMETA-INF/services/jdk.vm.ci.services.JVMCIServiceLocator\\E"}
+      {"pattern":"\\QMETA-INF/services/jdk.vm.ci.services.JVMCIServiceLocator\\E"},
+      {"pattern":"\\Qcom/sun/jna/windows-aarch64/libjnidispatch.dll\\E"}
     ],
     "excludes": [
       {"pattern":"*linux*"},

--- a/packages/runtime/src/config/resource-config-windows-amd64.json
+++ b/packages/runtime/src/config/resource-config-windows-amd64.json
@@ -2,7 +2,8 @@
   "resources":{
     "includes": [
       {"pattern":"\\QMETA-INF/services/jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory\\E"},
-      {"pattern":"\\QMETA-INF/services/jdk.vm.ci.services.JVMCIServiceLocator\\E"}
+      {"pattern":"\\QMETA-INF/services/jdk.vm.ci.services.JVMCIServiceLocator\\E"},
+      {"pattern":"\\Qcom/sun/jna/windows-x86-64/libjnidispatch.dll\\E"}
     ],
     "excludes": [
       {"pattern":"*linux*"},

--- a/packages/runtime/src/main/resources/META-INF/native-image/resource-config.json
+++ b/packages/runtime/src/main/resources/META-INF/native-image/resource-config.json
@@ -553,8 +553,6 @@
   }, {
     "pattern":"\\Qcom/oracle/graal/python/builtins/objects/module/Frozen__PHELLO___SPAM.bin\\E"
   }, {
-    "pattern":"\\Qcom/sun/jna/darwin-aarch64/libjnidispatch.jnilib\\E"
-  }, {
     "pattern":"\\Qgraalpy_versions\\E"
   }, {
     "pattern":"\\Qlogback-test.scmo\\E"
@@ -816,35 +814,17 @@
     "pattern":"jdk.jfr:\\Qjdk/jfr/internal/types/metadata.bin\\E"
   }],
   "excludes":[{
-    "pattern":".*\\.dll"
-  }, {
     "pattern":".*\\.proto"
-  }, {
-    "pattern":".*x86-64.*"
-  }, {
-    "pattern":".*x86.*"
-  }, {
-    "pattern":".*x86_64.*"
   }, {
     "pattern":"FreeBSD"
   }, {
     "pattern":"OpenBSD"
-  }, {
-    "pattern":"Win32"
-  }, {
-    "pattern":"Windows"
   }, {
     "pattern":"\\Qlicenses/"
   }, {
     "pattern":"freebsd"
   }, {
     "pattern":"openbsd"
-  }, {
-    "pattern":"win32"
-  }, {
-    "pattern":"windows"
-  }, {
-    "pattern":"x86"
   }]},
   "bundles":[{
     "name":"ElideTool",


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Fixes missing resource mappings on non-macOS operating systems.

Fixes and closes elide-dev/elide#984