### PR TITLE
fix: jna os info on linux/macos

### DIFF
--- a/packages/graalvm/src/main/kotlin/elide/runtime/feature/engine/AbstractStaticNativeLibraryFeature.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/feature/engine/AbstractStaticNativeLibraryFeature.kt
@@ -171,7 +171,9 @@ public abstract class AbstractStaticNativeLibraryFeature : NativeLibraryFeature 
       if (it.registerJni) (access as BeforeAnalysisAccessImpl).nativeLibraries.let { nativeLibraries ->
         when (it.type) {
           STATIC -> nativeLibraries.addStaticJniLibrary(it.name)
-          SHARED -> error("Dynamic native libraries not supported yet: $it")
+          SHARED -> if (it.registerJni) { /* Dynamic JNI libraries use JNI to load. */ } else {
+            nativeLibraries.addDynamicNonJniLibrary(it.name)
+          }
         }
       }
       if (it.eager) {

--- a/packages/runtime/build.gradle.kts
+++ b/packages/runtime/build.gradle.kts
@@ -649,7 +649,7 @@ val commonNativeArgs = listOfNotNull(
   "--install-exit-handlers",
   "--enable-url-protocols=jar",
   "--macro:truffle-svm",
-  "--enable-native-access=ALL-UNNAMED",
+  "--enable-native-access=com.sun.jna,ALL-UNNAMED",
   "-J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED",
   "-J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.hosted=ALL-UNNAMED",
   "-J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.hosted.c=ALL-UNNAMED",
@@ -668,6 +668,10 @@ val commonNativeArgs = listOfNotNull(
   "-J-Delide.staticJni=$enableStaticJni",
   "-Delide.natives=$nativesPath",
   "-J-Delide.natives=$nativesPath",
+  "-Djna.library.path=$nativesPath",
+  "-J-Djna.library.path=$nativesPath",
+  "-Djna.boot.library.path=$nativesPath",
+  "-J-Djna.boot.library.path=$nativesPath",
   "-Dorg.sqlite.lib.path=$nativesPath",
   "-J-Dorg.sqlite.lib.path=$nativesPath",
   "-Dorg.sqlite.lib.exportPath=$nativesPath",
@@ -799,6 +803,8 @@ val releaseFlags: List<String> = listOf(
 
 val jvmDefs = mapOf(
   "elide.natives" to nativesPath,
+  "jna.library.path" to nativesPath,
+  "jna.boot.library.path" to nativesPath,
   "elide.nativeTransport.v2" to enableNativeTransportV2.toString(),
   "io.netty.allocator.type" to "unpooled",
   "io.netty.native.deleteLibAfterLoading" to "false",
@@ -857,6 +863,7 @@ val initializeAtRuntime: List<String> = listOfNotNull(
 
   // --- JNA -----
 
+  "com.sun.jna.Native",
   "com.sun.jna.Structure${'$'}FFIType",
   "com.sun.jna.platform.mac.IOKit",
   "com.sun.jna.platform.mac.IOKitUtil",

--- a/packages/runtime/build.gradle.kts
+++ b/packages/runtime/build.gradle.kts
@@ -133,7 +133,7 @@ val enablePgo = false
 val enablePgoSampling = false
 val enablePgoInstrumentation = false
 val enablePgoReport = true
-val enableJna = false
+val enableJna = true
 val enableSbom = oracleGvm
 val enableSbomStrict = false
 val glibcTarget = "glibc"
@@ -861,6 +861,7 @@ val initializeAtRuntime: List<String> = listOfNotNull(
   "com.sun.jna.platform.mac.IOKit",
   "com.sun.jna.platform.mac.IOKitUtil",
   "com.sun.jna.platform.mac.SystemB",
+  "com.sun.jna.platform.linux.Udev",
 
   // --- JLine -----
 
@@ -886,6 +887,8 @@ val initializeAtRuntime: List<String> = listOfNotNull(
   "oshi.jna.platform.mac.IOKit",
   "oshi.jna.platform.mac.SystemB",
   "oshi.jna.platform.mac.SystemConfiguration",
+  "oshi.jna.platform.linux.LinuxLibc",
+  "com.sun.jna.platform.linux.LibC",
   "oshi.software.os",
   "oshi.software.os.linux",
   "oshi.software.os.linux.LinuxOperatingSystem",

--- a/packages/runtime/detekt-baseline.xml
+++ b/packages/runtime/detekt-baseline.xml
@@ -10,7 +10,7 @@
     <ID>CyclomaticComplexMethod:ToolShellCommand.kt$ToolShellCommand$override fun PolyglotEngineConfiguration.configureEngine()</ID>
     <ID>CyclomaticComplexMethod:ToolShellCommand.kt$ToolShellCommand$override suspend fun CommandContext.invoke(state: ToolContext&lt;ToolState>): CommandResult</ID>
     <ID>CyclomaticComplexMethod:ToolShellCommand.kt$ToolShellCommand$private fun beginInteractiveSession( languages: EnumSet&lt;GuestLanguage>, primaryLanguage: GuestLanguage, engine: PolyglotEngine, ctx: PolyglotContext, )</ID>
-    <ID>CyclomaticComplexMethod:ToolShellCommand.kt$ToolShellCommand$private fun displayFormattedError( exc: Throwable, message: String, advice: String? = null, internal: Boolean = false, stacktrace: Boolean = internal, )</ID>
+    <ID>CyclomaticComplexMethod:ToolShellCommand.kt$ToolShellCommand$private fun displayFormattedError( exc: Throwable, message: String, advice: String? = null, internal: Boolean = false, stacktrace: Boolean = internal, withCause: Boolean = true, )</ID>
     <ID>FunctionParameterNaming:Statics.kt$Statics$`in`: InputStream</ID>
     <ID>LargeClass:ToolShellCommand.kt$ToolShellCommand : AbstractSubcommand</ID>
     <ID>LoopWithTooManyJumpStatements:ToolShellCommand.kt$ToolShellCommand$while</ID>
@@ -29,12 +29,9 @@
     <ID>NestedBlockDepth:SelfTestCommand.kt$SelfTestCommand$override suspend fun CommandContext.invoke(state: ToolContext&lt;ToolState>): CommandResult</ID>
     <ID>ObjectPropertyNaming:Statics.kt$Statics$val `in`: InputStream get() = delegatedInStream.get() ?: System.`in`</ID>
     <ID>ReturnCount:ExecutionController.kt$ExecutionController$private fun toHost(polyglotException: PolyglotException): Throwable</ID>
-    <ID>ReturnCount:NativeSQLiteFeature.kt$NativeSQLiteFeature$override fun unpackNatives(access: BeforeAnalysisAccess): List&lt;UnpackedNative></ID>
     <ID>ReturnCount:NativeUtil.kt$NativeUtil$@JvmStatic internal fun loadOrCopy( workdir: File, path: String, libName: String, loader: ClassLoader, forceCopy: Boolean = false, forceLoad: Boolean = false, loadFromPath: Boolean = true, ): Pair&lt;Boolean, Boolean></ID>
     <ID>ReturnCount:RuntimeWorkdirManager.kt$RuntimeWorkdirManager$private fun nearestDirectoryWithAnyOfTheseFiles( files: SortedSet&lt;String>, base: File? = null, depth: Int? = null, ): File?</ID>
     <ID>SpreadOperator:Elide.kt$Elide.Companion$(*args)</ID>
-    <ID>SpreadOperator:NativeSQLiteFeature.kt$NativeSQLiteFeature$(*fields( NativeDB::class.java, "pointer", "busyHandler", "commitListener", "updateListener", "progressHandler", ))</ID>
-    <ID>SpreadOperator:NativeSQLiteFeature.kt$NativeSQLiteFeature$(*this.fields(Function::class.java, "context", "value", "args"))</ID>
     <ID>SwallowedException:DefaultProjectManager.kt$DefaultProjectManager.Companion$ioe: IOException</ID>
     <ID>SwallowedException:DefaultProjectManager.kt$DefaultProjectManager.Companion$thr: Throwable</ID>
     <ID>SwallowedException:Elide.kt$Elide.Companion$uoe: UnsupportedOperationException</ID>

--- a/packages/runtime/src/main/resources/META-INF/native-image/jni-config.json
+++ b/packages/runtime/src/main/resources/META-INF/native-image/jni-config.json
@@ -406,6 +406,10 @@
   "methods":[{"name":"toString","parameterTypes":[] }]
 },
 {
+  "name":"java.lang.UnsatisfiedLinkError",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String"] }]
+},
+{
   "name":"java.lang.Void",
   "allDeclaredMethods":true,
   "allPublicMethods":true,

--- a/packages/runtime/src/main/resources/META-INF/native-image/jni-config.json
+++ b/packages/runtime/src/main/resources/META-INF/native-image/jni-config.json
@@ -71,7 +71,17 @@
   "allPublicMethods":true,
   "allDeclaredConstructors":true,
   "allPublicConstructors":true,
-  "methods":[{"name":"dispose","parameterTypes":[] }, {"name":"fromNative","parameterTypes":["com.sun.jna.FromNativeConverter","java.lang.Object","java.lang.reflect.Method"] }, {"name":"fromNative","parameterTypes":["java.lang.Class","java.lang.Object"] }, {"name":"fromNative","parameterTypes":["java.lang.reflect.Method","java.lang.Object"] }, {"name":"nativeType","parameterTypes":["java.lang.Class"] }, {"name":"toNative","parameterTypes":["com.sun.jna.ToNativeConverter","java.lang.Object"] }]
+  "methods":[
+    {"name":"dispose","parameterTypes":[] },
+    {"name":"fromNative","parameterTypes":["com.sun.jna.FromNativeConverter","java.lang.Object","java.lang.reflect.Method"] },
+    {"name":"fromNative","parameterTypes":["java.lang.Class","java.lang.Object"] },
+    {"name":"fromNative","parameterTypes":["java.lang.reflect.Method","java.lang.Object"] },
+    {"name":"nativeType","parameterTypes":["java.lang.Class"] },
+    {"name":"toNative","parameterTypes":["com.sun.jna.ToNativeConverter","java.lang.Object"]},
+    {"name":"open","parameterTypes":["java.lang.String","java.lang.Integer"]},
+    {"name":"close","parameterTypes":["java.lang.Long"]},
+    {"name":"findSymbol","parameterTypes":["java.lang.Long","java.lang.String"]}
+  ]
 },
 {
   "name":"com.sun.jna.Native$ffi_callback",
@@ -154,6 +164,13 @@
 },
 {
   "name":"com.sun.jna.ptr.PointerByReference",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"com.sun.jna.platform.mac.CoreFoundation$CFStringRef",
   "allDeclaredMethods":true,
   "allPublicMethods":true,
   "allDeclaredConstructors":true,

--- a/packages/runtime/src/main/resources/META-INF/native-image/proxy-config.json
+++ b/packages/runtime/src/main/resources/META-INF/native-image/proxy-config.json
@@ -3,9 +3,18 @@
     "interfaces":["com.github.ajalt.mordant.internal.jna.MacosLibC"]
   },
   {
+    "interfaces":["com.github.ajalt.mordant.internal.jna.PosixLibC"]
+  },
+  {
     "interfaces":["com.sun.jna.Callback"]
   },
   {
     "interfaces":["com.sun.jna.Library"]
+  },
+  {
+    "interfaces":["com.sun.jna.platform.linux.Udev"]
+  },
+  {
+    "interfaces":["oshi.jna.platform.linux.LinuxLibc"]
   }
 ]

--- a/packages/runtime/src/main/resources/META-INF/native-image/proxy-config.json
+++ b/packages/runtime/src/main/resources/META-INF/native-image/proxy-config.json
@@ -16,5 +16,17 @@
   },
   {
     "interfaces":["oshi.jna.platform.linux.LinuxLibc"]
+  },
+  {
+    "interfaces":["com.sun.jna.platform.mac.SystemB"]
+  },
+  {
+    "interfaces":["oshi.jna.platform.mac.SystemB"]
+  },
+  {
+    "interfaces":["com.sun.jna.platform.mac.IOKit"]
+  },
+  {
+    "interfaces":["com.sun.jna.platform.mac.CoreFoundation"]
   }
 ]

--- a/packages/runtime/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/packages/runtime/src/main/resources/META-INF/native-image/reflect-config.json
@@ -7420,5 +7420,117 @@
 {
   "name":"sun.security.x509.SubjectKeyIdentifierExtension",
   "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"oshi.jna.ByRef$CloseableSizeTByReference",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"oshi.jna.ByRef$CloseableIntByReference",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"oshi.jna.ByRef$CloseableLongByReference",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"oshi.jna.ByRef$CloseableNativeLongByReference",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"com.sun.jna.platform.unix.LibCAPI$size_t",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"com.sun.jna.platform.mac.CoreFoundation$CFMutableDictionaryRef",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"com.sun.jna.platform.mac.IOKit$IOIterator",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"com.sun.jna.platform.mac.IOKit$IORegistryEntry",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"com.sun.jna.platform.mac.CoreFoundation$CFStringRef",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"com.sun.jna.platform.mac.CoreFoundation$CFTypeID",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"com.sun.jna.platform.mac.CoreFoundation$CFIndex",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"com.sun.jna.platform.mac.CoreFoundation$CFAllocatorRef",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"com.sun.jna.platform.mac.CoreFoundation$CFTypeRef",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name":"com.sun.jna.platform.mac.CoreFoundation$CFDataRef",
+  "methods":[{"name":"<init>","parameterTypes":[] }],
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
 }
 ]

--- a/packages/runtime/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/packages/runtime/src/main/resources/META-INF/native-image/reflect-config.json
@@ -123,6 +123,10 @@
   "queryAllDeclaredMethods":true
 },
 {
+  "name":"com.github.ajalt.mordant.internal.jna.PosixLibC$winsize",
+  "allDeclaredFields":true
+},
+{
   "name":"com.google.common.jimfs.SystemJimfsFileSystemProvider",
   "methods":[{"name":"removeFileSystemRunnable","parameterTypes":["java.net.URI"] }]
 },
@@ -205,6 +209,22 @@
   "allPublicConstructors":true,
   "fields":[{"name":"memory", "allowWrite":true}, {"name":"typeInfo"}],
   "methods":[{"name":"newInstance","parameterTypes":["java.lang.Class"] }, {"name":"newInstance","parameterTypes":["java.lang.Class","long"] }, {"name":"newInstance","parameterTypes":["java.lang.Class","com.sun.jna.Pointer"] }]
+},
+{
+  "name":"com.sun.jna.platform.linux.Udev$UdevContext",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.jna.platform.linux.Udev$UdevDevice",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.jna.platform.linux.Udev$UdevEnumerate",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.jna.platform.linux.Udev$UdevListEntry",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "name":"com.sun.jna.ptr.IntByReference",
@@ -2106,6 +2126,10 @@
   "fields":[{"name":"TYPE"}]
 },
 {
+  "name":"java.lang.Enum",
+  "methods":[{"name":"name","parameterTypes":[] }]
+},
+{
   "name":"java.lang.Exception"
 },
 {
@@ -2427,6 +2451,14 @@
 {
   "name":"java.util.LinkedHashMap",
   "methods":[{"name":"toString","parameterTypes":[] }]
+},
+{
+  "name":"java.util.Locale",
+  "allDeclaredClasses":true,
+  "methods":[{"name":"getDefault","parameterTypes":["java.util.Locale$Category"] }, {"name":"setDefault","parameterTypes":["java.util.Locale$Category","java.util.Locale"] }]
+},
+{
+  "name":"java.util.Locale$Category"
 },
 {
   "name":"java.util.PropertyPermission",
@@ -3044,6 +3076,18 @@
 {
   "name":"org.graalvm.polyglot.management.Management",
   "fields":[{"name":"ACCESS"}]
+},
+{
+  "name":"org.graalvm.shadowed.com.ibm.icu.impl.ICUCurrencyDisplayInfoProvider",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.graalvm.shadowed.com.ibm.icu.impl.ICUCurrencyMetaInfo",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.graalvm.shadowed.com.ibm.icu.number.LocalizedNumberFormatter",
+  "fields":[{"name":"callCountInternal"}]
 },
 {
   "name":"org.graalvm.shadowed.org.jcodings.provider.JCodingsProviderImpl"

--- a/packages/runtime/src/main/resources/META-INF/native-image/resource-config.json
+++ b/packages/runtime/src/main/resources/META-INF/native-image/resource-config.json
@@ -49,6 +49,8 @@
   }, {
     "pattern":"\\QMETA-INF/elide/embedded/runtime/ts/runtime.json.gz\\E"
   }, {
+    "pattern":"\\QMETA-INF/elide/embedded/runtime/wasm/runtime.json.gz\\E"
+  }, {
     "pattern":"\\QMETA-INF/elide/embedded/tools/tsc/typescript.js.gz\\E"
   }, {
     "pattern":"\\QMETA-INF/graalvm/org.graalvm.polyglot/version\\E"
@@ -553,6 +555,8 @@
   }, {
     "pattern":"\\Qcom/oracle/graal/python/builtins/objects/module/Frozen__PHELLO___SPAM.bin\\E"
   }, {
+    "pattern":"\\Qcom/sun/jna/linux-x86-64/libjnidispatch.so\\E"
+  }, {
     "pattern":"\\Qgraalpy_versions\\E"
   }, {
     "pattern":"\\Qlogback-test.scmo\\E"
@@ -567,7 +571,35 @@
   }, {
     "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/ICUConfig.properties\\E"
   }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/curr/en.res\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/curr/en_Latn.res\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/curr/en_US.res\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/curr/pool.res\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/curr/root.res\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/curr/supplementalData.res\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/en.res\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/en_US.res\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/numberingSystems.res\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/pnames.icu\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/pool.res\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/res_index.res\\E"
+  }, {
+    "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/root.res\\E"
+  }, {
     "pattern":"\\Qorg/graalvm/shadowed/com/ibm/icu/impl/data/icudt74b/uprops.icu\\E"
+  }, {
+    "pattern":"\\Qoshi.properties\\E"
   }, {
     "pattern":"\\Qtruffleruby/core/argf.rb\\E"
   }, {

--- a/tools/scripts/cpu.js
+++ b/tools/scripts/cpu.js
@@ -1,0 +1,3 @@
+const os = require("node:os");
+const cpus = os.cpus();
+console.log("CPU info: " + JSON.stringify(cpus, null, 2));


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Builds on top of #988 with a better suite of fixes on both macOS and Linux for OS info obtain via OSHI/JNA. Fixes and closes #990.

- [x] Fixes on macOS
- [x] Fixes on Linux

## Changelog

- fix: jna/oshi reflection and proxy metadata
- fix: no stacktrace for host-side error causes in native mode
- chore: cpu test script
- chore: update `graalvm` module pin / detekt baseline