### PR TITLE
fix: cast err with python + embedded vfs

### DIFF
--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/vfs/EmbeddedGuestVFSImpl.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/vfs/EmbeddedGuestVFSImpl.kt
@@ -376,12 +376,25 @@ internal class EmbeddedGuestVFSImpl private constructor (
     }
   }
 
+  private fun fixAttributeTypes(map: MutableMap<String, Any>): MutableMap<String, Any> {
+    return map.apply {
+      if (containsKey("ino")) {
+        val ino = this["ino"]
+        if (ino is Int) {
+          this["ino"] = ino.toLong()
+        }
+      }
+    }
+  }
+
   override fun readAttributes(path: Path, attributes: String, vararg options: LinkOption): MutableMap<String, Any> {
     return embeddedForPathOrFallBack(path, {
       super.readAttributes(path, attributes, *options)
     }) { fs, info ->
       inflatePath(path, fs, info)
-      fs.provider().readAttributes(path, attributes, *options)
+      fs.provider().readAttributes(path, attributes, *options).let {
+        fixAttributeTypes(it)
+      }
     }
   }
 

--- a/packages/runtime/build.gradle.kts
+++ b/packages/runtime/build.gradle.kts
@@ -761,7 +761,7 @@ val experimentalFlags = listOf(
 // CFlags for release mode.
 val releaseCFlags: List<String> = listOf(
   "-flto",
-)
+).onlyIf(!HostManager.hostIsMac)  // lto flag breaks macos builds
 
 // PGO profiles to specify in release mode.
 val profiles: List<String> = listOf(
@@ -813,7 +813,7 @@ val jvmDefs = mapOf(
   "java.net.preferIPv4Stack" to "true",
   "logback.statusListenerClass" to "ch.qos.logback.core.status.NopStatusListener",
   "networkaddress.cache.ttl" to "10",
-  "polyglotimpl.DisableVersionChecks" to "true",
+  "polyglotimpl.DisableVersionChecks" to "false",
   "user.country" to "US",
   "user.language" to "en",
   "org.sqlite.lib.path" to nativesPath,

--- a/packages/runtime/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/packages/runtime/src/main/resources/META-INF/native-image/reflect-config.json
@@ -2439,6 +2439,118 @@
   "methods":[{"name":"toString","parameterTypes":[] }]
 },
 {
+  "name": "tools.elide.vfs.Directory",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.Directory$Builder",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.File",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.File$Builder",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.Filesystem",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.Filesystem$Builder",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.Tree",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.Tree$Builder",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.TreeEntry",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.TreeEntry$Builder",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.Bundle",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.Bundle$Builder",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.BundleHeader",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.BundleHeader$Builder",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.BundleInfo",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
+  "name": "tools.elide.vfs.BundleInfo$Builder",
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true
+},
+{
   "name":"java.util.Base64$Decoder",
   "allDeclaredMethods":true,
   "allPublicMethods":true,


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

- [x] Fix cast error in VFS during startup
- [x] Fix missing reflection metadata for VFS protobuf types
- [x] Fix `-flto` flag (breaks macOS build)

Fixes and closes elide-dev/elide#989.

## Changelog

- fix: cast error for `ino` attribute; should be `Long`
- fix: `-flto` breaks mac native build
- fix: missing vfs protobuf metadata