### PR TITLE
fix(typescript): fixup ts module loader

### DIFF
--- a/packages/graalvm-ts/src/main/java/elide/runtime/lang/typescript/JSRealmPatcher.java
+++ b/packages/graalvm-ts/src/main/java/elide/runtime/lang/typescript/JSRealmPatcher.java
@@ -12,12 +12,10 @@
  */
 package elide.runtime.lang.typescript;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.js.runtime.JSRealm;
 import java.lang.reflect.Field;
 
 class JSRealmPatcher {
-  @CompilerDirectives.TruffleBoundary
   public static void setTSModuleLoader(JSRealm jsRealm, TypeScriptModuleLoader newModuleLoader) {
     try {
       Field moduleLoaderField = JSRealm.class.getDeclaredField("moduleLoader");


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Fixes and closes elide-dev/elide#824, relating to the TypeScript module loader.

## Changelog

- fix: truffle boundary for native ts module loader
- chore: general typescript cleanup