### PR TITLE
fix(sqlite): static initialization

### DIFF
--- a/packages/graalvm/detekt-baseline.xml
+++ b/packages/graalvm/detekt-baseline.xml
@@ -77,7 +77,7 @@
     <ID>SpreadOperator:NativeCryptoFeature.kt$NativeCryptoFeature$( "netty_tcnative_linux_$archTag", *tcnative, builtin = true, )</ID>
     <ID>SpreadOperator:NativeCryptoFeature.kt$NativeCryptoFeature$( "netty_tcnative_osx_$archTag", *tcnative, builtin = true, )</ID>
     <ID>SpreadOperator:NativeSQLiteFeature.kt$NativeSQLiteFeature$(*fields( NativeDB::class.java, "pointer", "busyHandler", "commitListener", "updateListener", "progressHandler", ))</ID>
-    <ID>SpreadOperator:NativeSQLiteFeature.kt$NativeSQLiteFeature$(*this.fields(Function::class.java, "context", "value", "args"))</ID>
+    <ID>SpreadOperator:NativeSQLiteFeature.kt$NativeSQLiteFeature$(*fields(Function::class.java, "context", "value", "args"))</ID>
     <ID>SpreadOperator:NativeTransportFeature.kt$NativeTransportFeature$("epoll", "aarch64", *epollImpls)</ID>
     <ID>SpreadOperator:NativeTransportFeature.kt$NativeTransportFeature$("epoll", "x86-64", *epollImpls)</ID>
     <ID>SpreadOperator:NativeTransportFeature.kt$NativeTransportFeature$("kqueue", "aarch64", *kqueueImpls)</ID>

--- a/packages/graalvm/src/main/kotlin/elide/runtime/feature/engine/NativeSQLiteFeature.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/feature/engine/NativeSQLiteFeature.kt
@@ -115,7 +115,7 @@ import elide.runtime.feature.NativeLibraryFeature.UnpackedNative
     RuntimeJNIAccess.register(method(DB::class.java, "throwex", Integer.TYPE))
     RuntimeJNIAccess.register(method(NativeDB::class.java, "throwex", String::class.java))
     RuntimeJNIAccess.register(Function::class.java)
-    RuntimeJNIAccess.register(*this.fields(Function::class.java, "context", "value", "args"))
+    RuntimeJNIAccess.register(*fields(Function::class.java, "context", "value", "args"))
     RuntimeJNIAccess.register(method(Function::class.java, "xFunc"))
     RuntimeJNIAccess.register(Collation::class.java)
     RuntimeJNIAccess.register(method(

--- a/packages/runtime/src/main/resources/META-INF/native-image/jni-config.json
+++ b/packages/runtime/src/main/resources/META-INF/native-image/jni-config.json
@@ -421,5 +421,9 @@
 {
   "name":"sun.nio.ch.FileChannelImpl",
   "fields":[{"name":"fd"}]
+},
+{
+  "name":"com.sun.jna.Native",
+  "methods":[{"name":"dispose","parameterTypes":[] }, {"name":"fromNative","parameterTypes":["com.sun.jna.FromNativeConverter","java.lang.Object","java.lang.reflect.Method"] }, {"name":"fromNative","parameterTypes":["java.lang.Class","java.lang.Object"] }, {"name":"fromNative","parameterTypes":["java.lang.reflect.Method","java.lang.Object"] }, {"name":"nativeType","parameterTypes":["java.lang.Class"] }, {"name":"toNative","parameterTypes":["com.sun.jna.ToNativeConverter","java.lang.Object"] }]
 }
 ]

--- a/packages/sqlite/src/main/java/org/sqlite/SQLiteJDBCLoader.java
+++ b/packages/sqlite/src/main/java/org/sqlite/SQLiteJDBCLoader.java
@@ -199,9 +199,12 @@ public class SQLiteJDBCLoader {
 
             // Set executable (x) flag to enable Java to load the native library
             var file = extractedLibFile.toFile();
-            file.setReadable(true);
-            file.setWritable(true, true);
-            file.setExecutable(true);
+            var didSetReadable = file.setReadable(true);
+            assert didSetReadable;
+            var didSetWritable = file.setWritable(true, true);
+            assert didSetWritable;
+            var didSetExecutable = file.setExecutable(true);
+            assert didSetExecutable;
 
             // Check whether the contents are properly copied from the resource folder
             {


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Fixes for SQLite's static init code.

## Changelog

- fix(sqlite): guard static init so it cannot be run more than once
- fix(sqlite): universally use `JNI_VERSION_1_8`
- chore: better (manual) debug logs for sqlite native