### PR TITLE
Fix language stats for the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-/*.js -linguist-detectable
-/*.mjs -linguist-detectable
+/*.js
+/*.mjs
 *.proto linguist-language=Protocol-Buffer linguist-detectable
 *.soy linguist-language=Closure-Templates linguist-detectable
 *.ts linguist-language=TypeScript linguist-detectable
@@ -11,7 +11,7 @@
 *.lock linguist-generated binary
 pnpm-lock.yaml linguist-generated binary
 gradle/verification* linguist-generated binary
-**/package-info.java -linguist-detectable linguist-generated
+**/package-info.java linguist-detectable linguist-generated
 samples/** -linguist-detectable
 tools/plugin/**/*.* -linguist-detectable
 tools/scripts/*.* -linguist-detectable
@@ -30,3 +30,4 @@ docs/* linguist-documentation -linguist-detectable linguist-generated
 tools/plugin/gradle-plugin/plugin-build/plugin/src/model/java -linguist-detectable linguist-generated
 tools/plugin/gradle-plugin/plugin-build/plugin/src/model/kotlin -linguist-detectable linguist-generated
 tools/plugin/gradle-plugin/plugin-build/plugin/src/main/proto -linguist-detectable linguist-generated
+*.rs linguist-detectable


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related to #1073

Update `.gitattributes` to improve language stats detection for Java, JavaScript, and Rust files.

* **JavaScript Files:**
  - Remove the `-linguist-detectable` attribute from `*.js` and `*.mjs` files.
* **Java Files:**
  - Update `**/package-info.java` to be `linguist-detectable`.
* **Rust Files:**
  - Add the `linguist-detectable` attribute to `*.rs` files.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/elide-dev/elide/issues/1073?shareId=c1d2a2e1-bab9-40f3-b5e4-a64d6f911f3c).