### PR TITLE
[WIP] Implement Node `stream`

### DIFF
--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/node/stream/NodeStreamConsumers.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/node/stream/NodeStreamConsumers.kt
@@ -19,6 +19,15 @@ import elide.runtime.gvm.internals.intrinsics.js.AbstractNodeBuiltinModule
 import elide.runtime.gvm.internals.intrinsics.js.JsSymbol.JsSymbols.asJsSymbol
 import elide.runtime.intrinsics.GuestIntrinsic.MutableIntrinsicBindings
 import elide.runtime.intrinsics.js.node.StreamConsumersAPI
+import elide.runtime.intrinsics.js.node.stream.Readable
+import elide.runtime.intrinsics.js.node.stream.Writable
+import elide.runtime.intrinsics.js.node.buffer.Buffer
+import elide.runtime.intrinsics.js.JsPromise
+import org.graalvm.polyglot.Value
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 // Internal symbol where the Node built-in module is installed.
 private const val STREAM_CONSUMERS_MODULE_SYMBOL = "node_stream_consumers"
@@ -41,5 +50,122 @@ internal class NodeStreamConsumers : StreamConsumersAPI {
   internal companion object {
     private val SINGLETON = NodeStreamConsumers()
     fun obtain(): NodeStreamConsumers = SINGLETON
+  }
+
+  /**
+   * Consumes a Readable stream and returns a promise that resolves with the data as a string.
+   *
+   * @param stream The Readable stream to consume.
+   * @param encoding The encoding to use. Default is UTF-8.
+   * @return A promise that resolves with the data as a string.
+   */
+  fun text(stream: Readable, encoding: Charset = StandardCharsets.UTF_8): JsPromise<String> {
+    return JsPromise.create { resolve, reject ->
+      val builder = StringBuilder()
+      stream.setEncoding(encoding.name())
+      stream.on("data") { chunk ->
+        builder.append(chunk.asString())
+      }
+      stream.on("end") {
+        resolve(builder.toString())
+      }
+      stream.on("error") { error ->
+        reject(error)
+      }
+    }
+  }
+
+  /**
+   * Consumes a Readable stream and returns a promise that resolves with the data as a Buffer.
+   *
+   * @param stream The Readable stream to consume.
+   * @return A promise that resolves with the data as a Buffer.
+   */
+  fun buffer(stream: Readable): JsPromise<Buffer> {
+    return JsPromise.create { resolve, reject ->
+      val chunks = mutableListOf<Buffer>()
+      stream.on("data") { chunk ->
+        chunks.add(chunk.asBuffer())
+      }
+      stream.on("end") {
+        resolve(Buffer.concat(chunks.toTypedArray()))
+      }
+      stream.on("error") { error ->
+        reject(error)
+      }
+    }
+  }
+
+  /**
+   * Consumes a Readable stream and writes the data to a Writable stream.
+   *
+   * @param readable The Readable stream to consume.
+   * @param writable The Writable stream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun pipe(readable: Readable, writable: Writable): JsPromise<Unit> {
+    return JsPromise.create { resolve, reject ->
+      readable.pipe(writable)
+      writable.on("finish") {
+        resolve(Unit)
+      }
+      writable.on("error") { error ->
+        reject(error)
+      }
+    }
+  }
+
+  /**
+   * Consumes a Readable stream and writes the data to an OutputStream.
+   *
+   * @param readable The Readable stream to consume.
+   * @param outputStream The OutputStream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun writeToOutputStream(readable: Readable, outputStream: OutputStream): JsPromise<Unit> {
+    return pipe(readable, Writable.wrap(outputStream))
+  }
+
+  /**
+   * Consumes an InputStream and returns a promise that resolves with the data as a string.
+   *
+   * @param inputStream The InputStream to consume.
+   * @param encoding The encoding to use. Default is UTF-8.
+   * @return A promise that resolves with the data as a string.
+   */
+  fun text(inputStream: InputStream, encoding: Charset = StandardCharsets.UTF_8): JsPromise<String> {
+    return text(Readable.wrap(inputStream, encoding), encoding)
+  }
+
+  /**
+   * Consumes an InputStream and returns a promise that resolves with the data as a Buffer.
+   *
+   * @param inputStream The InputStream to consume.
+   * @return A promise that resolves with the data as a Buffer.
+   */
+  fun buffer(inputStream: InputStream): JsPromise<Buffer> {
+    return buffer(Readable.wrap(inputStream))
+  }
+
+  /**
+   * Consumes an InputStream and writes the data to a Writable stream.
+   *
+   * @param inputStream The InputStream to consume.
+   * @param writable The Writable stream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun pipe(inputStream: InputStream, writable: Writable): JsPromise<Unit> {
+    return pipe(Readable.wrap(inputStream), writable)
+  }
+
+  /**
+   * Consumes an InputStream and writes the data to an OutputStream.
+   *
+   * @param inputStream The InputStream to consume.
+   * @param outputStream The OutputStream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun writeToOutputStream(inputStream: InputStream, outputStream: OutputStream): JsPromise<Unit> {
+    return writeToOutputStream(Readable.wrap(inputStream), outputStream)
   }
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/node/stream/NodeStreamPromises.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/node/stream/NodeStreamPromises.kt
@@ -19,6 +19,15 @@ import elide.runtime.gvm.internals.intrinsics.js.AbstractNodeBuiltinModule
 import elide.runtime.gvm.internals.intrinsics.js.JsSymbol.JsSymbols.asJsSymbol
 import elide.runtime.intrinsics.GuestIntrinsic.MutableIntrinsicBindings
 import elide.runtime.intrinsics.js.node.StreamPromisesAPI
+import elide.runtime.intrinsics.js.node.stream.Readable
+import elide.runtime.intrinsics.js.node.stream.Writable
+import elide.runtime.intrinsics.js.node.buffer.Buffer
+import elide.runtime.intrinsics.js.JsPromise
+import org.graalvm.polyglot.Value
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 // Internal symbol where the Node built-in module is installed.
 private const val STREAM_PROMISES_MODULE_SYMBOL = "node_stream_promises"
@@ -41,5 +50,122 @@ internal class NodeStreamPromises : StreamPromisesAPI {
   internal companion object {
     private val SINGLETON = NodeStreamPromises()
     fun obtain(): NodeStreamPromises = SINGLETON
+  }
+
+  /**
+   * Consumes a Readable stream and returns a promise that resolves with the data as a string.
+   *
+   * @param stream The Readable stream to consume.
+   * @param encoding The encoding to use. Default is UTF-8.
+   * @return A promise that resolves with the data as a string.
+   */
+  fun text(stream: Readable, encoding: Charset = StandardCharsets.UTF_8): JsPromise<String> {
+    return JsPromise.create { resolve, reject ->
+      val builder = StringBuilder()
+      stream.setEncoding(encoding.name())
+      stream.on("data") { chunk ->
+        builder.append(chunk.asString())
+      }
+      stream.on("end") {
+        resolve(builder.toString())
+      }
+      stream.on("error") { error ->
+        reject(error)
+      }
+    }
+  }
+
+  /**
+   * Consumes a Readable stream and returns a promise that resolves with the data as a Buffer.
+   *
+   * @param stream The Readable stream to consume.
+   * @return A promise that resolves with the data as a Buffer.
+   */
+  fun buffer(stream: Readable): JsPromise<Buffer> {
+    return JsPromise.create { resolve, reject ->
+      val chunks = mutableListOf<Buffer>()
+      stream.on("data") { chunk ->
+        chunks.add(chunk.asBuffer())
+      }
+      stream.on("end") {
+        resolve(Buffer.concat(chunks.toTypedArray()))
+      }
+      stream.on("error") { error ->
+        reject(error)
+      }
+    }
+  }
+
+  /**
+   * Consumes a Readable stream and writes the data to a Writable stream.
+   *
+   * @param readable The Readable stream to consume.
+   * @param writable The Writable stream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun pipe(readable: Readable, writable: Writable): JsPromise<Unit> {
+    return JsPromise.create { resolve, reject ->
+      readable.pipe(writable)
+      writable.on("finish") {
+        resolve(Unit)
+      }
+      writable.on("error") { error ->
+        reject(error)
+      }
+    }
+  }
+
+  /**
+   * Consumes a Readable stream and writes the data to an OutputStream.
+   *
+   * @param readable The Readable stream to consume.
+   * @param outputStream The OutputStream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun writeToOutputStream(readable: Readable, outputStream: OutputStream): JsPromise<Unit> {
+    return pipe(readable, Writable.wrap(outputStream))
+  }
+
+  /**
+   * Consumes an InputStream and returns a promise that resolves with the data as a string.
+   *
+   * @param inputStream The InputStream to consume.
+   * @param encoding The encoding to use. Default is UTF-8.
+   * @return A promise that resolves with the data as a string.
+   */
+  fun text(inputStream: InputStream, encoding: Charset = StandardCharsets.UTF_8): JsPromise<String> {
+    return text(Readable.wrap(inputStream, encoding), encoding)
+  }
+
+  /**
+   * Consumes an InputStream and returns a promise that resolves with the data as a Buffer.
+   *
+   * @param inputStream The InputStream to consume.
+   * @return A promise that resolves with the data as a Buffer.
+   */
+  fun buffer(inputStream: InputStream): JsPromise<Buffer> {
+    return buffer(Readable.wrap(inputStream))
+  }
+
+  /**
+   * Consumes an InputStream and writes the data to a Writable stream.
+   *
+   * @param inputStream The InputStream to consume.
+   * @param writable The Writable stream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun pipe(inputStream: InputStream, writable: Writable): JsPromise<Unit> {
+    return pipe(Readable.wrap(inputStream), writable)
+  }
+
+  /**
+   * Consumes an InputStream and writes the data to an OutputStream.
+   *
+   * @param inputStream The InputStream to consume.
+   * @param outputStream The OutputStream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun writeToOutputStream(inputStream: InputStream, outputStream: OutputStream): JsPromise<Unit> {
+    return writeToOutputStream(Readable.wrap(inputStream), outputStream)
   }
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/node/stream/NodeStreamWeb.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/node/stream/NodeStreamWeb.kt
@@ -19,6 +19,15 @@ import elide.runtime.gvm.internals.intrinsics.js.AbstractNodeBuiltinModule
 import elide.runtime.gvm.internals.intrinsics.js.JsSymbol.JsSymbols.asJsSymbol
 import elide.runtime.intrinsics.GuestIntrinsic.MutableIntrinsicBindings
 import elide.runtime.intrinsics.js.node.WebStreamsAPI
+import elide.runtime.intrinsics.js.node.stream.Readable
+import elide.runtime.intrinsics.js.node.stream.Writable
+import elide.runtime.intrinsics.js.node.buffer.Buffer
+import elide.runtime.intrinsics.js.JsPromise
+import org.graalvm.polyglot.Value
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 // Internal symbol where the Node built-in module is installed.
 private const val STREAM_WEB_MODULE_SYMBOL = "node_stream_web"
@@ -41,5 +50,122 @@ internal class NodeWebStreams : WebStreamsAPI {
   internal companion object {
     private val SINGLETON = NodeWebStreams()
     fun obtain(): NodeWebStreams = SINGLETON
+  }
+
+  /**
+   * Consumes a Readable stream and returns a promise that resolves with the data as a string.
+   *
+   * @param stream The Readable stream to consume.
+   * @param encoding The encoding to use. Default is UTF-8.
+   * @return A promise that resolves with the data as a string.
+   */
+  fun text(stream: Readable, encoding: Charset = StandardCharsets.UTF_8): JsPromise<String> {
+    return JsPromise.create { resolve, reject ->
+      val builder = StringBuilder()
+      stream.setEncoding(encoding.name())
+      stream.on("data") { chunk ->
+        builder.append(chunk.asString())
+      }
+      stream.on("end") {
+        resolve(builder.toString())
+      }
+      stream.on("error") { error ->
+        reject(error)
+      }
+    }
+  }
+
+  /**
+   * Consumes a Readable stream and returns a promise that resolves with the data as a Buffer.
+   *
+   * @param stream The Readable stream to consume.
+   * @return A promise that resolves with the data as a Buffer.
+   */
+  fun buffer(stream: Readable): JsPromise<Buffer> {
+    return JsPromise.create { resolve, reject ->
+      val chunks = mutableListOf<Buffer>()
+      stream.on("data") { chunk ->
+        chunks.add(chunk.asBuffer())
+      }
+      stream.on("end") {
+        resolve(Buffer.concat(chunks.toTypedArray()))
+      }
+      stream.on("error") { error ->
+        reject(error)
+      }
+    }
+  }
+
+  /**
+   * Consumes a Readable stream and writes the data to a Writable stream.
+   *
+   * @param readable The Readable stream to consume.
+   * @param writable The Writable stream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun pipe(readable: Readable, writable: Writable): JsPromise<Unit> {
+    return JsPromise.create { resolve, reject ->
+      readable.pipe(writable)
+      writable.on("finish") {
+        resolve(Unit)
+      }
+      writable.on("error") { error ->
+        reject(error)
+      }
+    }
+  }
+
+  /**
+   * Consumes a Readable stream and writes the data to an OutputStream.
+   *
+   * @param readable The Readable stream to consume.
+   * @param outputStream The OutputStream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun writeToOutputStream(readable: Readable, outputStream: OutputStream): JsPromise<Unit> {
+    return pipe(readable, Writable.wrap(outputStream))
+  }
+
+  /**
+   * Consumes an InputStream and returns a promise that resolves with the data as a string.
+   *
+   * @param inputStream The InputStream to consume.
+   * @param encoding The encoding to use. Default is UTF-8.
+   * @return A promise that resolves with the data as a string.
+   */
+  fun text(inputStream: InputStream, encoding: Charset = StandardCharsets.UTF_8): JsPromise<String> {
+    return text(Readable.wrap(inputStream, encoding), encoding)
+  }
+
+  /**
+   * Consumes an InputStream and returns a promise that resolves with the data as a Buffer.
+   *
+   * @param inputStream The InputStream to consume.
+   * @return A promise that resolves with the data as a Buffer.
+   */
+  fun buffer(inputStream: InputStream): JsPromise<Buffer> {
+    return buffer(Readable.wrap(inputStream))
+  }
+
+  /**
+   * Consumes an InputStream and writes the data to a Writable stream.
+   *
+   * @param inputStream The InputStream to consume.
+   * @param writable The Writable stream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun pipe(inputStream: InputStream, writable: Writable): JsPromise<Unit> {
+    return pipe(Readable.wrap(inputStream), writable)
+  }
+
+  /**
+   * Consumes an InputStream and writes the data to an OutputStream.
+   *
+   * @param inputStream The InputStream to consume.
+   * @param outputStream The OutputStream to write to.
+   * @return A promise that resolves when the operation is complete.
+   */
+  fun writeToOutputStream(inputStream: InputStream, outputStream: OutputStream): JsPromise<Unit> {
+    return writeToOutputStream(Readable.wrap(inputStream), outputStream)
   }
 }


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related to #853

Implement the Node API's `stream` module in Kotlin.

* **NodeStreamConsumers.kt**:
  - Add methods to consume Readable streams and return promises that resolve with data as a string or Buffer.
  - Add methods to consume Readable streams and write data to Writable streams or OutputStreams.
  - Add methods to consume InputStreams and return promises that resolve with data as a string or Buffer.
  - Add methods to consume InputStreams and write data to Writable streams or OutputStreams.

* **NodeStreamPromises.kt**:
  - Add methods to consume Readable streams and return promises that resolve with data as a string or Buffer.
  - Add methods to consume Readable streams and write data to Writable streams or OutputStreams.
  - Add methods to consume InputStreams and return promises that resolve with data as a string or Buffer.
  - Add methods to consume InputStreams and write data to Writable streams or OutputStreams.

* **NodeStreamWeb.kt**:
  - Add methods to consume Readable streams and return promises that resolve with data as a string or Buffer.
  - Add methods to consume Readable streams and write data to Writable streams or OutputStreams.
  - Add methods to consume InputStreams and return promises that resolve with data as a string or Buffer.
  - Add methods to consume InputStreams and write data to Writable streams or OutputStreams.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/elide-dev/elide/issues/853?shareId=5d8694b0-e7af-4310-a045-83ebc18191be).