### PR TITLE
fix: expose `CustomEvent` constructor

### DIFF
--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -3370,6 +3370,7 @@ public final class elide/runtime/intrinsics/js/node/events/AddEventListenerOptio
 }
 
 public class elide/runtime/intrinsics/js/node/events/CustomEvent : elide/runtime/intrinsics/js/node/events/Event, org/graalvm/polyglot/proxy/ProxyObject {
+	public static final field Factory Lelide/runtime/intrinsics/js/node/events/CustomEvent$Factory;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Object;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -3401,6 +3402,10 @@ public class elide/runtime/intrinsics/js/node/events/CustomEvent : elide/runtime
 	public fun removeMember (Ljava/lang/String;)Z
 	public fun stopImmediatePropagation ()V
 	public fun stopPropagation ()V
+}
+
+public final class elide/runtime/intrinsics/js/node/events/CustomEvent$Factory : org/graalvm/polyglot/proxy/ProxyInstantiable {
+	public fun newInstance ([Lorg/graalvm/polyglot/Value;)Ljava/lang/Object;
 }
 
 public abstract interface class elide/runtime/intrinsics/js/node/events/Event {

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/events/CustomEvent.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/events/CustomEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Elide Technologies, Inc.
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
  *
  * Licensed under the MIT license (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
@@ -15,11 +15,13 @@ package elide.runtime.intrinsics.js.node.events
 import org.graalvm.polyglot.HostAccess.Implementable
 import org.graalvm.polyglot.Value
 import org.graalvm.polyglot.proxy.ProxyExecutable
+import org.graalvm.polyglot.proxy.ProxyInstantiable
 import org.graalvm.polyglot.proxy.ProxyObject
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import elide.annotations.API
+import elide.runtime.gvm.js.JsError
 import elide.vm.annotations.Polyglot
 
 // All properties and methods for custom events which are exposed to guest code.
@@ -200,5 +202,19 @@ private val CUSTOM_EVENT_PROPS_AND_METHODS = arrayOf(
     }
 
     else -> null
+  }
+
+  /**
+   * ## Custom Event - Factory
+   *
+   * Describes the interface for constructing [CustomEvent] instances.
+   */
+  public companion object Factory : ProxyInstantiable {
+    override fun newInstance(vararg args: Value?): Any {
+      val type = args.getOrNull(0)?.asString()
+        ?: throw JsError.typeError("CustomEvent type must be provided")
+      val detail = args.getOrNull(1)
+      return CustomEvent(type, detail)
+    }
   }
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/node/events/NodeEvents.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/node/events/NodeEvents.kt
@@ -48,6 +48,9 @@ private const val EVENTS_MODULE_SYMBOL = "node_events"
 // Public symbol where `EventTarget` is installed.
 private const val EVENT_TARGET_SYMBOL = "EventTarget"
 
+// Public symbol where `CustomEvent` is installed.
+private const val CUSTOM_EVENT_SYMBOL = "CustomEvent"
+
 // Maximum number of listeners to set as a default value.
 private const val DEFAULT_DEFAULT_MAX_LISTENERS = 10
 
@@ -60,6 +63,7 @@ private const val DEFAULT_DEFAULT_MAX_LISTENERS = 10
   override fun install(bindings: MutableIntrinsicBindings) {
     bindings[EVENTS_MODULE_SYMBOL.asJsSymbol()] = NodeEventsModuleFacade.obtain()
     bindings[EVENT_TARGET_SYMBOL.asPublicJsSymbol()] = EventTarget::class.java
+    bindings[CUSTOM_EVENT_SYMBOL.asPublicJsSymbol()] = CustomEvent.Factory
   }
 }
 

--- a/packages/graalvm/src/test/kotlin/elide/runtime/intrinsics/js/JsGlobalsTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/intrinsics/js/JsGlobalsTest.kt
@@ -131,6 +131,7 @@ private const val ENABLE_SUPPRESSIONS = true
     "Buffer",
     "atob",
     "BroadcastChannel",
+    "CustomEvent",
     "btoa",
     "clearImmediate",
     "clearInterval",
@@ -142,7 +143,6 @@ private const val ENABLE_SUPPRESSIONS = true
     "Crypto",
     "crypto",
     "CryptoKey",
-    "CustomEvent",
     "DecompressionStream",
     "Event",
     "EventSource",
@@ -225,7 +225,6 @@ private const val ENABLE_SUPPRESSIONS = true
     "DecompressionStream",  // not yet implemented
     "Crypto",  // not yet implemented
     "CryptoKey", // not yet implemented
-    "CustomEvent",  // not yet implemented
     "Event",  // not yet implemented
     "EventSource",  // not yet implemented
     "FormData",  // not yet implemented

--- a/packages/graalvm/src/test/kotlin/elide/runtime/node/NodeEventsTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/node/NodeEventsTest.kt
@@ -247,7 +247,9 @@ import elide.testing.annotations.TestCase
     val event = CustomEvent("sample")
     assertNotNull(event.timeStamp)
     assertTrue(event.timeStamp > 0)
-    Thread.sleep(1000)
+    while (System.currentTimeMillis().toDouble() == event.timeStamp) {
+      // wait for time to tick
+    }
     val event2 = CustomEvent("sample")
     assertNotNull(event2.timeStamp)
     assertTrue(event2.timeStamp > 0)
@@ -277,5 +279,32 @@ import elide.testing.annotations.TestCase
     assertTrue(event.canDispatch())
     event.stopImmediatePropagation()
     assertFalse(event.canDispatch())
+  }
+
+  @Test fun testCreateCustomEvent() = dual {
+    assertNotNull(CustomEvent("sample"))
+  }.guest {
+    // language=JavaScript
+    """
+      test(new CustomEvent("sample")).isNotNull();
+    """
+  }
+
+  @Test fun testCreateCustomEventWithDetail() = dual {
+    assertNotNull(CustomEvent("sample", mapOf("detail" to true)))
+  }.guest {
+    // language=JavaScript
+    """
+      test(new CustomEvent("sample", { detail: true })).isNotNull();
+    """
+  }
+
+  @Test fun testCreateCustomEventRequiresType() {
+    executeGuest {
+      // language=JavaScript
+      """
+      test(new CustomEvent())
+    """
+    }.fails()
   }
 }


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Fixes missing `CustomEvent` constructor; exposed by tests added in #1212.