### PR TITLE
feat: add support for `MessageChannel`

### DIFF
--- a/packages/engine/src/main/kotlin/elide/runtime/core/PluginRegistry.kt
+++ b/packages/engine/src/main/kotlin/elide/runtime/core/PluginRegistry.kt
@@ -24,7 +24,7 @@ package elide.runtime.core
    * @param configure A configuration DSL block to be applied to the plugin on installation.
    * @return A plugin instance added to the registry after installation.
    */
-  @Deprecated("Use installLazy instead", ReplaceWith("installLazy(plugin, configure)"))
+  @Deprecated("Use configure instead, which is lazy", ReplaceWith("configure(plugin, configure)"))
   public fun <C : Any, I : Any> install(plugin: EnginePlugin<C, I>, configure: C.() -> Unit = { }): I
 
   /**

--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -2254,6 +2254,20 @@ public abstract interface class elide/runtime/intrinsics/js/MapLike$Entry {
 	public abstract fun getValue ()Ljava/lang/Object;
 }
 
+public abstract interface class elide/runtime/intrinsics/js/MessageChannel : elide/runtime/interop/ReadOnlyProxyObject {
+	public abstract fun getPort1 ()Lelide/runtime/intrinsics/js/MessagePort;
+	public abstract fun getPort2 ()Lelide/runtime/intrinsics/js/MessagePort;
+}
+
+public abstract interface class elide/runtime/intrinsics/js/MessagePort : elide/runtime/intrinsics/js/node/events/EventTarget, java/lang/AutoCloseable, org/graalvm/polyglot/proxy/ProxyObject {
+	public abstract fun close ()V
+	public fun postMessage (Ljava/lang/Object;Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;)V
+	public fun postMessage (Ljava/lang/Object;Ljava/util/Collection;)V
+	public abstract fun postMessage (Ljava/lang/Object;Ljava/util/Collection;Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;)V
+	public fun postMessage ([Lorg/graalvm/polyglot/Value;)V
+	public abstract fun start ()V
+}
+
 public abstract interface class elide/runtime/intrinsics/js/MultiMapLike : elide/runtime/intrinsics/js/MapLike {
 	public abstract fun getAll (Ljava/lang/Object;)Ljava/util/List;
 }
@@ -2343,6 +2357,9 @@ public abstract interface class elide/runtime/intrinsics/js/Timers {
 	public abstract fun setTimeout (Ljava/lang/Long;[Ljava/lang/Object;Lorg/graalvm/polyglot/Value;)J
 	public static synthetic fun setTimeout$default (Lelide/runtime/intrinsics/js/Timers;Ljava/lang/Long;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)J
 	public static synthetic fun setTimeout$default (Lelide/runtime/intrinsics/js/Timers;Ljava/lang/Long;[Ljava/lang/Object;Lorg/graalvm/polyglot/Value;ILjava/lang/Object;)J
+}
+
+public abstract interface class elide/runtime/intrinsics/js/Transferable {
 }
 
 public abstract interface class elide/runtime/intrinsics/js/URL : java/io/Serializable, org/graalvm/polyglot/proxy/ProxyObject {
@@ -2679,6 +2696,31 @@ public abstract interface class elide/runtime/intrinsics/js/express/ExpressReque
 
 public abstract interface class elide/runtime/intrinsics/js/express/ExpressResponse {
 	public abstract fun send (Lorg/graalvm/polyglot/Value;)V
+}
+
+public final class elide/runtime/intrinsics/js/messaging/PostMessageOptions : java/lang/Record {
+	public static final field Companion Lelide/runtime/intrinsics/js/messaging/PostMessageOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Collection;)V
+	public synthetic fun <init> (Ljava/util/Collection;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Collection;
+	public final fun copy (Ljava/util/Collection;)Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;
+	public static synthetic fun copy$default (Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;Ljava/util/Collection;ILjava/lang/Object;)Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;
+	public static final fun empty ()Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun from (Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;
+	public fun hashCode ()I
+	public static final fun of (Ljava/util/Collection;)Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;
+	public static final fun of ([Lelide/runtime/intrinsics/js/Transferable;)Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;
+	public fun toString ()Ljava/lang/String;
+	public final fun transfer ()Ljava/util/Collection;
+}
+
+public final class elide/runtime/intrinsics/js/messaging/PostMessageOptions$Companion {
+	public final fun empty ()Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;
+	public final fun from (Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;
+	public final fun of (Ljava/util/Collection;)Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;
+	public final fun of ([Lelide/runtime/intrinsics/js/Transferable;)Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;
 }
 
 public abstract interface class elide/runtime/intrinsics/js/node/AssertAPI : elide/runtime/intrinsics/js/node/NodeAPI {
@@ -5818,6 +5860,24 @@ public abstract interface class elide/runtime/intrinsics/testing/TestingAPI$Test
 public abstract interface class elide/runtime/intrinsics/testing/TestingAPI$TestGraphNode$Test : elide/runtime/intrinsics/testing/TestingAPI$TestGraphNode {
 }
 
+public synthetic class elide/runtime/javascript/$MessageChannelBuiltin$Definition : io/micronaut/context/AbstractInitializableBeanDefinitionAndReference {
+	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
+	public fun <init> ()V
+	protected fun <init> (Ljava/lang/Class;Lio/micronaut/context/AbstractInitializableBeanDefinition$MethodOrFieldReference;)V
+	public fun instantiate (Lio/micronaut/context/BeanResolutionContext;Lio/micronaut/context/BeanContext;)Ljava/lang/Object;
+	public fun isEnabled (Lio/micronaut/context/BeanContext;)Z
+	public fun isEnabled (Lio/micronaut/context/BeanContext;Lio/micronaut/context/BeanResolutionContext;)Z
+	public fun load ()Lio/micronaut/inject/BeanDefinition;
+}
+
+public final synthetic class elide/runtime/javascript/$MessageChannelBuiltin$Introspection : io/micronaut/inject/beans/AbstractInitializableBeanIntrospectionAndReference {
+	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
+	public fun <init> ()V
+	public fun hasBuilder ()Z
+	public fun instantiate ()Ljava/lang/Object;
+	public fun isBuildable ()Z
+}
+
 public synthetic class elide/runtime/javascript/$NavigatorBuiltin$Definition : io/micronaut/context/AbstractInitializableBeanDefinitionAndReference {
 	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
 	public fun <init> ()V
@@ -5869,6 +5929,44 @@ public final synthetic class elide/runtime/javascript/$StructuredCloneBuiltin$In
 	public fun hasBuilder ()Z
 	public fun instantiate ()Ljava/lang/Object;
 	public fun isBuildable ()Z
+}
+
+public final class elide/runtime/javascript/MessageChannelBuiltin : elide/runtime/gvm/internals/intrinsics/js/AbstractJsIntrinsic, org/graalvm/polyglot/proxy/ProxyInstantiable {
+	public fun <init> ()V
+	public fun install (Lelide/runtime/intrinsics/GuestIntrinsic$MutableIntrinsicBindings;)V
+	public fun newInstance ([Lorg/graalvm/polyglot/Value;)Lelide/runtime/javascript/MessageChannelBuiltin$MessageChannelInstance;
+	public synthetic fun newInstance ([Lorg/graalvm/polyglot/Value;)Ljava/lang/Object;
+}
+
+public final class elide/runtime/javascript/MessageChannelBuiltin$MessageChannelInstance : elide/runtime/interop/ReadOnlyProxyObject, elide/runtime/intrinsics/js/MessageChannel {
+	public fun getMember (Ljava/lang/String;)Ljava/lang/Object;
+	public synthetic fun getMemberKeys ()Ljava/lang/Object;
+	public fun getMemberKeys ()[Ljava/lang/String;
+	public fun getPort1 ()Lelide/runtime/intrinsics/js/MessagePort;
+	public fun getPort2 ()Lelide/runtime/intrinsics/js/MessagePort;
+}
+
+public final class elide/runtime/javascript/MessagePortBuiltin : elide/runtime/intrinsics/js/MessagePort, elide/runtime/intrinsics/js/node/events/EventTarget, org/graalvm/polyglot/proxy/ProxyObject {
+	public fun addEventListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/AddEventListenerOptions;Lelide/runtime/intrinsics/js/node/events/EventListener;)V
+	public fun addEventListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;)V
+	public fun addEventListener (Ljava/lang/String;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;)V
+	public fun close ()V
+	public static final fun create (Ljava/lang/String;)Lelide/runtime/javascript/MessagePortBuiltin;
+	public fun dispatchEvent (Lelide/runtime/intrinsics/js/node/events/Event;)Z
+	public fun getMember (Ljava/lang/String;)Ljava/lang/Object;
+	public synthetic fun getMemberKeys ()Ljava/lang/Object;
+	public fun getMemberKeys ()[Ljava/lang/String;
+	public fun hasMember (Ljava/lang/String;)Z
+	public fun postMessage (Ljava/lang/Object;Ljava/util/Collection;Lelide/runtime/intrinsics/js/messaging/PostMessageOptions;)V
+	public fun putMember (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun removeEventListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;)V
+	public fun removeEventListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;Lelide/runtime/intrinsics/js/node/events/RemoveEventListenerOptions;)V
+	public fun removeEventListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;Lorg/graalvm/polyglot/Value;)V
+	public fun removeEventListener (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun removeEventListener (Ljava/lang/String;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;)V
+	public fun removeMember (Ljava/lang/String;)Z
+	public fun start ()V
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class elide/runtime/javascript/NavigatorBuiltin : elide/runtime/gvm/internals/intrinsics/js/AbstractJsIntrinsic, elide/runtime/interop/ReadOnlyProxyObject {
@@ -6569,6 +6667,57 @@ public final class elide/runtime/node/events/EventAware$Companion {
 	public final fun create ()Lelide/runtime/node/events/EventAware;
 	public final fun create (Ljava/lang/Iterable;)Lelide/runtime/node/events/EventAware;
 	public final fun create ([Ljava/lang/String;)Lelide/runtime/node/events/EventAware;
+}
+
+public final class elide/runtime/node/events/EventAwareProxy : elide/runtime/node/events/EventAware, org/graalvm/polyglot/proxy/ProxyObject {
+	public static final field Companion Lelide/runtime/node/events/EventAwareProxy$Companion;
+	public synthetic fun <init> (Lelide/runtime/node/events/EventAware;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun addEventListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/AddEventListenerOptions;Lelide/runtime/intrinsics/js/node/events/EventListener;)V
+	public fun addEventListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;)V
+	public fun addEventListener (Ljava/lang/String;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;)V
+	public fun addListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;)V
+	public fun addListener (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun close ()V
+	public static final fun create ()Lelide/runtime/node/events/EventAwareProxy;
+	public static final fun create (Ljava/lang/Iterable;)Lelide/runtime/node/events/EventAwareProxy;
+	public static final fun create ([Ljava/lang/String;)Lelide/runtime/node/events/EventAwareProxy;
+	public fun dispatchEvent (Lelide/runtime/intrinsics/js/node/events/Event;)Z
+	public fun emit (Ljava/lang/String;[Ljava/lang/Object;)Z
+	public fun eventNames ()Ljava/util/List;
+	public fun getMaxListeners ()I
+	public fun getMember (Ljava/lang/String;)Ljava/lang/Object;
+	public synthetic fun getMemberKeys ()Ljava/lang/Object;
+	public fun getMemberKeys ()Ljava/util/List;
+	public fun hasMember (Ljava/lang/String;)Z
+	public fun listenerCount (Ljava/lang/String;)I
+	public fun listeners (Ljava/lang/String;)Ljava/util/List;
+	public fun off (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun on (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;)Lelide/runtime/intrinsics/js/node/events/EventEmitter;
+	public fun on (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/node/events/EventEmitter;
+	public fun once (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;)V
+	public fun once (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun prependListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;)V
+	public fun prependListener (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun prependOnceListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;)V
+	public fun prependOnceListener (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun putMember (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun rawListeners (Ljava/lang/String;)Ljava/util/List;
+	public fun removeAllListeners ()V
+	public fun removeAllListeners (Ljava/lang/String;)V
+	public fun removeEventListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;)V
+	public fun removeEventListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;Lelide/runtime/intrinsics/js/node/events/RemoveEventListenerOptions;)V
+	public fun removeEventListener (Ljava/lang/String;Lelide/runtime/intrinsics/js/node/events/EventListener;Lorg/graalvm/polyglot/Value;)V
+	public fun removeEventListener (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun removeEventListener (Ljava/lang/String;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;)V
+	public fun removeListener (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun removeMember (Ljava/lang/String;)Z
+	public fun setMaxListeners (I)V
+}
+
+public final class elide/runtime/node/events/EventAwareProxy$Companion {
+	public final fun create ()Lelide/runtime/node/events/EventAwareProxy;
+	public final fun create (Ljava/lang/Iterable;)Lelide/runtime/node/events/EventAwareProxy;
+	public final fun create ([Ljava/lang/String;)Lelide/runtime/node/events/EventAwareProxy;
 }
 
 public abstract interface class elide/runtime/node/events/GuestEventListener : elide/runtime/intrinsics/js/node/events/EventListener, java/util/function/Consumer, org/graalvm/polyglot/proxy/ProxyExecutable {

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/MessageChannel.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/MessageChannel.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.intrinsics.js
+
+import elide.annotations.API
+import elide.runtime.interop.ReadOnlyProxyObject
+import elide.vm.annotations.Polyglot
+
+/**
+ * ## Message Channel
+ *
+ * Implements the `MessageChannel` global function for JavaScript, which is used to communicate between multiple
+ * browsing or execution contexts.
+ *
+ * ### Standards Compliance
+ *
+ * The `MessageChannel` class is defined as part of the WinterTC Minimum Common API.
+ *
+ * [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel)
+ */
+@API public interface MessageChannel : ReadOnlyProxyObject {
+  /**
+   * The first port created for this channel; initialized when the channel is constructed.
+   *
+   * Message ports are event-aware types. Events are delivered to the message port, and received via event handlers. See
+   * [MessagePort] for usage.
+   */
+  @get:Polyglot public val port1: MessagePort
+
+  /**
+   * The second port created for this channel; initialized when the channel is constructed.
+   *
+   * Message ports are event-aware types. Events are delivered to the message port, and received via event handlers. See
+   * [MessagePort] for usage.
+   */
+  @get:Polyglot public val port2: MessagePort
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/MessagePort.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/MessagePort.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.intrinsics.js
+
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyObject
+import java.lang.AutoCloseable
+import elide.annotations.API
+import elide.runtime.gvm.js.JsError
+import elide.runtime.intrinsics.js.messaging.PostMessageOptions
+import elide.runtime.intrinsics.js.node.events.EventTarget
+import elide.vm.annotations.Polyglot
+
+/**
+ * ## Message Port
+ *
+ * Implements the `MessagePort` global type for JavaScript, which represents one port in a two-sided channel which is
+ * used to communicate between multiple browsing or execution contexts.
+ *
+ * ### Standards Compliance
+ *
+ * The `MessagePort` class is defined as part of the WinterTC Minimum Common API.
+ *
+ * ### Usage
+ *
+ * From MDN:
+ * The MessagePort interface of the Channel Messaging API represents one of the two ports of a MessageChannel, allowing
+ * messages to be sent from one port and listening out for them arriving at the other.
+ *
+ * [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort)
+ */
+@API public interface MessagePort : ProxyObject, EventTarget, AutoCloseable {
+  /**
+   * ### Start
+   *
+   * Start services on this message port. Messages will not be delivered until `start` is called at least once; affixing
+   * a message handler implies a call to `start`.
+   *
+   * From MDN:
+   * The start() method of the MessagePort interface starts the sending of messages queued on the port. This method is
+   * only needed when using [EventTarget.addEventListener]; it is implied when using `onmessage`.
+   *
+   * [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/start)
+   */
+  @Polyglot public fun start()
+
+  /**
+   * ### Close Port
+   *
+   * From MDN:
+   * The close() method of the MessagePort interface disconnects the port, so it is no longer active. This stops the
+   * flow of messages to that port.
+   *
+   * [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/close)
+   */
+  @Polyglot override fun close()
+
+  /**
+   * ### Post Message
+   *
+   * Post a message to this port, causing any listeners to be dispatched with the message and any given parameters. This
+   * method has multiple overloads to support different types of messages and options.
+   *
+   * This particular method variant is designed for host-side dispatch with guest [Value] objects.
+   *
+   * @param values The values to post to the port.
+   *
+   * [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage)
+   */
+  public fun postMessage(vararg values: Value): Unit = when (values.size) {
+    0 -> throw JsError.typeError("`postMessage` requires at least one argument.")
+    1 -> postMessage(values.first(), null, PostMessageOptions.empty())
+    2 -> postMessage(values.first(), null, PostMessageOptions.from(values[1]))
+    else -> postMessage(
+      values.first(),
+      values[1].asHostObject<Collection<Transferable>>(),
+      PostMessageOptions.from(values[2])
+    )
+  }
+
+  /**
+   * ### Post Message
+   *
+   * Post a message to this port, causing any listeners to be dispatched with the message and any given parameters. This
+   * method has multiple overloads to support different types of messages and options.
+   *
+   * This method is designed for guest dispatch in the form:
+   * `postMessage(message, [ transfer_obj ])`
+   *
+   * @param message Message value to post.
+   * @param transfer A list of transferable objects to post with the message.
+   *
+   * [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage)
+   */
+  @Polyglot public fun postMessage(message: Any?, transfer: Collection<Transferable>?): Unit =
+    postMessage(message, transfer, PostMessageOptions.empty())
+
+  /**
+   * ### Post Message
+   *
+   * Post a message to this port, causing any listeners to be dispatched with the message and any given parameters. This
+   * method has multiple overloads to support different types of messages and options.
+   *
+   * This method is designed for guest dispatch in the form:
+   * `postMessage(message, { options })`
+   *
+   * @param message Message value to post.
+   * @param options Options to apply to this message posting.
+   *
+   * [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage)
+   */
+  @Polyglot public fun postMessage(message: Any?, options: PostMessageOptions?): Unit =
+    postMessage(message, null, options)
+
+  /**
+   * ### Post Message
+   *
+   * Post a message to this port, causing any listeners to be dispatched with the message and any given parameters. This
+   * method has multiple overloads to support different types of messages and options.
+   *
+   * This method is designed for guest dispatch in the form:
+   * `postMessage(message, [ transfer_obj ] { options })`
+   *
+   * @param message Message value to post.
+   * @param transfer A list of transferable objects to post with the message.
+   * @param options Options to apply to this message posting.
+   *
+   * [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage)
+   */
+  @Polyglot public fun postMessage(message: Any?, transfer: Collection<Transferable>?, options: PostMessageOptions?)
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/Transferable.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/Transferable.kt
@@ -10,13 +10,12 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under the License.
  */
-package elide.runtime.intrinsics.js.node.events
-
-import elide.annotations.API
+package elide.runtime.intrinsics.js
 
 /**
- * ## Event Emitter Or Target
+ * # Transferable
  *
- * Represents either an [EventEmitter] or an [EventTarget]; unifies common behavior between the two.
+ * Marker interface which describes a type that can safely be transferred between execution contexts; in practice, such
+ * contexts are typically different threads or workers.
  */
-@API public sealed interface EventEmitterOrTarget
+public interface Transferable

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/messaging/PostMessageOptions.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/messaging/PostMessageOptions.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.intrinsics.js.messaging
+
+import org.graalvm.polyglot.Value
+import elide.runtime.intrinsics.js.Transferable
+
+/**
+ * ## Post Message Options
+ *
+ * Describes options that can apply to a `postMessage` operation as part of a `MessagePort`. The only available option,
+ * [transfer], specifies objects that should be transferred to the receiving context instead of cloned.
+ *
+ * @property transfer Objects that should be transferred to the receiving context instead of cloned.
+ */
+@JvmRecord public data class PostMessageOptions(
+  public val transfer: Collection<Transferable> = emptyList(),
+) {
+  /** Factory utilities for [PostMessageOptions]. */
+  public companion object {
+    // After selecting a guest value to build transferable values from, use it to build them into a list.
+    @JvmStatic private fun buildTransferrablesFrom(value: Value): Collection<Transferable> {
+      return buildList(value.arraySize.toInt()) {
+        for (i in 0 until value.arraySize) {
+          add(value.getArrayElement(i).`as`<Transferable>(Transferable::class.java))
+        }
+      }
+    }
+
+    // Build a set of transferable objects from the provided guest value.
+    @JvmStatic private fun buildTransferrables(value: Value?): Collection<Transferable> {
+      return when {
+        // nulls -> empty list
+        value == null || value.isNull -> emptyList()
+
+        // has array members directly -> build from value
+        value.hasArrayElements() -> buildTransferrablesFrom(value)
+
+        // object with `transfer` array -> build from that
+        value.hasMembers() -> if (value.hasMember("transfer")) {
+          buildTransferrablesFrom(value.getMember("transfer"))
+        } else {
+          emptyList()
+        }
+
+        // otherwise, empty list
+        else -> emptyList()
+      }
+    }
+
+    /** @return Empty/default [PostMessageOptions]. */
+    @JvmStatic public fun empty(): PostMessageOptions = PostMessageOptions()
+
+    /** @return [PostMessageOptions] with the provided [transfer] objects. */
+    @JvmStatic public fun of(vararg transfer: Transferable): PostMessageOptions = PostMessageOptions(transfer.toList())
+
+    /** @return [PostMessageOptions] with the provided [transfer] objects. */
+    @JvmStatic public fun of(transfer: Collection<Transferable>): PostMessageOptions = PostMessageOptions(transfer)
+
+    /** @return [PostMessageOptions] from the provided [value]. */
+    @JvmStatic public fun from(value: Value?): PostMessageOptions = PostMessageOptions(
+      transfer = buildTransferrables(value),
+    )
+  }
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/javascript/MessageChannelBuiltin.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/javascript/MessageChannelBuiltin.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+@file:OptIn(DelicateElideApi::class)
+
+package elide.runtime.javascript
+
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyInstantiable
+import jakarta.inject.Singleton
+import elide.runtime.core.DelicateElideApi
+import elide.runtime.gvm.api.Intrinsic
+import elide.runtime.gvm.internals.intrinsics.js.AbstractJsIntrinsic
+import elide.runtime.gvm.js.JsSymbol.JsSymbols.asPublicJsSymbol
+import elide.runtime.interop.ReadOnlyProxyObject
+import elide.runtime.intrinsics.GuestIntrinsic
+import elide.runtime.intrinsics.js.MessageChannel
+import elide.runtime.intrinsics.js.MessagePort
+import elide.vm.annotations.Polyglot
+
+// Name of the `MessageChannel` class in the global scope.
+private const val MESSAGE_CHANNEL_NAME = "MessageChannel"
+
+// Name of the `MessagePort` class in the global scope.
+private const val MESSAGE_PORT_NAME = "MessagePort"
+
+// Constants for properties and methods of `MessageChannel` and `MessagePort`.
+private const val MESSAGE_CHANNEL_PORT1 = "port1"
+private const val MESSAGE_CHANNEL_PORT2 = "port2"
+
+private val messageChannelProps = arrayOf(
+  MESSAGE_CHANNEL_PORT1,
+  MESSAGE_CHANNEL_PORT2,
+)
+
+// Public JavaScript symbol for the `MessageChannel` class.
+private val MESSAGE_CHANNEL_SYMBOL = MESSAGE_CHANNEL_NAME.asPublicJsSymbol()
+
+// Public JavaScript symbol for the `MessagePort` class.
+private val MESSAGE_PORT_SYMBOL = MESSAGE_PORT_NAME.asPublicJsSymbol()
+
+// Pair-wise message ports for the `MessageChannel` instance.
+internal typealias MessagePortPair = Pair<MessagePortBuiltin, MessagePortBuiltin>
+
+// Implements the `MessageChannel` class.
+@Singleton @Intrinsic public class MessageChannelBuiltin : ProxyInstantiable, AbstractJsIntrinsic() {
+  /**
+   * ### Message Channel Instance
+   *
+   * Created when [MessageChannelBuiltin] receives a message to instantiate a new `MessageChannel` object.
+   */
+  public class MessageChannelInstance internal constructor (private val pair: MessagePortPair) :
+    MessageChannel,
+    ReadOnlyProxyObject {
+    // Channel must be active to relay messages.
+    @Volatile private var active = false
+
+    @get:Polyglot override val port1: MessagePort get() = pair.first
+    @get:Polyglot override val port2: MessagePort get() = pair.second
+
+    internal fun activate() {
+      check(!active) { "Message channel instance is not active" }
+      active = true
+      pair.first.activate()
+      pair.second.activate()
+    }
+
+    internal fun target(port: MessagePortBuiltin): MessagePortBuiltin {
+      return when (port) {
+        pair.first -> pair.second
+        pair.second -> pair.first
+        else -> error("Invalid message port")
+      }
+    }
+
+    override fun getMemberKeys(): Array<String> = messageChannelProps
+
+    override fun getMember(key: String?): Any? = when (key) {
+      MESSAGE_CHANNEL_PORT1 -> pair.first
+      MESSAGE_CHANNEL_PORT2 -> pair.second
+      else -> null
+    }
+  }
+
+  override fun install(bindings: GuestIntrinsic.MutableIntrinsicBindings) {
+    bindings[MESSAGE_CHANNEL_SYMBOL] = this
+    bindings[MESSAGE_PORT_SYMBOL] = MessagePortBuiltin::class.java
+  }
+
+  override fun newInstance(vararg arguments: Value?): MessageChannelInstance {
+    val port1 = MessagePortBuiltin.create(MESSAGE_CHANNEL_PORT1)
+    val port2 = MessagePortBuiltin.create(MESSAGE_CHANNEL_PORT2)
+    val instance = MessageChannelInstance(port1 to port2)
+    port1.bind(instance)
+    port2.bind(instance)
+    instance.activate()
+    return instance
+  }
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/javascript/MessagePortBuiltin.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/javascript/MessagePortBuiltin.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+@file:OptIn(DelicateElideApi::class)
+
+package elide.runtime.javascript
+
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyExecutable
+import org.graalvm.polyglot.proxy.ProxyObject
+import java.lang.ref.WeakReference
+import elide.runtime.core.DelicateElideApi
+import elide.runtime.gvm.js.JsError
+import elide.runtime.intrinsics.js.MessagePort
+import elide.runtime.intrinsics.js.Transferable
+import elide.runtime.intrinsics.js.messaging.PostMessageOptions
+import elide.runtime.intrinsics.js.node.events.CustomEvent
+import elide.runtime.intrinsics.js.node.events.Event
+import elide.runtime.intrinsics.js.node.events.EventListener
+import elide.runtime.intrinsics.js.node.events.EventTarget
+import elide.runtime.node.events.EventAwareProxy
+import elide.runtime.node.events.StandardEventName
+import elide.vm.annotations.Polyglot
+
+// Properties and methods on a `MessagePort`.
+private const val MESSAGE_EV = StandardEventName.MESSAGE
+private const val ONMESSAGE_PROP = "on${MESSAGE_EV}"
+private const val POST_MESSAGE_FN = "postMessage"
+private const val CLOSE_FN = "close"
+private const val START_FN = "start"
+
+private val messagePortProps = arrayOf(
+  ONMESSAGE_PROP,
+  POST_MESSAGE_FN,
+  CLOSE_FN,
+  START_FN,
+)
+
+private sealed interface OnMessageHandler {
+  fun dispatch(message: Any?)
+
+  @JvmInline private value class FunctionHandler(private val fn: (Any?) -> Unit) : OnMessageHandler {
+    override fun dispatch(message: Any?) {
+      fn(message)
+    }
+  }
+
+  @JvmInline private value class GuestHandler(private val fn: Value) : OnMessageHandler {
+    override fun dispatch(message: Any?) {
+      fn.executeVoid(message)
+    }
+  }
+
+  @JvmInline private value class ProxyHandler(private val fn: ProxyExecutable) : OnMessageHandler {
+    override fun dispatch(message: Any?) {
+      fn.execute(Value.asValue(message))
+    }
+  }
+
+  companion object {
+    fun create(fn: (Any?) -> Unit): OnMessageHandler = FunctionHandler(fn)
+    fun create(fn: Value): OnMessageHandler = GuestHandler(fn)
+    fun create(fn: ProxyExecutable): OnMessageHandler = ProxyHandler(fn)
+  }
+}
+
+// Implements the `MessagePort` class.
+public class MessagePortBuiltin private constructor (
+  private val portName: String,
+  private val events: EventAwareProxy = EventAwareProxy.create(),
+) : MessagePort, EventTarget by events, ProxyObject {
+  // Held as weak because a channel may be closed and the port should be garbage collected.
+  private lateinit var channel: WeakReference<MessageChannelBuiltin.MessageChannelInstance>
+
+  // Whether this message port is still open for messages.
+  @Volatile private var open = false
+
+  // Whether this message port has started listening.
+  @Volatile private var listening = false
+
+  // Currently assigned main message handler. Responds to `onmessage`.
+  @Volatile private var handler: OnMessageHandler? = null
+
+  internal fun bind(channel: MessageChannelBuiltin.MessageChannelInstance) {
+    assert(!this::channel.isInitialized) { "Message port $portName is already bound to a channel." }
+    this.channel = WeakReference(channel)
+  }
+
+  internal fun activate() {
+    assert(this::channel.isInitialized) { "Message channel instance is not active" }
+    open = true
+  }
+
+  // Event listener for incoming messages to this port.
+  private val listener = EventListener { it ->
+    handler?.dispatch(it)
+  }
+
+  @Polyglot override fun start() {
+    check(open) { "MessagePort is closed" }
+    if (!listening) {
+      listening = true
+      events.addEventListener(StandardEventName.MESSAGE, listener)
+    }
+  }
+
+  @Polyglot override fun postMessage(message: Any?, transfer: Collection<Transferable>?, options: PostMessageOptions?) {
+    check(open) { "MessagePort is closed" }
+    val ev = CustomEvent(MESSAGE_EV, mapOf("data" to message))
+    channel.get()
+      ?.target(this)
+      ?.dispatchEvent(ev)
+  }
+
+  override fun dispatchEvent(event: Event): Boolean = when (event.type) {
+    StandardEventName.MESSAGE -> {
+      handler?.dispatch(event)
+      events.dispatchEvent(event)
+    }
+    else -> events.dispatchEvent(event)
+  }
+
+  @Polyglot override fun close() {
+    if (open) {
+      open = false
+    }
+    if (listening) {
+      events.removeEventListener(StandardEventName.MESSAGE, listener)
+      listening = false
+    }
+  }
+
+  override fun toString(): String {
+    return "MessagePort($portName, active=$open)"
+  }
+
+  override fun getMemberKeys(): Array<String> = messagePortProps.plus(events.memberKeys)
+
+  @Suppress("SpreadOperator")
+  override fun getMember(key: String): Any? = when (key) {
+    ONMESSAGE_PROP -> handler
+    POST_MESSAGE_FN -> ProxyExecutable { postMessage(*it) }
+    CLOSE_FN -> ProxyExecutable { close() }
+    START_FN -> ProxyExecutable { start() }
+    else -> events.getMember(key)
+  }
+
+  override fun hasMember(key: String): Boolean = key in messagePortProps || (
+    key == ONMESSAGE_PROP && handler != null
+  ) || (
+    events.hasMember(key)
+  )
+
+  override fun removeMember(key: String): Boolean = when (key) {
+    // clear handler if instructed
+    ONMESSAGE_PROP -> true.also { handler = null }
+    else -> events.removeMember(key)
+  }
+
+  override fun putMember(key: String, value: Value?): Unit = when (key) {
+    ONMESSAGE_PROP -> when {
+      // handler can be a host object
+      value != null && value.isProxyObject -> value.asProxyObject<ProxyExecutable>().let {
+        this.handler = OnMessageHandler.create(it)
+        start()
+      }
+
+      // handler must be non-null and executable
+      value == null || value.isNull || !value.canExecute() ->
+        throw JsError.typeError("Invalid handler for `$ONMESSAGE_PROP`")
+
+      else -> handler = OnMessageHandler.create(value)
+    }
+    else -> events.putMember(key, value)
+  }
+
+  internal companion object {
+    /** @return New [MessagePortBuiltin] bound weakly to the parent. */
+    @JvmStatic fun create(name: String) = MessagePortBuiltin(name)
+  }
+}

--- a/packages/graalvm/src/test/kotlin/elide/runtime/javascript/MessageChannelTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/javascript/MessageChannelTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+@file:Suppress("JSUnresolvedReference")
+
+package elide.runtime.javascript
+
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyExecutable
+import org.junit.jupiter.api.assertDoesNotThrow
+import java.util.concurrent.Callable
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import elide.runtime.gvm.internals.js.AbstractJsIntrinsicTest
+import elide.runtime.node.events.StandardEventName
+import elide.testing.annotations.TestCase
+import elide.vm.annotations.Polyglot
+
+@TestCase internal class MessageChannelTest : AbstractJsIntrinsicTest<MessageChannelBuiltin>() {
+  override fun provide(): MessageChannelBuiltin = MessageChannelBuiltin()
+
+  @Test override fun testInjectable() {
+    assertNotNull(provide())
+  }
+
+  @Test fun testCreateMessageChannelHost() {
+    assertNotNull(provide().newInstance())
+    val x = provide().newInstance()
+    assertNotNull(x)
+    assertNotNull(x.port1)
+    assertNotNull(x.port2)
+  }
+
+  @Test fun testCreateMessageChannel() = dual {
+    assertNotNull(provide().newInstance())
+    val x = provide().newInstance()
+    assertNotNull(x)
+    assertNotNull(x.port1)
+    assertNotNull(x.port2)
+  }.guest {
+    // language=JavaScript
+    """
+      const channel = new MessageChannel();
+      test(channel).isNotNull();
+      test(channel.port1).isNotNull();
+      test(channel.port2).isNotNull();
+    """
+  }
+
+  @Test fun testMessagePortProps() {
+    assertNotNull(provide().newInstance())
+    val x = provide().newInstance()
+    val port = x.port1
+    assertNotNull(port.toString())
+    val port2 = x.port2
+    assertNotNull(port2.toString())
+  }
+
+  @Test fun testPostMessageSimple() = dual {
+    val channel = provide().newInstance()
+    val msg = mapOf("hi" to 5)
+    assertDoesNotThrow {
+      channel.port1.postMessage(Value.asValue(msg))
+    }
+  }.guest {
+    // language=JavaScript
+    """
+      const channel = new MessageChannel();
+      const msg = {hi: 5};
+      channel.port1.postMessage(msg);
+    """
+  }
+
+  @Test fun testPortAddEventListener() = dual {
+    val channel = provide().newInstance()
+    val msg = mapOf("hi" to 5)
+    var dispatched = false
+    channel.port2.addEventListener(StandardEventName.MESSAGE) {
+      dispatched = true
+    }
+    assertDoesNotThrow {
+      channel.port1.postMessage(Value.asValue(msg))
+    }
+    assertTrue(dispatched)
+  }.guest {
+    // language=JavaScript
+    """
+      const channel = new MessageChannel();
+      const msg = {hi: 5};
+      let dispatched = false;
+      channel.port2.addEventListener("message", () => {
+        dispatched = true;
+      });
+      channel.port2.start();
+      channel.port1.start();
+      channel.port1.postMessage(msg);
+      test(dispatched === true).isEqualTo(true);
+    """
+  }
+
+  @Test fun testPortOnMessageHost() {
+    val channel = provide().newInstance()
+    val msg = mapOf("hi" to 5)
+    val dispatched = AtomicBoolean(false)
+    channel.port2.putMember("onmessage", Value.asValue(object: ProxyExecutable {
+      @Polyglot
+      override fun execute(arguments: Array<out Value>?): Value {
+        dispatched.set(true)
+        return Value.asValue(null)
+      }
+    }))
+    assertDoesNotThrow {
+      channel.port1.postMessage(Value.asValue(msg))
+    }
+    assertTrue(dispatched.get())
+  }
+
+  @Test fun testPortOnMessage() = executeGuest {
+    // language=JavaScript
+    """
+      const channel = new MessageChannel();
+      const msg = {hi: 5};
+      let dispatched = false;
+      channel.port2.onmessage = () => {
+        dispatched = true;
+      };
+      channel.port1.postMessage(msg);
+      test(dispatched === true).isEqualTo(true);
+    """
+  }.doesNotFail()
+}

--- a/packages/graalvm/src/test/kotlin/elide/runtime/winter/CommonMinimumTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/winter/CommonMinimumTest.kt
@@ -60,7 +60,6 @@ private const val ENABLE_SUPPRESSIONS = true
     "CryptoKey",
     "DOMException",
     "DecompressionStream",
-    "Event",
     "FormData",
     "SubtleCrypto",
     "TextDecoderStream",
@@ -86,6 +85,8 @@ private const val ENABLE_SUPPRESSIONS = true
     "File",
     "FormData",
     "Headers",
+    "MessageChannel",
+    "MessagePort",
     "ReadableByteStreamController",
     "ReadableStream",
     "ReadableStreamBYOBReader",
@@ -143,15 +144,12 @@ private const val ENABLE_SUPPRESSIONS = true
   private fun withFreshContext(block: suspend Context.() -> Unit): Unit = PolyglotEngine {
     hostAccess = ALLOW_ALL
 
-    vfs {
-      useHost = true
-    }
-
-    install(Wasm)
-    install(JavaScript) {
+    vfs { useHost = true }
+    configure(Wasm)
+    configure(JavaScript) {
       npm {
         enabled = true
-        modulesPath = System.getenv("PWD")
+        modulesPath = System.getProperty("user.dir")
         wasm = true
       }
     }


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds very basic support for [`MessageChannel`](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel) and [`MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort). These implementations dispatch their counterparts as expected, and new support is added to the Node events logic for accepting handlers (etc) at `on{event}` properties, but no cross-context dispatch is supported until reparenting `MessagePort` context is added later.

The intent is to get React 19 running, which requires these types (it's supposed to warn if they are missing, but that seems broken). We don't actually need any cross-context dispatch yet.

- [x] Add `MessageChannel`
- [x] Add `MessagePort`
- [x] Amend common minimum tests
- [x] Implement `on{event}` property support in `NodeEvents`
- [x] Tests for `on{event}` logic

## Changelog
```
feat: add `MessageChannel` interface and basic impl
feat: add `MessagePort` interface and basic impl
test: add initial tests for channel messaging
test: add `MessageChannel` and `MessagePort` to common minimum
chore: re-pin api for `graalvm` module
```