### PR TITLE
fix(cli): ask before opening links

### DIFF
--- a/packages/cli/build.gradle.kts
+++ b/packages/cli/build.gradle.kts
@@ -513,6 +513,10 @@ dependencies {
   // General
   implementation(libs.smartexception)
   implementation(libs.magicProgress)
+  implementation(libs.inquirer) {
+    exclude(group = "org.jline", module = "jline")
+    exclude(group = "org.fusesource.jansi", module = "jansi")
+  }
 
   runtimeOnly(mn.micronaut.graal)
   implementation(mn.netty.handler)

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/discord/ToolDiscordCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/discord/ToolDiscordCommand.kt
@@ -13,6 +13,8 @@
 
 package elide.tool.cli.cmd.discord
 
+import com.github.kinquirer.KInquirer
+import com.github.kinquirer.components.promptConfirm
 import io.micronaut.core.annotation.Introspected
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
@@ -36,19 +38,12 @@ import elide.tool.cli.ToolState
     private const val REDIRECT_TARGET = "https://elide.dev/discord"
   }
 
-  /** Whether to open the link in the default browser (defaults to `true`). */
-  @Option(
-    names = ["--open"],
-    description = ["Open the link, if possible"],
-    defaultValue = "true",
-  )
-  var openLink: Boolean = true
-
   @Suppress("DEPRECATION")
   override suspend fun CommandContext.invoke(state: ToolContext<ToolState>): CommandResult {
     val printLink: () -> Unit = {
       println("Open link to join Discord: $REDIRECT_TARGET")
     }
+    val openLink = KInquirer.promptConfirm("Open the link? 'No' will print it in the console", default = false)
     if (openLink) withContext(Dispatchers.IO) {
       val os = System.getProperty("os.name", "unknown").lowercase()
 


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Prompt before opening links, e.g. to the Discord.

Fixes and closes elide-dev/elide#1335.

![image](https://github.com/user-attachments/assets/3d7bf570-1b5c-49b5-bc44-be7603b2ee64)