### PR TITLE
feat(cli): support `javadoc` and `jar` tools

### DIFF
--- a/packages/cli/build.gradle.kts
+++ b/packages/cli/build.gradle.kts
@@ -230,6 +230,8 @@ val jvmCompileArgs = listOfNotNull(
   "--add-modules=jdk.unsupported",
   "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
   "--add-exports=java.base/jdk.internal.jrtfs=ALL-UNNAMED",
+  "--add-exports=jdk.jartool/sun.tools.jar=ALL-UNNAMED",
+  "--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED",
 ).plus(if (enableJpms) listOf(
   "--add-reads=elide.cli=ALL-UNNAMED",
   "--add-reads=elide.graalvm=ALL-UNNAMED",
@@ -900,6 +902,16 @@ val initializeAtRuntime: List<String> = listOfNotNull(
   // pkl needs this
   "org.msgpack.core.buffer.DirectBufferAccess",
 
+  // --- JDK Tooling -----
+
+  "elide.tool.cli.cmd.tool.jar.JarTool",
+  "elide.tool.cli.cmd.tool.javadoc.JavadocTool",
+  "jdk.tools.jlink.internal.Main",
+  "jdk.tools.jlink.internal.Utils",
+  "jdk.tools.jlink.internal.Main\$JlinkToolProvider",
+  "jdk.tools.jlink.internal.plugins.LegalNoticeFilePlugin",
+  "jdk.jpackage.internal.JPackageToolProvider",
+
   // --- JNA -----
 
   "com.sun.jna.Structure${'$'}FFIType",
@@ -1127,7 +1139,7 @@ val commonNativeArgs = listOfNotNull(
   "--install-exit-handlers",
   // @TODO breaks with old configs, and new configs can't use the agent.
   // "--exact-reachability-metadata",
-  "--enable-url-protocols=http,https,jar",
+  "--enable-url-protocols=http,https,jar,resource",
   "--color=always",
   "--initialize-at-build-time",
   "--link-at-build-time=elide",

--- a/packages/cli/src/main/kotlin/elide/tool/cli/CommandContext.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/CommandContext.kt
@@ -127,7 +127,11 @@ sealed interface CommandContext : CoroutineScope {
    * @param out String builder to emit.
    */
   fun output(out: StringBuilder) {
-    println(out.toString())
+    out.toString().let {
+      if (it.isNotEmpty() && it.isNotBlank()) {
+        println(it)
+      }
+    }
     System.out.flush()
   }
 

--- a/packages/cli/src/main/kotlin/elide/tool/cli/Elide.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/Elide.kt
@@ -46,7 +46,9 @@ import elide.tool.cli.cmd.pkl.ToolPklCommand
 import elide.tool.cli.cmd.project.ToolProjectCommand
 import elide.tool.cli.cmd.tool.ToolInvokeCommand
 import elide.tool.cli.cmd.repl.ToolShellCommand
+import elide.tool.cli.cmd.tool.jar.JarTool
 import elide.tool.cli.cmd.tool.javac.JavaCompiler
+import elide.tool.cli.cmd.tool.javadoc.JavadocTool
 import elide.tool.cli.cmd.tool.kotlinc.KotlinCompiler
 import elide.tool.cli.state.CommandState
 import elide.tool.engine.NativeEngine
@@ -98,6 +100,8 @@ internal const val ELIDE_HEADER = ("@|bold,fg(magenta)%n" +
     ToolProjectCommand::class,
     KotlinCompiler.KotlinCliTool::class,
     JavaCompiler.JavacCliTool::class,
+    JarTool.JarCliTool::class,
+    JavadocTool.JavadocCliTool::class,
   ],
   customSynopsis = [
     "",
@@ -112,7 +116,7 @@ internal const val ELIDE_HEADER = ("@|bold,fg(magenta)%n" +
     "    or:  elide @|bold,fg(cyan) run|repl|@ --js [OPTIONS]",
     "    or:  elide @|bold,fg(cyan) run|repl|@ --language=[@|bold,fg(green) JS|@] [OPTIONS] [FILE] [ARG...]",
     "    or:  elide @|bold,fg(cyan) run|repl|@ --languages=[@|bold,fg(green) JS|@,@|bold,fg(green) PYTHON|@,...] [OPTIONS] [FILE] [ARG...]",
-    "    or:  elide @|bold,fg(cyan) javac|kotlinc|...|@ [OPTIONS] [SOURCES...]",
+    "    or:  elide @|bold,fg(cyan) javac|kotlinc|jar|javadoc|...|@ [OPTIONS] [SOURCES...]",
   ],
 )
 @Suppress("MemberVisibilityCanBePrivate")

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/AbstractGenericTool.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/AbstractGenericTool.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
+package elide.tool.cli.cmd.tool
+
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.util.LinkedList
+import java.util.SortedSet
+import java.util.concurrent.atomic.AtomicLong
+import elide.runtime.Logger
+import elide.tool.Argument
+import elide.tool.Arguments
+import elide.tool.MutableArguments
+import elide.tool.Tool
+import elide.tool.cli.CommandContext
+
+/**
+ * ## Abstract Tool (Generic)
+ */
+abstract class AbstractGenericTool<T, I, O>(info: Tool.CommandLineTool) : AbstractTool(info) {
+  /**
+   * Create the tool provider instance.
+   *
+   * @return Generic tool provider.
+   */
+  abstract fun createTool(): T
+
+  /**
+   * Logger to use for this tool.
+   */
+  abstract val toolLogger: Logger
+
+  /**
+   * Generic description for this task.
+   */
+  abstract val taskDescription: String
+
+  /**
+   * Amend the arguments to be passed to the tool.
+   *
+   * @param args Arguments to amend.
+   */
+  open fun amendArgs(args: MutableArguments): Unit = Unit
+
+  /**
+   * Implementation to run the generic tool.
+   */
+  abstract fun toolRun(out: PrintWriter, err: PrintWriter, vararg args: String): Int
+
+  /**
+   * Wrapped execution of the tool itself, to customize before/after actions.
+   *
+   * @param block Block to execute
+   */
+  open suspend fun <R> toolExec(block: suspend () -> R): R = block()
+
+  /**
+   * Inputs for this tool.
+   */
+  abstract val inputs: I
+
+  /**
+   * Outputs for this tool.
+   */
+  abstract val outputs: O
+
+  /**
+   * Resolve inputs for this tool.
+   *
+   * @return Resolved inputs.
+   */
+  open fun resolveInputs(): I = inputs
+
+  /**
+   * Resolve outputs for this tool.
+   *
+   * @param out Standard output stream.
+   * @param err Standard error stream.
+   * @param ms Milliseconds since the tool started.
+   * @return Resolved outputs.
+   */
+  open suspend fun CommandContext.resolveOutputs(out: StringWriter, err: StringWriter, ms: Int): O = outputs.also {
+    val regularOutput = out.toString()
+    val regularError = err.toString()
+
+    output {
+      append(regularOutput)
+      append(regularError)
+      append("[${info.name}] Ran in ${ms}ms")
+    }
+  }
+
+  // Supported by default.
+  override fun supported(): Boolean = true
+
+  override suspend fun CommandContext.invoke(state: EmbeddedToolState): Tool.Result {
+    val args = MutableArguments.from(info.args).also { amendArgs(it) }
+
+    output {
+      """
+        Invoking `${info.name}` with:
+  
+          -- Arguments:
+          $args
+  
+          -- Inputs:
+          $inputs
+  
+          -- Outputs:
+          $outputs
+  
+          -- Environment:
+          ${info.environment}
+      """.trimIndent().also {
+        toolLogger.debug(it)
+        if (state.cmd.state.output.verbose) {
+          append(it)
+        }
+      }
+    }
+
+    toolLogger.debug { "Resolving inputs" }
+    resolveInputs()
+    val toolStart = System.currentTimeMillis()
+    val toolEnd = AtomicLong(0L)
+    val out = StringWriter()
+    val outPrinter = PrintWriter(out, true)
+    val err = StringWriter()
+    val errPrinter = PrintWriter(err, true)
+    val finalizdArgs = args.asArgumentList().toTypedArray()
+
+    val exitCode = toolExec {
+      @Suppress("TooGenericExceptionCaught", "SpreadOperator")
+      try {
+        toolLogger.debug { "Preparing generic tool execution task '$taskDescription'" }
+        toolRun(outPrinter, errPrinter, *finalizdArgs)
+      } catch (rxe: RuntimeException) {
+        toolLogger.debug { "Exception while executing task: $rxe" }
+
+        embeddedToolError(
+          info,
+          "$taskDescription failed: ${rxe.message}",
+          cause = rxe,
+        )
+      } finally {
+        toolLogger.debug { "$taskDescription job finished" }
+        toolEnd.set(System.currentTimeMillis())
+      }
+    }
+
+    out.flush()
+    err.flush()
+    val totalMs = toolEnd.get() - toolStart
+    toolLogger.debug { "$taskDescription job completed in ${totalMs}ms (exit code: $exitCode)" }
+    resolveOutputs(out, err, totalMs.toInt())
+    return Tool.Result.Success
+  }
+
+  companion object {
+    // Gather options, inputs, and outputs for an invocation of the jar tool.
+    @JvmStatic internal fun gatherArgs(
+      expectValues: SortedSet<String>,
+      args: Arguments,
+    ): Pair<LinkedList<Argument>, LinkedList<String>> {
+      val effective = LinkedList<Argument>()
+      val likelyInputs = LinkedList<String>()
+      var nextIsValueForKey: String? = null
+
+      for (arg in args.asArgumentList()) {
+        if (nextIsValueForKey != null) {
+          effective.add(Argument.of(nextIsValueForKey to arg))
+          nextIsValueForKey = null
+          continue
+        }
+        val argNormalized = arg.lowercase().trim()
+        val argSplit = argNormalized.split('=')
+        val argToken = argSplit.first()
+        if (argToken in expectValues) {
+          if (argSplit.size > 1) {
+            // Split on `=`.
+            val value = argSplit[1]
+            effective.add(Argument.of(argToken to value))
+          } else {
+            // Next token is a value for this key.
+            nextIsValueForKey = argToken
+          }
+        } else {
+          // Just add the token as-is.
+          effective.add(Argument.of(arg))
+          if (!argToken.startsWith("-") && !argToken.startsWith("@")) {
+            // this is a likely input
+            likelyInputs.add(arg)
+          }
+        }
+      }
+      return (effective to likelyInputs)
+    }
+  }
+}

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/DelegatedGenericToolCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/DelegatedGenericToolCommand.kt
@@ -11,27 +11,21 @@
  * License for the specific language governing permissions and limitations under the License.
  */
 
-package elide.tool
+package elide.tool.cli.cmd.tool
 
-import kotlinx.serialization.Serializable
+import elide.tool.Tool
 
 /**
- * # Program Inputs
+ * ## Delegated Tool Command (Generic)
+ *
+ * Implements generic support for tools which use the JDK's built-in [java.util.spi.ToolProvider] interface; such tools
+ * provide a [java.util.spi.ToolProvider.run] method.
+ *
+ * @param T Tool adapter implementation
  */
-@Serializable
-public sealed interface Inputs {
-  /**
-   * ## Inputs: None.
-   */
-  public interface None : Inputs
+abstract class DelegatedGenericToolCommand<T> (
+  info: Tool.CommandLineTool,
+  configurator: ToolCommandConfigurator<T>? = null,
+): DelegatedToolCommand<T>(info, configurator) where T: AbstractTool {
 
-  /**
-   * ## Inputs: Values.
-   */
-  public interface Values : Inputs
-
-  /**
-   * ## Inputs: Files.
-   */
-  public interface Files : Inputs
 }

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/DelegatedToolCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/DelegatedToolCommand.kt
@@ -167,6 +167,11 @@ abstract class DelegatedToolCommand<T> (
               errExitCode = exc.exitCode
               exc.message?.let { exitMessage = it }
             }
+            else -> {
+              logging.error("Failed to call tool: ${info.name}", exc)
+              errExitCode = 1
+              exitMessage = it.message ?: "Unknown error"
+            }
           }
         }.getOrElse {
           err(exitMessage, exitCode = errExitCode)

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/jar/JarTool.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/jar/JarTool.kt
@@ -1,0 +1,405 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
+@file:Suppress("JAVA_MODULE_DOES_NOT_EXPORT_PACKAGE")
+
+package elide.tool.cli.cmd.tool.jar
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.ReflectiveAccess
+import picocli.CommandLine
+import sun.tools.jar.JarToolProvider
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.spi.ToolProvider
+import jakarta.inject.Singleton
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlin.io.path.relativeTo
+import elide.runtime.Logger
+import elide.runtime.Logging
+import elide.tool.Argument
+import elide.tool.Arguments
+import elide.tool.Environment
+import elide.tool.Inputs
+import elide.tool.MutableArguments
+import elide.tool.Outputs
+import elide.tool.Tool
+import elide.tool.cli.CommandContext
+import elide.tool.cli.cmd.tool.AbstractGenericTool
+import elide.tool.cli.cmd.tool.AbstractTool
+import elide.tool.cli.cmd.tool.DelegatedToolCommand
+import elide.tool.cli.cmd.tool.jar.JarTool.JarToolInputs
+import elide.tool.cli.cmd.tool.jar.JarTool.JarToolOutputs
+
+// Name of the `jar` tool.
+private const val JAR = "jar"
+
+// Description to show for `jar`.
+private const val JARTOOL_DESCRIPTION = "Builds and manages Java Archive files (JARs)."
+
+// Tool description.
+private val jartool = Tool.describe(
+  name = JAR,
+  label = "JAR Tool",
+  version = System.getProperty("java.version"),
+  docs = URI.create("https://docs.oracle.com/javase/8/docs/technotes/guides/jar/index.html"),
+  description = JARTOOL_DESCRIPTION,
+  helpText = """
+    Usage: elide jar <elide option...> -- [OPTION...] [ [--release VERSION] [-C dir] files] ...
+
+    jar creates an archive for classes and resources, and can manipulate or
+    restore individual classes or resources from an archive.
+
+    where possible elide options include:
+      (None at this time.)
+
+     Examples:
+     # Create an archive called classes.jar with two class files:
+     elide jar --create --file classes.jar Foo.class Bar.class
+
+     # Create an archive using an existing manifest, with all the files in foo/:
+     elide jar --create --file classes.jar --manifest mymanifest -C foo/ .
+
+     # Create a modular jar archive, where the module descriptor is located in
+     # classes/module-info.class:
+     elide jar --create --file foo.jar --main-class com.foo.Main --module-version 1.0
+         -C foo/ classes resources
+
+     # Update an existing non-modular jar to a modular jar:
+     elide jar --update --file foo.jar --main-class com.foo.Main --module-version 1.0
+         -C foo/ module-info.class
+
+     # Create a multi-release jar, placing some files in the META-INF/versions/9 directory:
+     elide jar --create --file mr.jar -C foo classes --release 9 -C foo9 classes
+
+    To shorten or simplify the jar command, you can specify arguments in a separate
+    text file and pass it to the jar command with the at sign (@) as a prefix.
+
+     Examples:
+     # Read additional options and list of class files from the file classes.list
+     jar --create --file my.jar @classes.list
+
+     Main operation mode:
+
+      -c, --create               Create the archive. When the archive file name specified
+                                 by -f or --file contains a path, missing parent directories
+                                 will also be created
+      -i, --generate-index=FILE  Generate index information for the specified jar
+                                 archives. This option is deprecated and may be
+                                 removed in a future release.
+      -t, --list                 List the table of contents for the archive
+      -u, --update               Update an existing jar archive
+      -x, --extract              Extract named (or all) files from the archive.
+                                 If a file with the same name appears more than once in
+                                 the archive, each copy will be extracted, with later copies
+                                 overwriting (replacing) earlier copies unless -k is specified.
+      -d, --describe-module      Print the module descriptor, or automatic module name
+          --validate             Validate the contents of the jar archive. This option
+                                 will validate that the API exported by a multi-release
+                                 jar archive is consistent across all different release
+                                 versions.
+
+     Operation modifiers valid in any mode:
+    
+      -C DIR                     Change to the specified directory and include the
+                                 following file. When used in extract mode, extracts
+                                 the jar to the specified directory
+      -f, --file=FILE            The archive file name. When omitted, either stdin or
+                                 stdout is used based on the operation
+          --release VERSION      Places all following files in a versioned directory
+                                 of the jar (i.e. META-INF/versions/VERSION/)
+      -v, --verbose              Generate verbose output on standard output
+
+     Operation modifiers valid only in create and update mode:
+
+      -e, --main-class=CLASSNAME The application entry point for stand-alone
+                                 applications bundled into a modular, or executable,
+                                 jar archive
+      -m, --manifest=FILE        Include the manifest information from the given
+                                 manifest file
+      -M, --no-manifest          Do not create a manifest file for the entries
+          --module-version=VERSION    The module version, when creating a modular
+                                 jar, or updating a non-modular jar
+          --hash-modules=PATTERN Compute and record the hashes of modules
+                                 matched by the given pattern and that depend upon
+                                 directly or indirectly on a modular jar being
+                                 created or a non-modular jar being updated
+      -p, --module-path          Location of module dependence for generating
+                                 the hash
+
+     Operation modifiers valid only in create, update, and generate-index mode:
+    
+      -0, --no-compress          Store only; use no ZIP compression
+          --date=TIMESTAMP       The timestamp in ISO-8601 extended offset date-time with
+                                 optional time-zone format, to use for the timestamps of
+                                 entries, e.g. "2022-02-12T12:30:00-05:00"
+
+     Operation modifiers valid only in extract mode:
+
+      -k, --keep-old-files       Do not overwrite existing files.
+                                 If a Jar file entry with the same name exists in the target
+                                 directory, the existing file will not be overwritten.
+                                 As a result, if a file appears more than once in an
+                                 archive, later copies will not overwrite earlier copies.
+                                 Also note that some file system can be case insensitive.
+      --dir                    Directory into which the jar will be extracted
+
+     Other options:
+
+      -?, -h, --help[:compat]    Give this, or optionally the compatibility, help
+          --help-extra           Give help on extra options
+          --version              Print program version
+
+     An archive is a modular jar if a module descriptor, 'module-info.class', is
+     located in the root of the given directories, or the root of the jar archive
+     itself. The following operations are only valid when creating a modular jar,
+     or updating an existing non-modular jar: '--module-version',
+     '--hash-modules', and '--module-path'.
+
+     Mandatory or optional arguments to long options are also mandatory or optional
+     for any corresponding short options.
+  """.trimIndent()
+)
+
+// Argument names which require a value following, or separated by `=`.
+private val argNamesThatExpectValues = sortedSetOf(
+  "-f", "--file",
+  "-i", "--generate-index",
+  "--release",
+  "-e", "--main-class",
+  "-m", "--manifest",
+  "--module-version",
+  "--hash-modules",
+  "-p", "--module-path",
+  "--date",
+  "--dir",
+)
+
+/**
+ * # JAR Tool
+ *
+ * Implements an [AbstractTool] adapter to `jar`. Arguments are passed to the tool verbatim from the command-line.
+ */
+@ReflectiveAccess @Introspected class JarTool private constructor (
+  args: Arguments,
+  env: Environment,
+  override val inputs: JarToolInputs,
+  override val outputs: JarToolOutputs,
+): AbstractGenericTool<JarToolProvider, JarToolInputs, JarToolOutputs>(info = jartool.extend(
+  args,
+  env,
+).using(
+  inputs = inputs,
+  outputs = outputs.flatten(),
+)) {
+  // Jar tool.
+  private val systemJarTool by lazy { JarToolProvider() }
+
+  // Logging.
+  private val jarLogger by lazy { Logging.of(JarTool::class) }
+
+  override val toolLogger: Logger get() = jarLogger
+  override val taskDescription: String get() = "Jar assembly"
+
+  // Use the system JAR tool.
+  override fun createTool(): JarToolProvider = systemJarTool
+  override fun toolRun(out: PrintWriter, err: PrintWriter, vararg args: String): Int = createTool().run(out, err, *args)
+
+  /**
+   * JAR tool inputs.
+   *
+   * Implements understanding of inputs for `jar`.
+   */
+  sealed interface JarToolInputs: Inputs.Files {
+    /**
+     * Provided when no inputs are available.
+     */
+    data object NoInputs: JarToolInputs
+
+    /**
+     * Describes a sequence of input files to include in the JAR.
+     */
+    @JvmInline value class InputFiles(internal val files: PersistentList<Path>): JarToolInputs
+  }
+
+  /**
+   * JAR tool outputs.
+   *
+   * Implements understanding of JAR tool outputs -- typically JARs.
+   */
+  sealed interface JarToolOutputs {
+    /**
+     * Provided when no inputs are available.
+     */
+    data object NoOutputs: JarToolOutputs, Outputs.None {
+      override fun flatten(): Outputs = this
+    }
+
+    /**
+     * Flatten into an [Outputs] type.
+     *
+     * @return Outputs value.
+     */
+    fun flatten(): Outputs
+
+    /** Defines a [path] to an output JAR. */
+    @JvmInline value class Jar(internal val location: Pair<Path?, Path>): JarToolOutputs, Outputs.Disk.File {
+      val path: Path get() = location.second
+      val directory: Path? get() = location.first
+      override fun flatten(): Outputs = this
+    }
+  }
+
+  // Amend JAR tool args with additional options that were passed in, or which enable Elide features.
+  @Suppress("UNUSED_PARAMETER") override fun amendArgs(args: MutableArguments) {
+    // Nothing at this time.
+  }
+
+  override suspend fun CommandContext.resolveOutputs(out: StringWriter, err: StringWriter, ms: Int): JarToolOutputs {
+    val srcs = (inputs as JarToolInputs.InputFiles).files
+    val inputsCount = srcs.size
+    val plural = if (inputsCount > 1) "inputs" else "input file"
+    val outputPath: Path? = when (outputs) {
+      is JarToolOutputs.Jar -> outputs.path
+      is JarToolOutputs.NoOutputs -> null
+    }
+    val outputRelativeToCwd = outputPath
+      ?.toAbsolutePath()
+      ?.relativeTo(Paths.get(System.getProperty("user.dir")))
+
+    val regularOutput = out.toString()
+    val regularError = err.toString()
+
+    if (regularOutput.isNotEmpty()) {
+      output {
+        append(regularOutput)
+      }
+    }
+    if (regularError.isNotEmpty()) {
+      output {
+        append(regularError)
+      }
+    }
+    output {
+      val outputOrNothing = if (outputRelativeToCwd != null) " → $outputRelativeToCwd" else ""
+      append("[jar] Assembled $inputsCount $plural in ${ms}ms$outputOrNothing")
+    }
+    return outputs
+  }
+
+  /** Factories for configuring and obtaining instances of [JarTool]. */
+  @Suppress("unused") companion object {
+    /**
+     * Create inputs for the Jar tool.
+     *
+     * @param sequence Sequence of paths to include.
+     * @return Jar tool inputs.
+     */
+    @JvmStatic fun jarFiles(sequence: Sequence<Path>): JarToolInputs = JarToolInputs.InputFiles(
+      sequence.toList().toPersistentList().also {
+        if (it.isEmpty()) embeddedToolError(jartool, "No input files provided")
+      }
+    )
+
+    /**
+     * Create outputs for the Jar tool which specify a created jar.
+     *
+     * @param at Expected path to the built jar.
+     * @param dir Optional directory to place the jar in.
+     * @return Jar tool outputs.
+     */
+    @JvmStatic fun outputJar(at: Path, dir: Path? = null): JarToolOutputs = JarToolOutputs.Jar(dir to at)
+
+    /**
+     * Create a Jar tool instance from the provided inputs.
+     *
+     * @param args Arguments to the tool.
+     * @param inputs Inputs to the tool.
+     * @param outputs Outputs from the tool.
+     * @param env Environment for the tool; defaults to the host environment.
+     */
+    @JvmStatic fun create(
+      args: Arguments,
+      env: Environment,
+      inputs: JarToolInputs,
+      outputs: JarToolOutputs,
+    ): JarTool = JarTool(
+      args = args,
+      env = env,
+      inputs = inputs,
+      outputs = outputs,
+    )
+  }
+
+  @CommandLine.Command(
+    name = JAR,
+    description = [JARTOOL_DESCRIPTION],
+    mixinStandardHelpOptions = false,
+  )
+  @Singleton
+  @ReflectiveAccess
+  @Introspected
+  class JarCliTool: DelegatedToolCommand<JarTool>(jartool) {
+    @CommandLine.Spec override lateinit var spec: CommandLine.Model.CommandSpec
+
+    override fun configure(args: Arguments, environment: Environment): JarTool = gatherArgs(
+      argNamesThatExpectValues,
+      args,
+    ).let { (effective, likelyInputs) ->
+      // gather all inputs which should be paths; parse them.
+      val parsedInputs = likelyInputs.mapNotNull {
+        try {
+          Paths.get(it)
+        } catch (_: IllegalArgumentException) {
+          // skip: not a path
+          return@mapNotNull null
+        }.takeIf {
+          // only extant paths can be passed to jar tool, unless we are specifying an output, in which case the arg is
+          // prefixed or assigned with `=` and so is not present here.
+          Files.exists(it)
+        }
+      }.let {
+        when (it.size) {
+          0 -> JarToolInputs.NoInputs
+          else -> JarToolInputs.InputFiles(it.toPersistentList())
+        }
+      }
+
+      // resolve directory/jar output path args
+      val fileArg = effective.find {
+        it is Argument.KeyValueArg && (it.name == "-f" || it.name == "--file")
+      }?.let {
+        Paths.get((it as Argument.KeyValueArg).value)
+      }
+      val dirArg = effective.find {
+        it is Argument.KeyValueArg && (it.name == "--directory")
+      }?.let {
+        Paths.get((it as Argument.KeyValueArg).value)
+      }
+      JarTool(
+        args = args,
+        env = environment,
+        inputs = parsedInputs,
+        outputs = when (val outfile = fileArg) {
+          null -> JarToolOutputs.NoOutputs
+          else -> JarToolOutputs.Jar(dirArg to outfile)
+        },
+      )
+    }
+  }
+}

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/javac/JavaCompiler.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/javac/JavaCompiler.kt
@@ -60,10 +60,14 @@ private val javac = Tool.describe(
   name = JAVAC,
   label = "Java Compiler",
   version = System.getProperty("java.version"),
-  docs = URI.create("https://kotl.in/cli"),
+  docs = URI.create("https://docs.oracle.com/javase/8/docs/technotes/guides/javac/index.html"),
   description = JAVAC_DESCRIPTION,
   helpText = """
-  Usage: elide javac <options> <source files>
+  Usage: elide javac <elide options> -- <options> <source files>
+
+  where possible elide options include:
+    (None at this time.)
+
   where possible options include:
 
   @<filename>                  Read options and filenames from file

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/javadoc/JavadocTool.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/tool/javadoc/JavadocTool.kt
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
+@file:Suppress("JAVA_MODULE_DOES_NOT_EXPORT_PACKAGE")
+
+package elide.tool.cli.cmd.tool.javadoc
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.ReflectiveAccess
+import jdk.javadoc.internal.tool.JavadocToolProvider
+import picocli.CommandLine
+import java.io.PrintWriter
+import java.net.URI
+import jakarta.inject.Singleton
+import elide.runtime.Logger
+import elide.runtime.Logging
+import elide.tool.Argument
+import elide.tool.Arguments
+import elide.tool.Environment
+import elide.tool.Inputs
+import elide.tool.MutableArguments
+import elide.tool.Outputs
+import elide.tool.Tool
+import elide.tool.asArgumentString
+import elide.tool.cli.cmd.tool.AbstractGenericTool
+import elide.tool.cli.cmd.tool.AbstractTool
+import elide.tool.cli.cmd.tool.DelegatedToolCommand
+import elide.tool.cli.cmd.tool.javadoc.JavadocTool.JavadocInputs
+
+// Name of the `javadoc` tool.
+private const val JAVADOC = "javadoc"
+
+// Description to show for `javadoc`.
+private const val JAVADOCTOOL_DESCRIPTION = "Renders Java code into documentation."
+
+// Tool description.
+private val javadoc = Tool.describe(
+  name = JAVADOC,
+  label = "Javadoc",
+  version = System.getProperty("java.version"),
+  docs = URI.create("https://docs.oracle.com/javase/8/docs/technotes/guides/javadoc/index.html"),
+  description = JAVADOCTOOL_DESCRIPTION,
+  helpText = """
+    Usage:
+        elide javadoc <elide options> -- [options] [packagenames] [sourcefiles] [@files]
+
+    where possible elide options include:
+      (None at this time.)
+
+    where options include:
+        @<file>       Read options and filenames from file
+        --add-modules <module>(,<module>)*
+                      Root modules to resolve in addition to the initial modules,
+                      or all modules on the module path if <module> is
+                      ALL-MODULE-PATH.
+        -bootclasspath <path>
+                      Override location of platform class files used for non-modular
+                      releases
+        -breakiterator
+                      Compute first sentence with BreakIterator
+        --class-path <path>, -classpath <path>, -cp <path>
+                      Specify where to find user class files
+        -doclet <class>
+                      Generate output via alternate doclet
+        -docletpath <path>
+                      Specify where to find doclet class files
+        --enable-preview
+                      Enable preview language features. To be used in conjunction with
+                      either -source or --release.
+        -encoding <name>
+                      Source file encoding name
+        -exclude <pkglist>
+                      Specify a list of packages to exclude
+        --expand-requires (transitive|all)
+                      Instructs the tool to expand the set of modules to be
+                      documented. By default, only the modules given explicitly on
+                      the command line will be documented. A value of "transitive"
+                      will additionally include all "requires transitive"
+                      dependencies of those modules. A value of "all" will include
+                      all dependencies of those modules.
+        -extdirs <dirlist>
+                      Override location of installed extensions
+        --help, -help, -?, -h
+                      Display command-line options and exit
+        --help-extra, -X
+                      Print a synopsis of nonstandard options and exit
+        -J<flag>      Pass <flag> directly to the runtime system
+        --limit-modules <module>(,<module>)*
+                      Limit the universe of observable modules
+        -locale <name>
+                      Locale to be used, e.g. en_US or en_US_WIN
+        --module <module>(,<module>)*
+                      Document the specified module(s)
+        --module-path <path>, -p <path>
+                      Specify where to find application modules
+        --module-source-path <path>
+                      Specify where to find input source files for multiple modules
+        -package
+                      Show package/protected/public types and members. For
+                      named modules, show all packages and all module details.
+        -private
+                      Show all types and members. For named modules,
+                      show all packages and all module details.
+        -protected
+                      Show protected/public types and members (default). For
+                      named modules, show exported packages and the module's API.
+        -public
+                      Show only public types and members. For named modules,
+                      show exported packages and the module's API.
+        -quiet        Do not display status messages
+        --release <release>
+                      Provide source compatibility with specified release
+        --show-members <value>
+                      Specifies which members (fields, methods, or constructors) will be
+                      documented, where value can be one of "public", "protected",
+                      "package" or "private". The default is "protected", which will
+                      show public and protected members, "public" will show only
+                      public members, "package" will show public, protected and
+                      package members and "private" will show all members.
+        --show-module-contents <value>
+                      Specifies the documentation granularity of module
+                      declarations. Possible values are "api" or "all".
+        --show-packages <value>
+                      Specifies which module packages will be documented. Possible
+                      values are "exported" or "all" packages.
+        --show-types <value>
+                      Specifies which types (classes, interfaces, etc.) will be
+                      documented, where value can be one of "public", "protected",
+                      "package" or "private". The default is "protected", which will
+                      show public and protected types, "public" will show only
+                      public types, "package" will show public, protected and
+                      package types and "private" will show all types.
+        --source <release>, -source <release>
+                      Provide source compatibility with specified release
+        --source-path <path>, -sourcepath <path>
+                      Specify where to find source files
+        -subpackages <subpkglist>
+                      Specify subpackages to recursively load
+        --system <jdk>
+                      Override location of system modules used for modular releases
+        --upgrade-module-path <path>
+                      Override location of upgradeable modules
+        -verbose      Output messages about what Javadoc is doing
+        --version     Print version information
+        -Werror       Report an error if any warnings occur
+    
+    Provided by the Standard doclet:
+        --add-script <file>
+                      Add a script file to the generated documentation
+        --add-stylesheet <file>
+                      Add a stylesheet file to the generated documentation
+        --allow-script-in-comments
+                      Allow JavaScript in documentation comments, and options
+                      whose value is html-code
+        -author       Include @author paragraphs
+        -bottom <html-code>
+                      Include bottom text for each page
+        -charset <charset>
+                      Charset for cross-platform viewing of generated documentation
+        -d <directory>
+                      Destination directory for output files
+        -docencoding <name>
+                      Specify the character encoding for the output
+        -docfilessubdirs
+                      Enables deep copying of 'doc-files' directories. Subdirectories and all
+                      contents are recursively copied to the destination
+        -doctitle <html-code>
+                      Include title for the overview page
+        -excludedocfilessubdir <name>,<name>,...
+                      Exclude any 'doc-files' subdirectories with given name.
+                      ':' can also be used anywhere in the argument as a separator.
+        -footer <html-code>
+                      This option is no longer supported and reports a warning
+        -group <name> <g1>,<g2>...
+                      Group specified elements together in overview page.
+                      ':' can also be used anywhere in the argument as a separator.
+        -header <html-code>
+                      Include header text for each page
+        -helpfile <file>
+                      Specifies a file containing the text that will be displayed when the
+                      help link in the navigation bar is clicked
+        -html5        Generate HTML 5 output. This option is no longer required.
+        --javafx, -javafx
+                      Enable JavaFX functionality
+        -keywords     Include HTML meta tags with package, class and member info
+        -link <url>   Create links to javadoc output at <url>
+        --link-modularity-mismatch (warn|info)
+                      Report external documentation with wrong modularity with either
+                      a warning or informational message. The default behaviour is to
+                      report a warning.
+        -linkoffline <url1> <url2>
+                      Link to docs at <url1> using package list at <url2>
+        --link-platform-properties <url>
+                      Link to platform documentation URLs declared in properties file at <url>
+        -linksource   Generate source in HTML
+        --main-stylesheet <file>, -stylesheetfile <file>
+                      File to change style of the generated documentation
+        -nocomment    Suppress description and tags, generate only declarations
+        -nodeprecated
+                      Do not include @deprecated information
+        -nodeprecatedlist
+                      Do not generate deprecated list
+        --no-fonts    Do not include standard web fonts in generated documentation
+        -nohelp       Do not generate help link
+        -noindex      Do not generate index
+        -nonavbar     Do not generate navigation bar
+        --no-platform-links
+                      Do not generate links to the platform documentation
+        -noqualifier <name1>,<name2>,...
+                      Exclude the list of qualifiers from the output.
+                      ':' can also be used anywhere in the argument as a separator.
+        -nosince      Do not include @since information
+        -notimestamp  Do not include hidden time stamp
+        -notree       Do not generate class hierarchy
+        --override-methods (detail|summary)
+                      Document overridden methods in the detail or summary sections.
+                      The default is 'detail'.
+        -overview <file>
+                      Read overview documentation from HTML file
+        -serialwarn   Reports compile-time warnings for missing '@serial' tags
+        --since <release>(,<release>)*
+                      Document new and deprecated API in the specified releases
+        --since-label <text>
+                      Provide text to use in the heading of the "New API" page
+        --snippet-path <path>
+                      The path for external snippets
+        -sourcetab <tab length>
+                      Specify the number of spaces each tab takes up in the source
+        --spec-base-url
+                      Specify a base URL for relative URLs in @spec tags
+        -splitindex   Split index into one file per letter
+        -tag <name>:<locations>:<header>
+                      Specifies a custom tag with a single argument
+        -taglet       The fully qualified name of Taglet to register
+        -tagletpath   The path to Taglets
+        -top <html-code>
+                      Include top text for each page
+        -use          Create class and package usage pages
+        -version      Include @version paragraphs
+        -windowtitle <text>
+                      Browser window title for the documentation
+    
+    GNU-style options may use = instead of whitespace to separate the name of an
+    option from its value
+  """.trimIndent()
+)
+
+// Argument names which require a value following, or separated by `=`.
+private val argNamesThatExpectValues = sortedSetOf(
+  // Javadoc Parameters
+  "--add-modules",
+  "-bootclasspath",
+  "--class-path", "-classpath", "-cp",
+  "-doclet",
+  "-docletpath",
+  "-encoding",
+  "-exclude",
+  "--expand-requires",
+  "-extdirs",
+  "--legal-notices",
+  "--limit-modules",
+  "--module",
+  "--module-path", "-p",
+  "--module-source-path",
+  "--release",
+  "--show-members",
+  "--show-module-contents",
+  "--show-packages",
+  "--show-types",
+  "--source", "-source",
+  "--source-path", "-sourcepath",
+  "-subpackages",
+  "--system",
+  "--upgrade-module-path",
+
+  // Doclet Parameters (Standard)
+  "--add-script",
+  "--add-stylesheet",
+  "-bottom",
+  "-charset",
+  "-d",
+  "-docencoding",
+  "-doctitle",
+  "-excludedocfilessubdir",
+  "-footer",
+  "-group",
+  "-header",
+  "-helpfile",
+  "-link",
+  "--link-modularity-mismatch",
+  "-linkoffline",
+  "--link-platform-properties",
+  "--main-stylesheet", "-stylesheetfile",
+  "-noqualifier",
+  "--override-methods",
+  "-overview",
+  "--since",
+  "--since-label",
+  "--snippet-path",
+  "-sourcetab",
+  "--spec-base-url",
+  "-taglet",
+  "-top",
+  "-windowtitle",
+)
+
+/**
+ * # Javadoc Tool
+ *
+ * Implements an [AbstractTool] adapter to `javadoc`. Arguments are passed to the tool verbatim from the command-line.
+ */
+@ReflectiveAccess @Introspected class JavadocTool private constructor (
+  args: Arguments,
+  env: Environment,
+  override val inputs: JavadocInputs,
+  override val outputs: JavadocOutputs,
+): AbstractGenericTool<JavadocToolProvider, JavadocInputs, JavadocTool.JavadocOutputs>(info = javadoc.extend(
+  args,
+  env,
+).using(
+  inputs = inputs,
+  outputs = outputs.flatten(),
+)) {
+  // Javadoc tool.
+  private val tool by lazy { JavadocToolProvider() }
+
+  // Logging.
+  private val javadocLogger by lazy { Logging.of(JavadocTool::class) }
+
+  override fun createTool(): JavadocToolProvider = tool
+  override val taskDescription: String get() = "Javadoc render"
+  override val toolLogger: Logger get() = javadocLogger
+  override fun toolRun(out: PrintWriter, err: PrintWriter, vararg args: String): Int = createTool().run(out, err, *args)
+
+  /**
+   * Javadoc tool inputs.
+   *
+   * Implements understanding of inputs for `javadoc`.
+   */
+  sealed interface JavadocInputs: Inputs.Files {
+    /**
+     * Provided when no inputs are available.
+     */
+    data object NoInputs: JavadocInputs
+  }
+
+  /**
+   * Javadoc tool outputs.
+   *
+   * Implements understanding of javadoc tool outputs.
+   */
+  sealed interface JavadocOutputs {
+    /**
+     * Flatten into an [Outputs] type.
+     *
+     * @return Outputs value.
+     */
+    fun flatten(): Outputs
+
+    /**
+     * Provided when no outputs are available.
+     */
+    data object NoOutputs: JavadocOutputs, Outputs.None {
+      override fun flatten(): Outputs = this
+    }
+  }
+
+  override fun amendArgs(args: MutableArguments) {
+    args.filter {
+      when (it) {
+        is Argument.KeyValueArg -> it.name == "--legal-notices" && it.value != "none"
+        is Argument.StringArg -> it.asArgumentString().let { str ->
+          str.startsWith("--legal-notices") && !str.endsWith("=none")
+        }
+        else -> false
+      }
+    }.let {
+      if (it.isNotEmpty()) {
+        embeddedToolError(
+          javadoc,
+          "Elide's use of Javadoc doesn't support legal notices yet. Please omit the '--legal-notices' argument.",
+        )
+      }
+    }
+    // force the legal-notices argument to be none
+    (args as MutableArguments.MutableArgumentList).add(
+      Argument.of(
+        "--legal-notices" to "none",
+      )
+    )
+  }
+
+  @CommandLine.Command(
+    name = JAVADOC,
+    description = [JAVADOCTOOL_DESCRIPTION],
+    mixinStandardHelpOptions = false,
+  )
+  @Singleton
+  @ReflectiveAccess
+  @Introspected
+  class JavadocCliTool: DelegatedToolCommand<JavadocTool>(javadoc) {
+    @CommandLine.Spec override lateinit var spec: CommandLine.Model.CommandSpec
+
+    override fun configure(args: Arguments, environment: Environment): JavadocTool = gatherArgs(
+      argNamesThatExpectValues,
+      args,
+    ).let { _ ->
+      JavadocTool(
+        args = args,
+        env = environment,
+        inputs = JavadocInputs.NoInputs,
+        outputs = JavadocOutputs.NoOutputs,
+      )
+    }
+  }
+}

--- a/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
+++ b/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
@@ -1,6 +1,18 @@
 {
   "reflection": [
     {
+      "type": "jdk.javadoc.doclet.StandardDoclet",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
       "type": "org.jetbrains.kotlin.fir.extensions.FirAnalysisHandlerExtension[]",
       "unsafeAllocated": true
     },
@@ -27,6 +39,66 @@
       "allDeclaredFields": true,
       "allDeclaredMethods": true,
       "allDeclaredConstructors": true
+    },
+    {
+      "type": "elide.tool.cli.cmd.tool.jar.JarTool",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": "elide.tool.cli.cmd.tool.jar.JarTool$JarCliTool",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": "elide.tool.cli.cmd.tool.jar.$JarTool$Introspection",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "elide.tool.cli.cmd.tool.jar.$JarTool$JarCliTool$Definition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "elide.tool.cli.cmd.tool.javadoc.JavadocTool",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": "elide.tool.cli.cmd.tool.javadoc.JavadocTool$JavadocCliTool",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": "elide.tool.cli.cmd.tool.javadoc.$JavadocTool$Introspection",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "elide.tool.cli.cmd.tool.javadoc.$JavadocTool$JavadocCliTool$Definition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
       "type": "elide.tool.cli.cmd.tool.DelegatedToolCommand",
@@ -6232,6 +6304,25 @@
   ],
   "resources": [
     {
+      "glob": "resources/releases/element-list-*.txt"
+    },
+    {
+      "module": "jdk.javadoc",
+      "glob": "resources/releases/element-list-*.txt"
+    },
+    {
+      "module": "jdk.javadoc",
+      "glob": "jdk/javadoc/internal/doclets/formats/html/resources/fonts/dejavu.css"
+    },
+    {
+      "module": "jdk.javadoc",
+      "glob": "jdk/javadoc/internal/doclets/formats/html/resources/**"
+    },
+    {
+      "module": "jdk.javadoc",
+      "glob": "jdk/javadoc/internal/doclets/formats/html/resources/legal/jquery.md"
+    },
+    {
       "glob": "org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment$Companion.class"
     },
     {
@@ -6444,6 +6535,41 @@
     {
       "name": "ElideTool",
       "locales": [
+        "en-US"
+      ]
+    },
+    {
+      "name": "jdk.javadoc.internal.tool.resources.javadoc",
+      "locales": [
+        "en",
+        "en-US"
+      ]
+    },
+    {
+      "name": "com.sun.tools.javac.resources.compiler",
+      "locales": [
+        "en",
+        "en-US"
+      ]
+    },
+    {
+      "name": "jdk.javadoc.internal.doclets.toolkit.resources.doclets",
+      "locales": [
+        "en",
+        "en-US"
+      ]
+    },
+    {
+      "name": "jdk.javadoc.internal.doclint.resources.doclint",
+      "locales": [
+        "en",
+        "en-US"
+      ]
+    },
+    {
+      "name": "jdk.javadoc.internal.doclets.formats.html.resources.standard",
+      "locales": [
+        "en",
         "en-US"
       ]
     }

--- a/packages/engine/api/engine.api
+++ b/packages/engine/api/engine.api
@@ -1324,6 +1324,8 @@ public final class elide/tool/Argument$KeyValueArg : elide/tool/Argument {
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Lkotlin/Pair;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lkotlin/Pair;Lkotlin/Pair;)Z
+	public static final fun getName-impl (Lkotlin/Pair;)Ljava/lang/String;
+	public static final fun getValue-impl (Lkotlin/Pair;)Ljava/lang/String;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lkotlin/Pair;)I
 	public fun toString ()Ljava/lang/String;
@@ -1797,6 +1799,9 @@ public final class elide/tool/Inputs$Companion {
 }
 
 public abstract interface class elide/tool/Inputs$Files : elide/tool/Inputs {
+}
+
+public abstract interface class elide/tool/Inputs$None : elide/tool/Inputs {
 }
 
 public abstract interface class elide/tool/Inputs$Values : elide/tool/Inputs {
@@ -2486,6 +2491,9 @@ public abstract interface class elide/tool/Outputs$Disk$File : elide/tool/Output
 }
 
 public abstract interface class elide/tool/Outputs$Memory : elide/tool/Outputs {
+}
+
+public abstract interface class elide/tool/Outputs$None : elide/tool/Outputs {
 }
 
 public abstract interface class elide/tool/Tool {

--- a/packages/engine/src/main/kotlin/elide/tool/Argument.kt
+++ b/packages/engine/src/main/kotlin/elide/tool/Argument.kt
@@ -51,6 +51,8 @@ public sealed interface Argument : Arguments {
    * Argument with a key and a value.
    */
   @JvmInline public value class KeyValueArg internal constructor(private val pair: Pair<String, String>) : Argument {
+    public val name: String get() = pair.first
+    public val value: String get() = pair.second
     override fun ArgumentContext.asArgumentString(): String = "${pair.first}${kvToken}${pair.second}"
     override fun asArgumentSequence(): Sequence<Argument> = sequenceOf(this)
   }

--- a/packages/engine/src/main/kotlin/elide/tool/Outputs.kt
+++ b/packages/engine/src/main/kotlin/elide/tool/Outputs.kt
@@ -21,6 +21,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 public sealed interface Outputs {
   /**
+   * ## Outputs: None.
+   */
+  public interface None : Outputs
+
+  /**
    * ## Outputs: In-memory.
    */
   public sealed interface Memory : Outputs

--- a/tools/scripts/Hello.java
+++ b/tools/scripts/Hello.java
@@ -1,5 +1,16 @@
+package tools.scripts;
 
+/**
+ * Sample Java class.
+ */
 public class Hello {
+  private Hello() {}
+
+  /**
+   * Main program entrypoint.
+   *
+   * @param args Program arguments
+   */
   public static void main(String[] args) {
     System.out.println("Hello Java!");
   }


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds support for standard extra Java tools, including `javadoc` and `jar`.

- [x] Add `elide javadoc ...`
- [x] Add `elide jar ...`
- [x] Working in JVM mode
- [x] Working in native mode

## Changelog
```
feat(cli): implement `jar` tool support
feat(cli): implement `javadoc` tool support
```