### PR TITLE
fix: JAVA_HOME environment variable not passed on to cargo when building rust natives through gradle

### DIFF
--- a/packages/graalvm/build.gradle.kts
+++ b/packages/graalvm/build.gradle.kts
@@ -768,6 +768,7 @@ val buildRustNativesForHostRelease by tasks.registering(Exec::class) {
 
   executable = "cargo"
   args(baseCargoFlags.plus("--release"))
+  environment("JAVA_HOME", System.getProperty("java.home"))
 
   outputs.upToDateWhen { true }
   outputs.dir(targetDir)
@@ -779,6 +780,7 @@ val buildRustNativesForHost by tasks.registering(Exec::class) {
 
   executable = "cargo"
   args(baseCargoFlags.plus(listOfNotNull(if (isRelease) "--release" else null)))
+  environment("JAVA_HOME", System.getProperty("java.home"))
 
   outputs.upToDateWhen { true }
   outputs.dir(targetDir)


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Gradle doesn't expose JAVA_HOME environment variable to exec tasks, which is required by the builder crate.

## Changelog

- fix: JAVA_HOME environment variable not passed on to cargo when building rust natives through gradle