### PR TITLE
fix: missing Serializable annotations

### DIFF
--- a/packages/tooling/src/main/kotlin/elide/tooling/lockfile/ElideLockfile.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/lockfile/ElideLockfile.kt
@@ -172,7 +172,7 @@ private const val FILE_DIGEST_ALG = DEFAULT_DIGEST_ALGORITHM
      *
      * Fingerprint singleton which represents no content; this is used when fingerprinting absent data.
      */
-    public data object NoContent : Fingerprint {
+    @Serializable public data object NoContent : Fingerprint {
       override fun asBytes(): ByteString = ByteString()
     }
 
@@ -181,7 +181,7 @@ private const val FILE_DIGEST_ALG = DEFAULT_DIGEST_ALGORITHM
      *
      * Holds raw fingerprint data; used only when reading a lockfile, when context isn't important.
      */
-    public class RawFingerprint private constructor (
+    @Serializable public class RawFingerprint private constructor (
       private val data: ByteArray,
     ): Fingerprint, JSerializable {
       public companion object {


### PR DESCRIPTION
## Summary

Bug fix for #1444 with `SerializationException` on missing @Serializable annotation on `NoContent` class (+`RawFingerprint`).

P.S: I am not well-known with the code-base and to be honest whether it's appropriate fix (maybe it was supposed to be contextual serializers, so I gave my best guess on the problem). Didn't test, but I believe that it should fix the problem (?).

## Changelog
- fix(cli): fixed a `SerializationException` when running `elide install` by adding `Serializable` annotation.




