### PR TITLE
fix: ability to run `.kt` files directly

### DIFF
--- a/packages/cli/build.gradle.kts
+++ b/packages/cli/build.gradle.kts
@@ -458,6 +458,7 @@ dependencies {
   implementation(mn.micronaut.json.core)
   implementation(libs.kotlin.compiler.embedded)
   implementation(libs.bundles.mordant)
+  implementation(libs.classgraph)
 
   val gvmJarsRoot = rootProject.layout.projectDirectory.dir("third_party/oracle")
   val patchedLibs = files(

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
@@ -104,7 +104,7 @@ import elide.runtime.intrinsics.testing.TestResult
 import elide.runtime.intrinsics.testing.TestingRegistrar
 import elide.runtime.intrinsics.testing.TestingRegistrar.*
 import elide.runtime.plugins.Coverage
-import elide.runtime.plugins.kotlin.shell.GuestKotlinEvaluator
+import elide.runtime.plugins.jvm.Jvm
 import elide.runtime.plugins.vfs.VfsListener
 import elide.runtime.plugins.vfs.vfs
 import elide.runtime.precompiler.Precompiler
@@ -268,8 +268,11 @@ internal class ToolShellCommand @Inject constructor(
   // Whether JVM support has initialized.
   private val jvmInitialized = atomic(false)
 
+  // "Just-in-time," or built-ahead-of-time, JAR target; pre-calculated for JVM compile-and-run.
+  private val runnableJar = atomic<Path?>(null)
+
   // Full JVM classpath; calculated on first JVM init.
-  @Volatile private lateinit var fullClasspath: List<Path>
+  @Volatile private lateinit var fullClasspath: MutableList<Path>
 
   // Java Home to use; calculated on first JVM init.
   @Volatile private var javaHome: String? = null
@@ -1231,10 +1234,6 @@ internal class ToolShellCommand @Inject constructor(
     }
   }
 
-  private fun KotlinJarBundleInfo.asSource(): Source {
-    TODO("Not yet implemented: ${this::class.simpleName}")
-  }
-
   // Resolve a compiler for the provided language, compile the entrypoint, and return the resolved executable symbol.
   private fun compileEntrypoint(language: GuestLanguage, ctxAccessor: ContextAccessor, entry: File): ShellRunnable? {
     return when (language) {
@@ -1255,9 +1254,10 @@ internal class ToolShellCommand @Inject constructor(
 
         runBlocking(Dispatchers.IO) {
           KotlinPrecompiler.precompile(
-            Precompiler.PrecompileSourceRequest(
+            KotlinPrecompiler.PrecompileKotlinRequest(
               sourceInfo,
               config,
+              runnableJar.value,
             ),
             entry.readText(StandardCharsets.UTF_8),
           )
@@ -1268,17 +1268,54 @@ internal class ToolShellCommand @Inject constructor(
               ctxAccessor.invoke()
             )
             is KotlinJarBundleInfo -> {
-              // @TODO some way to patch the classpath earlier
-              println(
-                """
-                  Your Kotlin code was compiled to a JAR; to run it, execute:
-                  elide run ${it.path.absolutePathString()}
-
-                  Or, to run on a regular JVM:
-                  java -jar ${it.path.absolutePathString()}
-                """.trimIndent()
-              )
-              return@let null
+              if (commons().verbose) Statics.logging.info {
+                "Running effective equivalent of 'java -jar ${it.path.absolutePathString()}'"
+              }
+              val entry = when (val specified = it.entrypoint) {
+                null -> error(
+                  "Failed to determine entrypoint for Kotlin precompiled source; no `main.kt` specified or found. " +
+                  "Please specify the entrypoint to run."
+                )
+                else -> specified
+              }
+              ctxAccessor().let { ctx: PolyglotContext ->
+                when (val guestCls = ctx.bindings(Jvm).getMember(entry)) {
+                  null -> error("Failed to locate entry class '${it.name}' (at '$entry')")
+                  else -> when (val mainEntry = guestCls.getMember("main/([Ljava/lang/String;)V")) {
+                    null -> when (val mainNoArgEntry = guestCls.getMember("main/()V")) {
+                      null -> error(
+                        "Failed to locate main entrypoint in class '${it.name}'. Found members: '" +
+                        "${guestCls.memberKeys.joinToString(", ")}'."
+                      )
+                      else -> if (!mainNoArgEntry.canExecute()) {
+                        error("Main no-arg entrypoint in class '${it.name}' is not executable")
+                      } else {
+                        mainNoArgEntry.execute()
+                      }
+                    }
+                    else -> {
+                      if (!mainEntry.canExecute()) {
+                        error("Main entrypoint in class '${it.name}' is not executable")
+                      } else {
+                        // pull all args after `--`
+                        val secondOrderArgs = Statics.args.let { args ->
+                          val positionOfDoubleDash = args.indexOf("--")
+                          if (positionOfDoubleDash < 0) {
+                            emptyArray()
+                          } else {
+                            val secondaryArgs = LinkedList<String>()
+                            for (i in positionOfDoubleDash + 1 until args.size) {
+                              secondaryArgs.add(args[i])
+                            }
+                            secondaryArgs.toTypedArray()
+                          }
+                        }
+                        mainEntry.execute(secondOrderArgs)
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -1385,6 +1422,19 @@ internal class ToolShellCommand @Inject constructor(
 
   // Detect whether we are running in `test` mode (with alias `test` or `tests`).
   private fun testMode(): Boolean = _isTestMode
+
+  private val _jvmEntrypoint by lazy {
+    runnable?.takeIf {
+      it.endsWith(".jar") || it.endsWith(".kt") || it.endsWith(".java") || it.endsWith(".kts")
+    }?.let {
+      Paths.get(it).let {
+        if (it.isAbsolute) it else Paths.get(System.getProperty("user.dir")).resolve(it).absolute()
+      }
+    }
+  }
+
+  // Detect a runnable JAR, Kotlin source, or Java source file as the entrypoint.
+  private fun detectJvmEntrypoint(): Path? = _jvmEntrypoint
 
   // Read an executable script, and then execute the script and keep it started as a server.
   private fun readStartServer(
@@ -1862,16 +1912,20 @@ internal class ToolShellCommand @Inject constructor(
   }
 
   // Amend a base classpath with any additional resolved project dependencies.
-  private fun withProjectClasspath(project: ElideProject, lockfile: ElideLockfile?, base: Sequence<Path>): List<Path> {
+  private fun withProjectClasspath(
+    project: ElideProject,
+    lockfile: ElideLockfile?,
+    base: Sequence<Path>,
+  ): MutableList<Path> {
     return when (project.manifest.dependencies.maven.hasPackages()) {
       // the project doesn't specify any maven dependencies; return the base classpath
-      false -> base.toList()
+      false -> base.toMutableList()
 
       // the project defines maven dependencies; assemble a classpath and return.
       else -> runBlocking {
         withClasspathProvider(project, lockfile, base)?.classpath()?.toList()?.map {
           it.path
-        } ?: emptyList()
+        }?.toMutableList() ?: LinkedList()
       }
     }
   }
@@ -1893,6 +1947,8 @@ internal class ToolShellCommand @Inject constructor(
     project: ElideProject?,
     lockfile: ElideLockfile?,
     langs: Set<GuestLanguage>,
+    intendsToRun: Boolean = false,
+    runnableJarTarget: Path? = null,
   ) {
     val javaHome: String? = getJavaHomeAtRuntime()
     if (javaHome == null) {
@@ -1931,8 +1987,28 @@ internal class ToolShellCommand @Inject constructor(
       emptySequence()
     }
 
+    // fix: if the user intends to run kotlin, or intends to run a JAR, we should provision a path for that JAR unless
+    // the user provides one; nothing needs to be present at this path (yet), we just need to ensure it is known ahead
+    // of time so it can be added to the VM classpath.
+    val runnableJarPath = if (!intendsToRun) null else when (runnableJarTarget) {
+      // with an intent to run on JVM and no explicit JAR path, provision one where we can include things on the guest
+      // VM classpath even after initialization.
+      null -> {
+        // @TODO fix this in a smoother way, without unconditionally initializing a temp path
+        val mainTmpDir = System.getProperty("java.io.tmpdir")
+          ?: error("Failed to resolve temporary directory for JIT-runnable JAR")
+        val uuid = UUID.randomUUID().toString()
+        Paths.get(mainTmpDir).resolve("elide-runner-$uuid.jar")
+      }
+
+      // if the user passes an explicit path to a JAR, prefer that
+      else -> runnableJarTarget
+    }.also {
+      runnableJar.value = it
+    }
+
     val extraHome = System.getenv("KOTLIN_HOME") ?: System.getenv("ELIDE_KOTLIN_HOME")
-    val fullClasspath: List<Path> = (
+    val fullClasspath: MutableList<Path> = (
         when (extraHome) {
           null -> emptySequence()
           else -> initialGuestClasspathJars(Path(extraHome).resolve("lib"))
@@ -1960,7 +2036,13 @@ internal class ToolShellCommand @Inject constructor(
       }.let {
         when (project) {
           // with no active project, just return the initial classpath
-          null -> it.toList()
+          null -> {
+            val mut = LinkedList<Path>()
+            it.forEach { path ->
+              mut.add(path)
+            }
+            mut
+          }
 
           // otherwise, assemble a classpath from the base and any project deps
           else -> withProjectClasspath(project, lockfile, it.asSequence())
@@ -1971,9 +2053,17 @@ internal class ToolShellCommand @Inject constructor(
     if (verbose) Statics.logging.info {
       "Guest classpath: ${fullClasspath.joinToString(":")}"
     }
+
+    // if we have provisioned a just-in-time runnable JAR, add it to the classpath
+    runnableJarPath?.let {
+      if (verbose) Statics.logging.info {
+        "Runnable JAR path: $runnableJarPath"
+      }
+      fullClasspath.add(it)
+    }
     this@ToolShellCommand.fullClasspath = fullClasspath
 
-    configure(elide.runtime.plugins.jvm.Jvm) {
+    configure(Jvm) {
       logging.debug("Configuring JVM")
       resourcesPath = gvmResources
       enableSourceIntegration = testMode()  // we need coverage in test mode, which needs the source loader
@@ -2130,7 +2220,20 @@ internal class ToolShellCommand @Inject constructor(
         JVM, KOTLIN, JAVA, SCALA, GROOVY -> {
           if (!jvmInitialized.value) synchronized(this) {
             jvmInitialized.compareAndSet(false, true)
-            doInitJvmSupport(gvmResources, project, lockfile?.lockfile, langs)
+            detectJvmEntrypoint().let { entryFile ->
+              // if the user provides their own JAR target, use that
+              val jarTarget = if (entryFile?.endsWith(".jar") != true) null else {
+                entryFile
+              }
+              doInitJvmSupport(
+                gvmResources,
+                project,
+                lockfile?.lockfile,
+                langs,
+                intendsToRun = entryFile != null,
+                runnableJarTarget = jarTarget,
+              )
+            }
           }
           when (lang) {
             JAVA -> configure(elide.runtime.plugins.java.Java) {

--- a/packages/engine/api/engine.api
+++ b/packages/engine/api/engine.api
@@ -1188,7 +1188,7 @@ public final class elide/runtime/precompiler/Precompiler$PrecompileSourceInfo : 
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class elide/runtime/precompiler/Precompiler$PrecompileSourceRequest {
+public class elide/runtime/precompiler/Precompiler$PrecompileSourceRequest {
 	public fun <init> (Lelide/runtime/precompiler/Precompiler$SourceInfo;Ljava/lang/Object;)V
 	public final fun getConfig ()Ljava/lang/Object;
 	public final fun getSource ()Lelide/runtime/precompiler/Precompiler$SourceInfo;

--- a/packages/engine/src/main/kotlin/elide/runtime/precompiler/Precompiler.kt
+++ b/packages/engine/src/main/kotlin/elide/runtime/precompiler/Precompiler.kt
@@ -112,7 +112,7 @@ public sealed interface Precompiler<C, I, O> where C : Precompiler.Configuration
    * @param source Information about the source to be compiled.
    * @param config Configuration for the precompiler.
    */
-  public class PrecompileSourceRequest<C>(
+  public open class PrecompileSourceRequest<C>(
     public val source: SourceInfo,
     public val config: C,
   )

--- a/packages/graalvm-kt/api/graalvm-kt.api
+++ b/packages/graalvm-kt/api/graalvm-kt.api
@@ -40,14 +40,17 @@ public abstract interface class elide/runtime/gvm/kotlin/KotlinCompilerConfig$Ko
 }
 
 public final class elide/runtime/gvm/kotlin/KotlinJarBundleInfo : elide/runtime/gvm/kotlin/KotlinRunnable, elide/runtime/precompiler/Precompiler$BundleInfo {
-	public fun <init> (Ljava/lang/String;Ljava/nio/file/Path;)V
+	public fun <init> (Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun apply (Lelide/runtime/core/PolyglotContext;)Lorg/graalvm/polyglot/Value;
 	public synthetic fun apply (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/nio/file/Path;
-	public final fun copy (Ljava/lang/String;Ljava/nio/file/Path;)Lelide/runtime/gvm/kotlin/KotlinJarBundleInfo;
-	public static synthetic fun copy$default (Lelide/runtime/gvm/kotlin/KotlinJarBundleInfo;Ljava/lang/String;Ljava/nio/file/Path;ILjava/lang/Object;)Lelide/runtime/gvm/kotlin/KotlinJarBundleInfo;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;)Lelide/runtime/gvm/kotlin/KotlinJarBundleInfo;
+	public static synthetic fun copy$default (Lelide/runtime/gvm/kotlin/KotlinJarBundleInfo;Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;ILjava/lang/Object;)Lelide/runtime/gvm/kotlin/KotlinJarBundleInfo;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntrypoint ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
 	public fun getPath ()Ljava/nio/file/Path;
 	public fun hashCode ()I
@@ -71,6 +74,12 @@ public final class elide/runtime/gvm/kotlin/KotlinPrecompiler : elide/runtime/pr
 	public static final field INSTANCE Lelide/runtime/gvm/kotlin/KotlinPrecompiler;
 	public synthetic fun invoke (Lelide/runtime/precompiler/Precompiler$PrecompileSourceRequest;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun invoke (Lelide/runtime/precompiler/Precompiler$PrecompileSourceRequest;Ljava/lang/String;)Lelide/runtime/gvm/kotlin/KotlinRunnable;
+}
+
+public final class elide/runtime/gvm/kotlin/KotlinPrecompiler$PrecompileKotlinRequest : elide/runtime/precompiler/Precompiler$PrecompileSourceRequest {
+	public fun <init> (Lelide/runtime/precompiler/Precompiler$SourceInfo;Lelide/runtime/gvm/kotlin/KotlinCompilerConfig;Ljava/nio/file/Path;)V
+	public synthetic fun <init> (Lelide/runtime/precompiler/Precompiler$SourceInfo;Lelide/runtime/gvm/kotlin/KotlinCompilerConfig;Ljava/nio/file/Path;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getJarTarget ()Ljava/nio/file/Path;
 }
 
 public final class elide/runtime/gvm/kotlin/KotlinPrecompiler$Provider : elide/runtime/precompiler/Precompiler$Provider {

--- a/packages/graalvm-kt/src/main/kotlin/elide/runtime/gvm/kotlin/KotlinJarBundleInfo.kt
+++ b/packages/graalvm-kt/src/main/kotlin/elide/runtime/gvm/kotlin/KotlinJarBundleInfo.kt
@@ -10,7 +10,6 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under the License.
  */
-
 @file:OptIn(DelicateElideApi::class)
 
 package elide.runtime.gvm.kotlin
@@ -21,7 +20,13 @@ import elide.runtime.core.DelicateElideApi
 import elide.runtime.core.PolyglotContext
 import elide.runtime.precompiler.Precompiler.BundleInfo
 
-public data class KotlinJarBundleInfo(override val name: String, override val path: Path) : BundleInfo, KotlinRunnable {
+public data class KotlinJarBundleInfo(
+  override val name: String,
+  override val path: Path,
+  public val entrypoint: String? = null,
+) : BundleInfo, KotlinRunnable {
   override fun apply(context: PolyglotContext): Value? = null // Always null: this represents a JAR on disk.
-  override fun toString(): String = "KotlinJarBundleInfo(name='$name', path=$path)"
+  override fun toString(): String {
+    return "KotlinJarBundleInfo(name='$name', path=$path, entrypoint=${entrypoint ?: "<none>"})"
+  }
 }

--- a/packages/graalvm-kt/src/test/kotlin/elide/runtime/gvm/kotlin/KotlinPrecompilerTest.kt
+++ b/packages/graalvm-kt/src/test/kotlin/elide/runtime/gvm/kotlin/KotlinPrecompilerTest.kt
@@ -59,7 +59,7 @@ class KotlinPrecompilerTest {
           KotlinPrecompiler.precompileSafe(
             PrecompileSourceRequest(
               source = PrecompileSourceInfo(
-                name = "Example.kt",
+                name = "main.kt",
               ),
               config = KotlinCompilerConfig.DEFAULT,
             ),

--- a/tools/scripts/a.kt
+++ b/tools/scripts/a.kt
@@ -1,0 +1,3 @@
+fun main() {
+  println("Hello, Kotlin!")
+}


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds some logic to cover some cases where execution of `.kt` files is possible:
- One of the sources is called `main.kt`, or ends in `main.kt`
- There is only one source being run at `<anything>.kt`

In these cases, Elide can predict the class name, so we can reliably build and run, just like we do for `.kts`.

- Fixes #1472 

## Changelog
```
fix: emit better error when running <x>.kt files
fix: ability to run `.kt` files
chore: update api pins
```