### PR TITLE
chore: add initial native-image workflow

### DIFF
--- a/.github/workflows/job.native-image.yml
+++ b/.github/workflows/job.native-image.yml
@@ -1,0 +1,322 @@
+#
+# Copyright (c) 2024 Elide Technologies, Inc.
+#
+# Licensed under the MIT license (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# https://opensource.org/license/mit/
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under the License.
+#
+
+name: Native Image
+
+"on":
+  workflow_dispatch:
+    inputs:
+      ## Input: Enable Release Targets
+      release:
+        description: "Release"
+        type: boolean
+        default: false
+
+      ## Input: Static Linkage
+      static:
+        description: "Static"
+        type: boolean
+        default: false
+
+      ## Input: Runner
+      runner:
+        description: "Runner"
+        type: string
+        default: ubuntu-cipool
+
+  workflow_call:
+    inputs:
+      release:
+        description: "Release"
+        type: boolean
+        default: false
+      static:
+        description: "Static"
+        type: boolean
+        default: false
+      runner:
+        description: "Runner to use"
+        type: string
+        default: ubuntu-latest
+
+    secrets:
+      BUILDLESS_APIKEY:
+        required: false
+        description: "Buildless API Key"
+      BUILDBOT_SERVICE_ACCOUNT:
+        required: false
+        description: "GCP Service Account"
+      BUILDBOT_GHCR_TOKEN:
+        required: false
+        description: "GHCR Token"
+      CODECOV_TOKEN:
+        required: false
+        description: "Codecov token"
+      GRADLE_CONFIGURATION_KEY:
+        required: false
+        description: "Gradle cache key"
+
+env:
+  RUST_BACKTRACE: full
+  ELIDE_VERSION: "1.0.0-beta6"
+  SCCACHE_DIRECT: "true"
+  RUSTC_WRAPPER: "sccache"
+  BUILDLESS_APIKEY: ${{ secrets.BUILDLESS_APIKEY }}
+
+permissions:
+  contents: read
+
+jobs:
+  ##
+  ## Job: Library Build
+  ##
+  gradle:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [Ubuntu]
+        mode: ["Strict"]
+        machine:
+          - ${{ inputs.runner }}
+
+    name: "Native (${{ matrix.os }})"
+    runs-on: ${{ matrix.machine }}
+    continue-on-error: ${{ matrix.mode != 'Strict' }}
+
+    permissions:
+      contents: "read"
+
+    defaults:
+      run:
+        shell: bash
+
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+
+    steps:
+      - name: "Setup: Harden Runner"
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            agent.less.build:443
+            androidx.dev:443
+            api.codecov.io:443
+            api.foojay.io:443
+            api.github.com:443
+            api.nuget.org:443
+            api.sonarcloud.io:443
+            apt.llvm.org:443
+            apt.llvm.org:80
+            azure.archive.ubuntu.com:80
+            bun.sh:443
+            cli.codecov.io:443
+            cli.less.build:443
+            crates.io:443
+            d3ob9fqp587by1.cloudfront.net:443
+            dc.services.visualstudio.com:443
+            dl.elide.dev:443
+            dl.google.com:443
+            dl.less.build:443
+            download-cdn.jetbrains.com:443
+            download.jetbrains.com:443
+            download.oracle.com:443
+            downloads.gradle.org:443
+            ea6ne4j2sb.execute-api.eu-central-1.amazonaws.com:443
+            edge.pkg.st:443
+            elide-snapshots.storage-download.googleapis.com:443
+            elide.sh:80
+            elide.zip:443
+            esm.ubuntu.com:443
+            files.pythonhosted.org:443
+            github.com:22
+            github.com:443
+            global.less.build:443
+            go.dev:443
+            google.com:443
+            gradle.less.build:443
+            gradle.pkg.st:443
+            ha.pool.sks-keyservers.net:11371
+            httpbin.org:443
+            index.crates.io:443
+            ingest.codecov.io:443
+            jcenter.bintray.com:443
+            jitpack.io:443
+            jpms.pkg.st:443
+            keybase.io:443
+            keys.openpgp.org:443
+            keyserver.ubuntu.com:443
+            local.less.build:443
+            maven.elide.dev:443
+            maven.pkg.jetbrains.space:443
+            maven.pkg.st:443
+            mirror.bazel.build:443
+            motd.ubuntu.com:443
+            nodejs.org:443
+            npm.pkg.st:443
+            o26192.ingest.us.sentry.io:443
+            objects.githubusercontent.com:443
+            oss.sonatype.org:443
+            packages.microsoft.com:443
+            pgp.mit.edu:443
+            plugins-artifacts.gradle.org:443
+            plugins.gradle.org:443
+            projectlombok.org:443
+            proxy.golang.org:443
+            pypi.org:443
+            raw.githubusercontent.com:443
+            registry.npmjs.org:443
+            registry.yarnpkg.com:443
+            releases.bazel.build:443
+            repo.maven.apache.org:443
+            repo1.maven.org:443
+            sc-cleancode-sensorcache-eu-central-1-prod.s3.amazonaws.com:443
+            scanner.sonarcloud.io:443
+            scans-in.gradle.com:443
+            services.gradle.org:443
+            sonarcloud.io:443
+            static.crates.io:443
+            static.rust-lang.org:443
+            storage.googleapis.com:443
+            www.google.com:443
+            www.googleapis.com:443
+            ziglang.org:443
+      - name: "Setup: Checkout"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          submodules: true
+          persist-credentials: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Setup: Cache Restore"
+        id: cache-restore
+        uses: buildjet/cache/restore@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+        with:
+          key: elide-v3-build-${{ hashFiles('gradle/elide.versions.toml') }}
+          path: |
+            tools/elide-build/build/**/*.*
+            packages/*/build/**/*.*
+            target/
+            target/x86_64-unknown-linux-gnu/debug/*.a
+            target/x86_64-unknown-linux-gnu/debug/*.so
+            third_party/sqlite/install/
+          restore-keys: |
+            elide-v3-build-${{ hashFiles('gradle/elide.versions.toml') }}
+            elide-v3-
+      - name: "Setup: Rust"
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
+        with:
+          toolchain: stable
+          cache: true # handled by sccache
+          cache-key: "elide-rust-v1-{{ hashFiles('Cargo.lock') }}"
+      - name: "Setup: SCCache"
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - name: "Setup: Rust Caching"
+        run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+      - name: "Setup: GraalVM (Java 24)"
+        uses: graalvm/setup-graalvm@01ed653ac833fe80569f1ef9f25585ba2811baab # v1.3.3
+        with:
+          distribution: "graalvm"
+          java-version: "24"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Setup: Node"
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 23
+      - name: "Setup: Bun"
+        uses: step-security/setup-bun@a961ff54612b97ac3259f517fb6a81be3b657a59 # v2.0.2
+        with:
+          bun-version: "1.2.14"
+      - name: "Setup: PNPM"
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          version: "10.6.2"
+#      - name: "Setup: Elide"
+#        uses: elide-dev/setup-elide@990b915b2974a70e7654acb1303607b4cd1d3538 # v2
+#        with:
+#          version: "1.0.0-beta6"
+      - name: "Setup: uv"
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      - name: "Setup: Dependencies"
+        run: |
+          echo "Setting up venv..."
+          uv venv
+          echo "Activating venv..."
+          . .venv/bin/activate
+          echo "Installing dependencies via Pip..."
+          uv pip install -r config/requirements.txt
+          echo PATH=$PATH >> $GITHUB_ENV
+          echo "Installing dependencies..."
+          pnpm install
+      - name: "Setup: Gradle"
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
+        id: gradlebuild
+        continue-on-error: ${{ matrix.mode == 'labs' }}
+        env:
+          CI: true
+          BUILDLESS_APIKEY: ${{ secrets.BUILDLESS_APIKEY }}
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+        with:
+          cache-read-only: false
+          cache-encryption-key: ${{ secrets.GRADLE_CONFIGURATION_KEY }}
+          dependency-graph: generate-and-submit
+          gradle-home-cache-cleanup: true
+          gradle-home-cache-includes: binaryen
+            caches
+            jdks
+            native
+            native-build-tools
+            nodejs
+            notifications
+            wrapper
+            yarn
+      - name: "Setup: Gradle Settings"
+        run: cp -fv ./.github/workflows/gradle-ci.properties ~/.gradle/gradle.properties
+      - name: "Build Environment"
+        run: file Makefile && make info CI=yes 2>&1 | tee build-info.txt
+      - name: "🛠️ Build Packages"
+        env:
+          CI: true
+          BUILDLESS_APIKEY: ${{ secrets.BUILDLESS_APIKEY }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          TEST_EXCEPTIONS: true
+        run: |
+          ./gradlew \
+            :packages:cli:nativeOptimizedCompile \
+            -x check \
+            -x test \
+            -x jvmTest \
+            --scan \
+            --build-cache \
+            --daemon \
+            --dependency-verification=off \
+            --stacktrace \
+            -Pelide.ci=true \
+            -PbuildSamples=false \
+            -Pelide.optMode=4 \
+            -PbuildDocs=false \
+            -Pelide.stamp=${{ inputs.release }} \
+            -Pelide.pgo=${{ inputs.release }} \
+            -Pelide.static=${{ inputs.static }} \
+            -Pelide.buildMode=${{ inputs.release == true && 'release' || 'dev' }}
+      - name: "Artifact: Build Outputs"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: elide-native-${{ inputs.release == true && 'release' || 'dev' }}-${{ matrix.os }}
+          path: packages/cli/build/native/nativeOptimizedCompile/**/*.*
+      - name: "Artifact: Provenance Subject"
+        id: hash
+        if: ${{ matrix.os == 'ubuntu' && inputs.provenance }}
+        run: |
+          echo "hashes=$(sha256sum ./packages/cli/build/native/nativeOptimizedCompile/elide | base64 -w0)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Adds an initial workflow for building Elide's native image. Need to merge this (whether it's ready or not) so it shows up for manual dispatch.
