### PR TITLE
fix: release script overrides

### DIFF
--- a/.github/workflows/checks.apicheck.yml
+++ b/.github/workflows/checks.apicheck.yml
@@ -164,4 +164,5 @@ jobs:
             -x :packages:graalvm:buildThirdPartyNatives \
             -x :packages:graalvm:buildRustNativesForHost \
             -x :packages:graalvm:natives \
-            --no-configuration-cache
+            --no-configuration-cache \
+            --stacktrace

--- a/.github/workflows/checks.formatting.yml
+++ b/.github/workflows/checks.formatting.yml
@@ -168,4 +168,5 @@ jobs:
             -x :packages:graalvm:buildThirdPartyNatives \
             -x :packages:graalvm:buildRustNativesForHost \
             -x :packages:graalvm:natives \
-            --no-configuration-cache
+            --no-configuration-cache \
+            --stacktrace

--- a/.github/workflows/job.native-image.yml
+++ b/.github/workflows/job.native-image.yml
@@ -300,7 +300,7 @@ jobs:
           echo "${{ inputs.version }}" > ./.version
           echo "${{ inputs.version }}" > ./.release
           sed -i "s/elide = \"${current_version}\"/elide = \"${{ inputs.version }}\"/g" gradle/elide.versions.toml
-          sed -i "s/elide-bin = \"${current_version}\"/elide = \"${{ inputs.version }}\"/g" gradle/elide.versions.toml
+          sed -i "s/elide-bin = \"${current_version}\"/elide-bin = \"${{ inputs.version }}\"/g" gradle/elide.versions.toml
           sed -i "s/${current_version}/${{ inputs.version }}/g" tools/elide-build/src/main/kotlin/elide/internal/conventions/Constants.kt
       - name: "🛠️ Release: Image"
         env:

--- a/.github/workflows/job.native-image.yml
+++ b/.github/workflows/job.native-image.yml
@@ -74,6 +74,18 @@ name: Native Image
         type: boolean
         default: false
 
+      ## Input: Release Packing
+      pack:
+        description: "Pack"
+        type: boolean
+        default: false
+
+      ## Input: Version Override
+      version:
+        description: "Version Override"
+        type: string
+        default: ""
+
   workflow_call:
     inputs:
       release:
@@ -104,6 +116,21 @@ name: Native Image
         description: "PGO"
         type: boolean
         default: false
+      pack:
+        description: "Pack"
+        type: boolean
+        default: false
+      version:
+        description: "Version Override"
+        type: string
+        default: ""
+    outputs:
+      hashes:
+        description: "Provenance Hashes"
+        value: ${{ jobs.gradle.outputs.hashes }}
+      version:
+        description: "Release Version"
+        value: ${{ jobs.gradle.outputs.version }}
 
     secrets:
       BUILDLESS_APIKEY:
@@ -122,9 +149,9 @@ name: Native Image
         required: false
         description: "Gradle cache key"
 
+# Do not add `ELIDE_VERSION` here like other workflows, or it may interfere with the release version override.
 env:
   RUST_BACKTRACE: full
-  ELIDE_VERSION: "1.0.0-beta6"
   SCCACHE_DIRECT: "true"
   RUSTC_WRAPPER: "sccache"
   BUILDLESS_APIKEY: ${{ secrets.BUILDLESS_APIKEY }}
@@ -160,6 +187,10 @@ jobs:
 
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
+      version: ${{ steps.release-prep.outputs.version }}
+      platform: ${{ inputs.os }}-${{ inputs.arch }}
+      releaseArtifact: ${{ steps.pack-artifact.outputs.id }}
+      builtArtifact: ${{ steps.build-artifact.outputs.id }}
 
     steps:
       - name: "Setup: Harden Runner"
@@ -220,10 +251,6 @@ jobs:
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: "10.6.2"
-#      - name: "Setup: Elide"
-#        uses: elide-dev/setup-elide@990b915b2974a70e7654acb1303607b4cd1d3538 # v2
-#        with:
-#          version: "1.0.0-beta6"
       - name: "Setup: uv"
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       - name: "Setup: Dependencies"
@@ -261,9 +288,21 @@ jobs:
             yarn
       - name: "Setup: Gradle Settings"
         run: cp -fv ./.github/workflows/gradle-ci.properties ~/.gradle/gradle.properties
+      - name: "Setup: Cosign"
+        if: inputs.pack
+        uses: sigstore/cosign-installer@fb28c2b6339dcd94da6e4cbcbc5e888961f6f8c3 # v3.9.0
       - name: "Build Environment"
         run: file Makefile && make info CI=yes 2>&1 | tee build-info.txt
-      - name: "🛠️ Build Image"
+      - name: "Overrides: Version"
+        if: inputs.version != ''
+        run: |
+          current_version=$(cat ./.version)
+          echo "${{ inputs.version }}" > ./.version
+          echo "${{ inputs.version }}" > ./.release
+          sed -i "s/elide = \"${current_version}\"/elide = \"${{ inputs.version }}\"/g" gradle/elide.versions.toml
+          sed -i "s/elide-bin = \"${current_version}\"/elide = \"${{ inputs.version }}\"/g" gradle/elide.versions.toml
+          sed -i "s/${current_version}/${{ inputs.version }}/g" tools/elide-build/src/main/kotlin/elide/internal/conventions/Constants.kt
+      - name: "🛠️ Release: Image"
         env:
           CI: true
           BUILDLESS_APIKEY: ${{ secrets.BUILDLESS_APIKEY }}
@@ -292,6 +331,7 @@ jobs:
             -Pelide.buildMode=${{ inputs.release == true && 'release' || 'dev' }}
       - name: "Artifact: Build Outputs"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        id: build-artifact
         with:
           name: elide-native-${{ inputs.release == true && 'release' || 'dev' }}-${{ matrix.os }}-${{ matrix.arch }}
           path: packages/cli/build/native/nativeOptimizedCompile/**/*.*
@@ -300,3 +340,30 @@ jobs:
         if: ${{ matrix.os == 'linux' && inputs.provenance }}
         run: |
           echo "hashes=$(sha256sum ./packages/cli/build/native/nativeOptimizedCompile/elide | base64 -w0)" >> "$GITHUB_OUTPUT"
+      - name: "🛠️ Release: Package"
+        if: inputs.pack
+        run: bash ./tools/scripts/build-release-opt.sh
+      - name: "Release: Prepare"
+        if: inputs.pack
+        id: release-prep
+        working-directory: ./packages/cli/build/native/nativeOptimizedCompile
+        run: |
+          currentVersion=$(cat ./.release)
+          releaseOverride="${{ inputs.version }}"
+          version="${releaseOverride:-$currentVersion}"
+          mkdir -p "release/${{ inputs.os }}-${{ inputs.arch }}/$version"
+          cp -fv elide-*.{tgz,txz,zip}* "release/${{ inputs.os }}-${{ inputs.arch }}/$version/"
+          cp -fv elide.sbom.json "release/${{ inputs.os }}-${{ inputs.arch }}/$version/"
+          cp -fv elide-build-report.html "release/${{ inputs.os }}-${{ inputs.arch }}/$version/elide.build-report.html"
+          mkdir -p staging/release
+          mv "packages/cli/build/native/nativeOptimizedCompile/release staging/
+          echo "version=$version" >> $GITHUB_OUTPUT
+          tree -L 3 staging/
+          echo "Release built."
+      - name: "Artifact: Release Package"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        id: pack-artifact
+        if: inputs.pack
+        with:
+          name: elide-native-${{ inputs.release == true && 'release' || 'dev' }}-${{ matrix.os }}-${{ matrix.arch }}-release.zip
+          path: staging/**/*.*

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,7 +52,7 @@ plugins {
   id("build.less") version ("1.0.0-rc2")
   id("com.autonomousapps.build-health") version ("2.10.1")
   id("com.gradle.enterprise") version ("3.16.2")
-  id("org.gradle.toolchains.foojay-resolver-convention") version ("0.9.0")
+  id("org.gradle.toolchains.foojay-resolver-convention") version ("1.0.0")
   id("com.gradle.common-custom-user-data-gradle-plugin") version ("2.1")
   id("io.micronaut.platform.catalog") version (extra.properties["micronautCatalogVersion"] as String)
   id("elide.toolchains.jvm")

--- a/tools/elide-build/settings.gradle.kts
+++ b/tools/elide-build/settings.gradle.kts
@@ -46,6 +46,7 @@ pluginManagement {
 
 plugins {
   id("com.gradle.enterprise") version("3.16.2")
+  id("org.gradle.toolchains.foojay-resolver-convention") version ("1.0.0")
 }
 
 dependencyResolutionManagement {

--- a/tools/elide-build/src/main/kotlin/elide/internal/conventions/Constants.kt
+++ b/tools/elide-build/src/main/kotlin/elide/internal/conventions/Constants.kt
@@ -212,14 +212,8 @@ public object Constants {
 
   /** Static library configuration values. */
   public object Elide {
-    /** Major library version. */
-    private const val MAJOR_VERSION = "1.0.0"
-
-    /** Major library version tag. */
-    private const val VERSION_TAG = "beta5"
-
     /** Version string for the library. */
-    public const val VERSION: String = "$MAJOR_VERSION-$VERSION_TAG"
+    public const val VERSION: String = "1.0.0-beta6"
 
     /** Maven group shared by Elide artifacts. */
     public const val GROUP: String = "dev.elide"

--- a/tools/scripts/build-release-opt.sh
+++ b/tools/scripts/build-release-opt.sh
@@ -13,12 +13,24 @@
 # License for the specific language governing permissions and limitations under the License.
 #
 
-version=$(cat ./.release)
-platform=$(uname -s | tr '[:upper:]' '[:lower:]')
-arch=$(uname -m)
+# load from `ELIDE_VERSION` or default to `./.release`
+releaseVersion=$(cat ./.release 2>/dev/null || echo "999.0.0")
+version="${ELIDE_VERSION:-$releaseVersion}"
+hostPlatform=$(uname -s | tr '[:upper:]' '[:lower:]')
+platform="${ELIDE_PLATFORM-$hostPlatform}"
+hostArch=$(uname -m)
+arch="${ELIDE_ARCH-$hostArch}"
 variant="opt"
-
 archive_prefix="elide"
+
+echo "----------------------------------------------------"
+
+echo "Elide Release Builder"
+echo "- Version: $version"
+echo "- Platform: $platform"
+echo "- Architecture: $arch"
+
+echo "----------------------------------------------------"
 
 if [ "$arch" = "arm64" ]; then
   arch="aarch64"


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Allows overrides for `platform`, `version`, and `arch` values in the release script, which clears the way for automated snapshot releasing in GHA.