### PR TITLE
fix: `elide init` flags and conveniences

### DIFF
--- a/packages/cli/src/main/kotlin/elide/tool/cli/AbstractSubcommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/AbstractSubcommand.kt
@@ -43,6 +43,7 @@ import elide.runtime.core.PolyglotContext
 import elide.runtime.core.PolyglotEngine
 import elide.runtime.core.PolyglotEngineConfiguration
 import elide.runtime.telemetry.RunEvent
+import elide.runtime.telemetry.TelemetryConfig
 import elide.tool.cli.err.AbstractToolError
 import elide.tool.cli.options.CommonOptions
 import elide.tool.cli.options.TelemetryOptions
@@ -535,8 +536,11 @@ fun AbstractTool.EmbeddedToolError.render(logging: Logger, ctx: AbstractSubcomma
   }
 
   // Send a telemetry event if configured.
-  @Suppress("TooGenericExceptionCaught")
+  @Suppress("TooGenericExceptionCaught", "KotlinConstantConditions")
   private fun sendRunEvent(start: TimeSource.Monotonic.ValueTimeMark) {
+    if (!TelemetryConfig.ENABLED) {
+      return
+    }
     try {
       telemetry.sendRunEvent(
         mode = RunEvent.ExecutionMode.Run,
@@ -579,9 +583,6 @@ fun AbstractTool.EmbeddedToolError.render(logging: Logger, ctx: AbstractSubcomma
    */
   override suspend fun Context.invoke(state: CommandState): CommandResult = use {
     val start = TimeSource.Monotonic.markNow()
-
-    // if the user has disabled telemetry in any way, we need to neuter it early
-    telemetry.manager().disableTelemetry()
 
     // allow the subclass to register its own shared resources
     sharedResources.addAll(initialize())

--- a/packages/telemetry/api/telemetry.api
+++ b/packages/telemetry/api/telemetry.api
@@ -165,6 +165,14 @@ public final class elide/runtime/telemetry/RunEvent$ExecutionMode : java/lang/En
 	public static fun values ()[Lelide/runtime/telemetry/RunEvent$ExecutionMode;
 }
 
+public final class elide/runtime/telemetry/TelemetryConfig {
+	public static final field ENABLED Z
+	public static final field ENDPOINT Ljava/lang/String;
+	public static final field HOSTNAME Ljava/lang/String;
+	public static final field INSTANCE Lelide/runtime/telemetry/TelemetryConfig;
+	public static final field PATH Ljava/lang/String;
+}
+
 public synthetic class elide/runtime/telemetry/client/$DefaultTelemetryClient$Definition : io/micronaut/context/AbstractInitializableBeanDefinitionAndReference {
 	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
 	public fun <init> ()V

--- a/packages/telemetry/src/main/kotlin/elide/runtime/telemetry/TelemetryConfig.kt
+++ b/packages/telemetry/src/main/kotlin/elide/runtime/telemetry/TelemetryConfig.kt
@@ -15,8 +15,9 @@ package elide.runtime.telemetry
 /**
  * Provides access to static telemetry service configuration.
  */
-internal object TelemetryConfig {
-  const val HOSTNAME: String = "telemetry.elide.dev"
-  const val PATH: String = "/v1/event:submit"
-  const val ENDPOINT: String = "https://$HOSTNAME$PATH"
+public object TelemetryConfig {
+  public const val ENABLED: Boolean = false
+  public const val HOSTNAME: String = "telemetry.elide.dev"
+  public const val PATH: String = "/v1/event:submit"
+  public const val ENDPOINT: String = "https://$HOSTNAME$PATH"
 }


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Small conveniences and fixes for `elide init`.

## Changelog
```
fix: don't prompt about overwrite for empty dirs
chore: add `--yes` flag to `elide init`
chore: properly enforce `--force` flag
```