### PR TITLE
feat: pluggable runner jvms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,6 +3579,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "njvm"
+version = "1.0.0-beta7"
+dependencies = [
+ "builder",
+ "java_native",
+ "jni",
+ "lazy_static",
+]
+
+[[package]]
 name = "node-maintainer"
 version = "0.3.34"
 source = "git+https://github.com/elide-dev/orogene?rev=b588243194126dda6899041317ef765c9e383827#b588243194126dda6899041317ef765c9e383827"

--- a/crates/njvm/Cargo.toml
+++ b/crates/njvm/Cargo.toml
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2024-2025 Elide Technologies, Inc.
+#
+# Licensed under the MIT license (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# https://opensource.org/license/mit/
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under the License.
+#
+
+[package]
+name = "njvm"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+
+[lib]
+crate-type = ["lib", "staticlib", "cdylib"]
+
+[features]
+
+[build-dependencies]
+builder = { workspace = true }
+
+[dependencies]
+java_native = { workspace = true }
+jni = { workspace = true, default-features = false, features = ["invocation"] }
+lazy_static = { workspace = true }

--- a/crates/njvm/src/lib.rs
+++ b/crates/njvm/src/lib.rs
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+use jni::{InitArgsBuilder, JNIVersion, JavaVM};
+use lazy_static::lazy_static;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+lazy_static! {
+  static ref ACTIVE_JVM: Arc<Mutex<Option<NativeJVM>>> = Arc::new(Mutex::new(None));
+}
+
+// Atomic flips when a JVM is initialized.
+static JVM_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+/// Native Java Virtual Machine
+///
+/// Manages state with regard to a running in-process JVM.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct NativeJVM {
+  vm: JavaVM,
+}
+
+impl NativeJVM {
+  #[allow(dead_code)]
+  fn java_vm(&self) -> &JavaVM {
+    &self.vm
+  }
+}
+
+/// Create JVM
+///
+/// Prepares and launches a native JVM which can then be obtained and manipulated through module-level functions.
+fn create_jvm(args: Vec<String>) -> NativeJVM {
+  let mut jvm_args_builder = InitArgsBuilder::new().version(JNIVersion::V21);
+
+  for arg in args.iter() {
+    let cstr = arg.as_str();
+    jvm_args_builder = jvm_args_builder.option(cstr);
+  }
+
+  let finalized_args = jvm_args_builder
+    .build()
+    .expect("failed to build jvm init args");
+
+  // Create a new VM
+  NativeJVM {
+    vm: JavaVM::new(finalized_args).expect("failed to create jvm instance"),
+  }
+}
+
+/// Create or use JVM
+///
+/// Initializes a JVM if none is running, using the provided `args`, and then returns a reference to the JVM instance.
+pub fn create_or_use_jvm(args: Vec<String>) -> NativeJVM {
+  let mut engine = ACTIVE_JVM.lock().unwrap();
+  if engine.is_none() {
+    let runtime = create_jvm(args);
+    *engine = Some(runtime);
+    JVM_INITIALIZED.store(true, Ordering::SeqCst);
+  }
+  let mut jvm = ACTIVE_JVM.lock().unwrap();
+  if let Some(runtime) = jvm.take() {
+    runtime
+  } else {
+    panic!("JVM was not initialized, but is expected to be.");
+  }
+}
+
+/// Obtain JVM
+///
+/// Obtain a reference to the running JVM instance, if any.
+pub fn obtain_jvm() -> Option<NativeJVM> {
+  match ACTIVE_JVM.lock() {
+    Ok(engine) => engine.clone(),
+    Err(_) => None, // If the lock is poisoned, return None
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -74,10 +74,10 @@ gradle.enterprise.testretry.enabled = false
 systemProp.gradle.enterprise.testretry.enabled = false
 
 # Settings: Languages / Runtimes
-versions.java.language = 22
+versions.java.language = 21
 versions.java.toolchain = 24
-versions.java.minimum = 22
-versions.java.target = 22
+versions.java.minimum = 21
+versions.java.target = 21
 versions.kotlin.sdk = 2.2.0
 versions.kotlin.language = 2.1
 versions.android.sdk.target = 33

--- a/packages/cli/build.gradle.kts
+++ b/packages/cli/build.gradle.kts
@@ -462,6 +462,7 @@ dependencies {
   implementation(projects.packages.terminal)
   implementation(projects.packages.localAi)
   implementation(projects.packages.telemetry)
+  implementation(projects.packages.runner)
   implementation(libs.dirs)
   implementation(libs.snakeyaml)
   implementation(mn.micronaut.json.core)

--- a/packages/cli/src/main/kotlin/elide/tool/cli/options/EngineJvmOptions.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/options/EngineJvmOptions.kt
@@ -29,4 +29,11 @@ import elide.tool.cli.GuestLanguage
     defaultValue = "false",
   )
   override var debug: Boolean = false
+
+  @Option(
+    names = ["--jvm:espresso"],
+    description = ["Prefer Espresso over standard JVMs"],
+    defaultValue = "false",
+  )
+  var preferEspresso: Boolean = false
 }

--- a/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
+++ b/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
@@ -868,7 +868,15 @@
       "type": "com.google.common.jimfs.SystemJimfsFileSystemProvider",
       "allDeclaredFields": true,
       "allDeclaredMethods": true,
-      "allDeclaredConstructors": true
+      "allDeclaredConstructors": true,
+      "methods": [
+        {
+          "name": "removeFileSystemRunnable",
+          "parameterTypes": [
+            "java.net.URI"
+          ]
+        }
+      ]
     },
     {
       "type": "com.google.common.util.concurrent.AbstractFutureState",
@@ -1256,6 +1264,17 @@
       ]
     },
     {
+      "type": "elide.runtime.core.internals.graalvm.GraalVMConfiguration",
+      "fields": [
+        {
+          "name": "entrypointArgs$volatile"
+        },
+        {
+          "name": "initialized$volatile"
+        }
+      ]
+    },
+    {
       "type": "elide.runtime.diag.DiagnosticsContainer",
       "fields": [
         {
@@ -1416,6 +1435,17 @@
         {
           "name": "<init>",
           "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "elide.runtime.gvm.internals.intrinsics.js.abort.AbortSignal",
+      "fields": [
+        {
+          "name": "abortReason$volatile"
+        },
+        {
+          "name": "didAbort$volatile"
         }
       ]
     },
@@ -2801,6 +2831,54 @@
         {
           "name": "<init>",
           "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "elide.runtime.runner.AbstractRunner",
+      "fields": [
+        {
+          "name": "activeContext$volatile"
+        },
+        {
+          "name": "activeJob$volatile"
+        },
+        {
+          "name": "closed$volatile"
+        },
+        {
+          "name": "coroutines$volatile"
+        },
+        {
+          "name": "initialized$volatile"
+        }
+      ]
+    },
+    {
+      "type": "elide.runtime.runner.AbstractRunnerJob",
+      "fields": [
+        {
+          "name": "allArguments$volatile"
+        },
+        {
+          "name": "currentInputs$volatile"
+        },
+        {
+          "name": "currentOutputs$volatile"
+        }
+      ]
+    },
+    {
+      "type": "elide.runtime.runner.jvm.EspressoJvmRunner"
+    },
+    {
+      "type": "elide.runtime.runner.jvm.StandardJvmRunner",
+      "fields": [
+        {
+          "name": "resolvedJavaHome$volatile"
+        },
+        {
+          "name": "runnerOptions$volatile"
         }
       ]
     },
@@ -4398,7 +4476,23 @@
       "type": "elide.tooling.project.manifest.ElidePackageManifest$KotlinFeatureOptions",
       "allDeclaredFields": true,
       "allDeclaredMethods": true,
-      "allDeclaredConstructors": true
+      "allDeclaredConstructors": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "boolean",
+            "boolean",
+            "boolean",
+            "boolean",
+            "boolean",
+            "boolean",
+            "boolean",
+            "boolean",
+            "boolean"
+          ]
+        }
+      ]
     },
     {
       "type": "elide.tooling.project.manifest.ElidePackageManifest$KotlinJvmCompilerOptions",
@@ -11527,6 +11621,9 @@
     },
     {
       "glob": "META-INF/services/elide.runtime.intrinsics.GuestIntrinsic"
+    },
+    {
+      "glob": "META-INF/services/elide.runtime.runner.Runner"
     },
     {
       "glob": "META-INF/services/elide.tooling.config.BuildConfigurator"

--- a/packages/exec/build.gradle.kts
+++ b/packages/exec/build.gradle.kts
@@ -11,6 +11,7 @@
  * License for the specific language governing permissions and limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import elide.internal.conventions.kotlin.KotlinTarget
 import elide.toolchain.host.TargetInfo
 
@@ -28,6 +29,7 @@ elide {
     explicitApi = true
     customKotlinCompilerArgs += listOf("-Xcontext-receivers")
   }
+
   checks {
     diktat = false
   }

--- a/packages/graalvm/build.gradle.kts
+++ b/packages/graalvm/build.gradle.kts
@@ -119,7 +119,6 @@ elide {
 
   jvm {
     alignVersions = true
-    target = JvmTarget.JVM_22
   }
 
   java {

--- a/packages/runner/api/runner.api
+++ b/packages/runner/api/runner.api
@@ -1,0 +1,148 @@
+public abstract class elide/runtime/runner/AbstractRunner : elide/runtime/runner/Runner {
+	public fun <init> (Ljava/lang/String;)V
+	public fun accept (Lelide/runtime/runner/RunnerJob;)V
+	public synthetic fun accept (Ljava/lang/Object;)V
+	public fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun close ()V
+	public fun configure (Lorg/graalvm/polyglot/Context;Lkotlin/coroutines/CoroutineContext;)V
+	protected final fun err (Ljava/lang/String;ILjava/lang/Throwable;)Lelide/runtime/runner/RunnerOutcome;
+	public static synthetic fun err$default (Lelide/runtime/runner/AbstractRunner;Ljava/lang/String;ILjava/lang/Throwable;ILjava/lang/Object;)Lelide/runtime/runner/RunnerOutcome;
+	public fun getInfo ()Lelide/runtime/runner/RunnerInfo;
+	protected abstract fun invoke (Lelide/runtime/runner/RunnerExecution;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun invoke (Lelide/runtime/runner/RunnerJob;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun poll ()Lkotlinx/coroutines/Deferred;
+	protected final fun success ()Lelide/runtime/runner/RunnerOutcome;
+}
+
+public abstract class elide/runtime/runner/AbstractRunnerJob : elide/runtime/runner/RunnerJob {
+	public fun <init> ()V
+	public fun <init> (Lelide/tooling/Arguments;)V
+	public synthetic fun <init> (Lelide/tooling/Arguments;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun configure (Lelide/tooling/Inputs;Lelide/tooling/Outputs;Lelide/tooling/Arguments;)V
+	public static synthetic fun configure$default (Lelide/runtime/runner/AbstractRunnerJob;Lelide/tooling/Inputs;Lelide/tooling/Outputs;Lelide/tooling/Arguments;ILjava/lang/Object;)V
+	public fun getArguments ()Lelide/tooling/Arguments;
+	public fun getInputs ()Lelide/tooling/Inputs;
+	public fun getOutputs ()Lelide/tooling/Outputs;
+}
+
+public final class elide/runtime/runner/AbstractRunnerJob$NoInputs : elide/tooling/Inputs$None {
+	public static final field INSTANCE Lelide/runtime/runner/AbstractRunnerJob$NoInputs;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/runtime/runner/AbstractRunnerJob$NoOutputs : elide/tooling/Outputs$None {
+	public static final field INSTANCE Lelide/runtime/runner/AbstractRunnerJob$NoOutputs;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class elide/runtime/runner/JvmRunner : elide/runtime/runner/Runner$BytecodeRunner {
+	public static final field Companion Lelide/runtime/runner/JvmRunner$Companion;
+	public static fun create (Lkotlin/Pair;Lelide/tooling/Classpath;Lelide/tooling/Modulepath;Lelide/tooling/Arguments;Lelide/tooling/Environment;)Lelide/runtime/runner/JvmRunner$JvmRunnerJob;
+	public static fun of (Ljava/lang/String;Lelide/tooling/Classpath;Lelide/tooling/Arguments;Lelide/tooling/Environment;)Lelide/runtime/runner/JvmRunner$JvmRunnerJob;
+}
+
+public final class elide/runtime/runner/JvmRunner$Companion {
+	public final fun create (Lkotlin/Pair;Lelide/tooling/Classpath;Lelide/tooling/Modulepath;Lelide/tooling/Arguments;Lelide/tooling/Environment;)Lelide/runtime/runner/JvmRunner$JvmRunnerJob;
+	public static synthetic fun create$default (Lelide/runtime/runner/JvmRunner$Companion;Lkotlin/Pair;Lelide/tooling/Classpath;Lelide/tooling/Modulepath;Lelide/tooling/Arguments;Lelide/tooling/Environment;ILjava/lang/Object;)Lelide/runtime/runner/JvmRunner$JvmRunnerJob;
+	public final fun of (Ljava/lang/String;Lelide/tooling/Classpath;Lelide/tooling/Arguments;Lelide/tooling/Environment;)Lelide/runtime/runner/JvmRunner$JvmRunnerJob;
+	public static synthetic fun of$default (Lelide/runtime/runner/JvmRunner$Companion;Ljava/lang/String;Lelide/tooling/Classpath;Lelide/tooling/Arguments;Lelide/tooling/Environment;ILjava/lang/Object;)Lelide/runtime/runner/JvmRunner$JvmRunnerJob;
+}
+
+public final class elide/runtime/runner/JvmRunner$JvmRunnerJob : elide/runtime/runner/AbstractRunnerJob, elide/runtime/runner/RunnerJob$RunBytecode {
+	public final fun getClasspath ()Lelide/tooling/Classpath;
+	public final fun getEnvironment ()Lelide/tooling/Environment;
+	public final fun getJvmArgs ()Lelide/tooling/Arguments;
+	public final fun getMainClass ()Ljava/lang/String;
+	public final fun getMainModule ()Ljava/util/Optional;
+	public final fun getModulepath ()Lelide/tooling/Modulepath;
+}
+
+public abstract interface class elide/runtime/runner/Runner : java/lang/AutoCloseable, java/util/function/Consumer {
+	public abstract fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun configure (Lorg/graalvm/polyglot/Context;Lkotlin/coroutines/CoroutineContext;)V
+	public fun eligible (Lelide/runtime/runner/JvmRunner$JvmRunnerJob;)Z
+	public abstract fun getInfo ()Lelide/runtime/runner/RunnerInfo;
+	public abstract fun invoke (Lelide/runtime/runner/RunnerJob;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun poll ()Lkotlinx/coroutines/Deferred;
+}
+
+public abstract interface class elide/runtime/runner/Runner$BytecodeRunner : elide/runtime/runner/Runner {
+}
+
+public abstract interface class elide/runtime/runner/Runner$NativeRunner : elide/runtime/runner/Runner {
+}
+
+public abstract interface class elide/runtime/runner/Runner$SourceRunner : elide/runtime/runner/Runner {
+}
+
+public abstract interface class elide/runtime/runner/RunnerExecution {
+	public abstract fun getContext ()Lorg/graalvm/polyglot/Context;
+	public abstract fun getJob ()Lelide/runtime/runner/RunnerJob;
+}
+
+public abstract interface class elide/runtime/runner/RunnerInfo {
+	public abstract fun getExits ()Z
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract interface class elide/runtime/runner/RunnerJob {
+	public abstract fun getArguments ()Lelide/tooling/Arguments;
+	public abstract fun getInputs ()Lelide/tooling/Inputs;
+	public abstract fun getOutputs ()Lelide/tooling/Outputs;
+}
+
+public abstract interface class elide/runtime/runner/RunnerJob$RunBytecode : elide/runtime/runner/RunnerJob {
+}
+
+public abstract interface class elide/runtime/runner/RunnerJob$RunNative : elide/runtime/runner/RunnerJob {
+}
+
+public abstract interface class elide/runtime/runner/RunnerJob$RunSources : elide/runtime/runner/RunnerJob {
+}
+
+public abstract interface class elide/runtime/runner/RunnerOutcome {
+	public abstract fun getExit ()I
+	public abstract fun isSuccess ()Z
+}
+
+public final class elide/runtime/runner/RunnerOutcome$Failure : java/lang/Record, elide/runtime/runner/RunnerOutcome {
+	public fun <init> (ILjava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun cause ()Ljava/lang/Throwable;
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Throwable;
+	public final fun copy (ILjava/lang/String;Ljava/lang/Throwable;)Lelide/runtime/runner/RunnerOutcome$Failure;
+	public static synthetic fun copy$default (Lelide/runtime/runner/RunnerOutcome$Failure;ILjava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)Lelide/runtime/runner/RunnerOutcome$Failure;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun exit ()I
+	public synthetic fun getExit ()I
+	public fun hashCode ()I
+	public fun isSuccess ()Z
+	public final fun message ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/runtime/runner/RunnerOutcome$Success : elide/runtime/runner/RunnerOutcome {
+	public static final field INSTANCE Lelide/runtime/runner/RunnerOutcome$Success;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getExit ()I
+	public fun hashCode ()I
+	public fun isSuccess ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/runtime/runner/Runners {
+	public static final field INSTANCE Lelide/runtime/runner/Runners;
+	public static final fun all ()Ljava/util/List;
+	public static final fun jvm (Lelide/runtime/runner/JvmRunner$JvmRunnerJob;Ljava/lang/Boolean;)Ljava/util/List;
+	public static synthetic fun jvm$default (Lelide/runtime/runner/JvmRunner$JvmRunnerJob;Ljava/lang/Boolean;ILjava/lang/Object;)Ljava/util/List;
+}
+
+public abstract interface class elide/runtime/runner/TruffleRunner {
+}
+

--- a/packages/runner/build.gradle.kts
+++ b/packages/runner/build.gradle.kts
@@ -10,3 +10,67 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under the License.
  */
+import elide.internal.conventions.kotlin.KotlinTarget
+import elide.internal.conventions.publishing.publish
+import elide.toolchain.host.TargetInfo
+
+plugins {
+  kotlin("jvm")
+  kotlin("plugin.serialization")
+  alias(libs.plugins.ksp)
+  alias(libs.plugins.micronaut.minimal.library)
+  alias(libs.plugins.micronaut.graalvm)
+  alias(libs.plugins.elide.conventions)
+}
+
+group = "dev.elide"
+
+elide {
+  publishing {
+    id = "runner"
+    name = "Elide Runner"
+    description = "Logic package for Elide's runner features."
+
+    publish("jvm") {
+      from(components["kotlin"])
+    }
+  }
+
+  kotlin {
+    target = KotlinTarget.JVM
+    explicitApi = true
+    ksp = true
+  }
+
+  java {
+    // disable module-info processing (not present)
+    configureModularity = false
+  }
+
+  checks {
+    diktat = false
+  }
+}
+
+val elideTarget = TargetInfo.current(project)
+
+dependencies {
+  api(mn.micronaut.core)
+  api(projects.packages.base)
+  api(projects.packages.exec)
+  api(projects.packages.tooling)
+  api(libs.graalvm.polyglot)
+  api(libs.kotlinx.coroutines.core)
+  api(libs.guava)
+
+  testApi(projects.packages.base)
+  testImplementation(projects.packages.test)
+  testImplementation(projects.packages.graalvmJvm)
+  testAnnotationProcessor(mn.micronaut.inject.java)
+  testImplementation(libs.graalvm.espresso.polyglot)
+  testImplementation(libs.graalvm.espresso.language)
+}
+
+tasks.test {
+  jvmArgs("-Dpolyglot.engine.WarnInterpreterOnly=false")
+}

--- a/packages/runner/build.gradle.kts
+++ b/packages/runner/build.gradle.kts
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under the License.
  */
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import elide.internal.conventions.kotlin.KotlinTarget
 import elide.internal.conventions.publishing.publish
 import elide.toolchain.host.TargetInfo

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/AbstractRunner.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/AbstractRunner.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+import org.graalvm.polyglot.Context
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlin.coroutines.CoroutineContext
+import elide.runtime.runner.base.RunnerInfoImpl
+
+/**
+ * ## Abstract Runner
+ *
+ * An abstract base class for implementing a [Runner] that can execute jobs of type [T]. This class provides basic
+ * functionality for managing the runner's lifecycle, including initialization, job acceptance, and execution.
+ */
+public abstract class AbstractRunner<T: RunnerJob>(private val name: String) : Runner<T> {
+  private val initialized = atomic(false)
+  private val closed = atomic(false)
+  private val activeContext = atomic<Context?>(null)
+  private val coroutines = atomic<CoroutineContext?>(null)
+  private val activeJob = atomic<Deferred<RunnerOutcome>?>(null)
+
+  // Use the runner's internals, but only in an active and initialized state.
+  private inline fun <R> withActive(block: () -> R): R {
+    require(!closed.value) { "Runner is closed" }
+    require(initialized.value) { "Runner is not initialized" }
+    return block()
+  }
+
+  override val info: RunnerInfo get() = RunnerInfoImpl(
+    name = name,
+  )
+
+  override fun close() {
+    closed.value = true
+  }
+
+  override fun accept(job: T): Unit = withActive {
+    runBlocking {
+      coroutineScope {
+        activeJob.value = async(requireNotNull(coroutines.value), start = kotlinx.coroutines.CoroutineStart.DEFAULT) {
+          invoke(object: RunnerExecution<T> {
+            override val job: T = job
+            override val context: Context = requireNotNull(activeContext.value) { "Context not ready for execution" }
+          })
+        }
+      }
+    }
+  }
+
+  override fun configure(context: Context, coroutineContext: CoroutineContext) {
+    activeContext.value = context
+    coroutines.value = coroutineContext
+    initialized.value = true
+  }
+
+  override fun poll(): Deferred<RunnerOutcome>? = withActive {
+    activeJob.value
+  }
+
+  override suspend fun await(): RunnerOutcome = withActive {
+    requireNotNull(activeJob.value).await()
+  }
+
+  override suspend fun invoke(job: T): RunnerOutcome {
+    accept(job)
+    return await()
+  }
+
+  /**
+   * Emit an error as the outcome of the current job.
+   *
+   * @param message The error message to emit.
+   * @param exitCode The exit code to use for the error outcome; if none is specified, this defaults to `1`.
+   * @param cause An optional [Throwable] cause for the error.
+   * @return A [RunnerOutcome] representing the error.
+   */
+  protected fun err(message: String, exitCode: Int = 1, cause: Throwable? = null): RunnerOutcome {
+    return RunnerOutcome.Failure(
+      message = message,
+      exit = exitCode,
+      cause = cause,
+    )
+  }
+
+  /**
+   * Emit a successful outcome for the current job.
+   *
+   * @return A [RunnerOutcome] representing a successful execution.
+   */
+  protected fun success(): RunnerOutcome = RunnerOutcome.Success
+
+  /**
+   * ### Invoke with Job
+   *
+   * Invokes this runner with the given [exec] job, prepared by the internals of this class from a [RunnerJob] instance
+   * of type [T]. The resulting job is a [Deferred] instance that yields a [RunnerOutcome] when completed.
+   *
+   * @param exec The [RunnerExecution] to invoke this runner with.
+   * @return A [Deferred] instance that yields a [RunnerOutcome].
+   */
+  protected abstract suspend operator fun invoke(exec: RunnerExecution<T>): RunnerOutcome
+}

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/AbstractRunner.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/AbstractRunner.kt
@@ -51,13 +51,11 @@ public abstract class AbstractRunner<T: RunnerJob>(private val name: String) : R
 
   override fun accept(job: T): Unit = withActive {
     runBlocking {
-      coroutineScope {
-        activeJob.value = async(requireNotNull(coroutines.value), start = kotlinx.coroutines.CoroutineStart.DEFAULT) {
-          invoke(object: RunnerExecution<T> {
-            override val job: T = job
-            override val context: Context = requireNotNull(activeContext.value) { "Context not ready for execution" }
-          })
-        }
+      activeJob.value = async(requireNotNull(coroutines.value), start = kotlinx.coroutines.CoroutineStart.DEFAULT) {
+        invoke(object: RunnerExecution<T> {
+          override val job: T = job
+          override val context: Context = requireNotNull(activeContext.value) { "Context not ready for execution" }
+        })
       }
     }
   }

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/AbstractRunnerJob.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/AbstractRunnerJob.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+import kotlinx.atomicfu.atomic
+import elide.tooling.Arguments
+import elide.tooling.Inputs
+import elide.tooling.Outputs
+
+/**
+ * ## Abstract Runner Job
+ *
+ * Describes the abstract base implementation of a [RunnerJob], regardless of type or underlying behavior; runner jobs
+ * may collect inputs, outputs, arguments, and other environment information, and then are passed to [Runner] instances
+ * for execution.
+ */
+public abstract class AbstractRunnerJob (args: Arguments? = null) : RunnerJob {
+  private val currentInputs = atomic<Inputs?>(null)
+  private val currentOutputs = atomic<Outputs?>(null)
+  private val allArguments = atomic<Arguments>(args ?: Arguments.empty())
+
+  /** Signifies no inputs. */
+  public data object NoInputs : Inputs.None
+
+  /** Signifies no outputs. */
+  public data object NoOutputs : Outputs.None
+
+  /**
+   * Configure this runner job with the given inputs, outputs, and arguments.
+   *
+   * @param inputs Inputs to configure this job with, or `null` to signify no inputs.
+   * @param outputs Outputs to configure this job with, or `null` to signify no outputs.
+   * @param arguments Arguments to configure this job with, or an empty set of arguments.
+   */
+  public fun configure(
+    inputs: Inputs? = null,
+    outputs: Outputs? = null,
+    arguments: Arguments = Arguments.empty(),
+  ) {
+    currentInputs.value = inputs ?: NoInputs
+    currentOutputs.value = outputs ?: NoOutputs
+    allArguments.value = arguments
+  }
+
+  override val inputs: Inputs get() = (currentInputs.value ?: NoInputs)
+  override val outputs: Outputs get() = (currentOutputs.value ?: NoOutputs)
+  override val arguments: Arguments get() = allArguments.value
+}

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/JvmRunner.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/JvmRunner.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+import java.util.Optional
+import elide.tooling.Arguments
+import elide.tooling.Classpath
+import elide.tooling.Environment
+import elide.tooling.Modulepath
+
+/**
+ * ## JVM Runner
+ *
+ * Extends the base concept of a [Runner.BytecodeRunner] for use as a JVM-specific runner; gathers JVM-style arguments
+ * and inputs and then executes them in a given JVM-like environment.
+ */
+public interface JvmRunner : Runner.BytecodeRunner<JvmRunner.JvmRunnerJob> {
+  /**
+   * ### JVM Runner Job
+   *
+   * @property mainClass Main class to execute.
+   * @property mainModule Optional main module within which the main class resides, if applicable.
+   * @property classpath Classpath to use for the job.
+   * @property modulepath Optional modulepath to use for the job, if applicable.
+   * @property environment Optional environment to use for the job, if applicable.
+   * @property jvmArgs JVM arguments to use for the job, if applicable.
+   * @param args Arguments to pass to the job.
+   */
+  public class JvmRunnerJob internal constructor (
+    public val mainClass: String,
+    public val mainModule: Optional<String>,
+    public val classpath: Classpath,
+    public val modulepath: Modulepath? = null,
+    public val environment: Environment? = null,
+    public val jvmArgs: Arguments = Arguments.empty(),
+    args: Arguments,
+  ) : AbstractRunnerJob(args), RunnerJob.RunBytecode
+
+  /** Factories for [JvmRunnerJob] instances. */
+  public companion object {
+    /**
+     * Create a classpath-based JVM runner job.
+     *
+     * This method supports a minimal suite of arguments; for full arguments, use [JvmRunner.create].
+     *
+     * @param mainClass Main class to execute.
+     * @param classpath Classpath to use for the job.
+     * @param args Arguments to pass to the job.
+     * @param env Optional environment to use for the job, if applicable.
+     *
+     * @return A new [JvmRunnerJob] instance configured with the provided parameters.
+     */
+    @JvmStatic public fun of(
+      mainClass: String,
+      classpath: Classpath,
+      args: Arguments,
+      env: Environment? = null,
+    ): JvmRunnerJob = JvmRunnerJob(
+      mainClass = mainClass,
+      mainModule = Optional.empty(),
+      classpath = classpath,
+      modulepath = null,
+      environment = env,
+      args = args,
+    )
+
+    /**
+     * Create a classpath-based JVM runner job, potentially with module support.
+     *
+     * @param main Main module and class to execute, as a pair of (module, class).
+     * @param classpath Classpath to use for the job.
+     * @param modulepath Modulepath to use for the job.
+     * @param args Arguments to pass to the job.
+     * @param env Optional environment to use for the job, if applicable.
+     *
+     * @return A new [JvmRunnerJob] instance configured with the provided parameters.
+     */
+    @JvmStatic public fun create(
+      main: Pair<String?, String>,
+      classpath: Classpath,
+      modulepath: Modulepath,
+      args: Arguments,
+      env: Environment? = null,
+    ): JvmRunnerJob = JvmRunnerJob(
+      mainClass = main.second,
+      mainModule = Optional.ofNullable(main.first),
+      classpath = classpath,
+      modulepath = modulepath,
+      environment = env,
+      args = args,
+    )
+  }
+}

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/Runner.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/Runner.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+import org.graalvm.polyglot.Context
+import java.util.function.Consumer
+import kotlinx.coroutines.Deferred
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * # Runner
+ *
+ * Sealed type hierarchy base for all runners, in all languages or contexts. Runners are responsible for executing guest
+ * code through Elide's runtime facilities.
+ *
+ * @property info Information about this runner.
+ */
+public sealed interface Runner<T> : AutoCloseable, Consumer<T> where T: RunnerJob {
+  /**
+   * Provide basic information about this runner; this includes the runner's name, version, or other uniform metadata
+   * available for all runners.
+   */
+  public val info: RunnerInfo
+
+  /**
+   * Assign a Truffle [context] to use for this runner. This method must be called at least once before invoking the
+   * runner with a job, if the runner plans to use Truffle execution facilities.
+   *
+   * @param context The [Context] to configure this runner with.
+   */
+  public fun configure(context: Context, coroutineContext: CoroutineContext)
+
+  /**
+   * Poll for an outcome from the runner, if a current job is active; this method returns the [Deferred] job that is
+   * currently executing, or `null` if no job is active.
+   *
+   * @return A [Deferred] instance that is currently under execution, or `null` if no job is active.
+   */
+  public fun poll(): Deferred<RunnerOutcome>?
+
+  /**
+   * Await the final outcome of the current job, if one is active. This method suspends until the job completes and
+   * returns the [RunnerOutcome] of the job.
+   *
+   * Note that this method will throw an exception if no job is currently active, so it should only be called when
+   * [poll] returns a non-null value, or when the runner is known to have an active job.
+   *
+   * @return The [RunnerOutcome] of the currently active job.
+   */
+  public suspend fun await(): RunnerOutcome
+
+  /**
+   * All in one cycle, mount and initialize a new job within the runner, then execute it, then await a result, and
+   * provide it as a return value to the caller.
+   *
+   * @param job The [RunnerJob] to execute.
+   * @return A [Deferred] instance that will complete with the [RunnerOutcome] of the job.
+   */
+  public suspend operator fun invoke(job: T): RunnerOutcome
+
+  // --- Runner Types
+
+  /**
+   * ## Runner (Source)
+   *
+   * Expects to run guest code in the form of source code, which will be interpreted for execution (or, alternatively,
+   * compiled on-the-fly).
+   */
+  public sealed interface SourceRunner<T> : Runner<T> where T: RunnerJob.RunSources
+
+  /**
+   * ## Runner (Bytecode)
+   *
+   * Expects to run guest code in the form of bytecode, which will be executed by a virtual machine or interpreter.
+   */
+  public sealed interface BytecodeRunner<T> : Runner<T> where T: RunnerJob.RunBytecode
+
+  /**
+   * ## Runner (Native)
+   *
+   * Expects to run guest code in the form of native code, which will be executed directly.
+   */
+  public sealed interface NativeRunner<T> : Runner<T> where T: RunnerJob.RunNative
+}

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/Runner.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/Runner.kt
@@ -33,6 +33,17 @@ public sealed interface Runner<T> : AutoCloseable, Consumer<T> where T: RunnerJo
   public val info: RunnerInfo
 
   /**
+   * Decide whether this runner is eligible to run the given [job]. This method should be used to determine if the
+   * runner itself is supported.
+   *
+   * @param job The [JvmRunner.JvmRunnerJob] to check for eligibility.
+   * @return `true` if the runner is eligible to run the job, `false` otherwise.
+   */
+  public fun eligible(job: JvmRunner.JvmRunnerJob): Boolean {
+    return true
+  }
+
+  /**
    * Assign a Truffle [context] to use for this runner. This method must be called at least once before invoking the
    * runner with a job, if the runner plans to use Truffle execution facilities.
    *

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/RunnerExecution.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/RunnerExecution.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+import org.graalvm.polyglot.Context
+
+/**
+ * ## Runner Execution
+ *
+ * Internal state class which models available facilities and inputs for a [RunnerJob] as it executes within the context
+ * of a [Runner].
+ */
+public interface RunnerExecution<T> where T: RunnerJob {
+  /**
+   * The [RunnerJob] which is under execution.
+   */
+  public val job: T
+
+  /**
+   * The Truffle [Context] in which this job is executing, as applicable.
+   */
+  public val context: Context
+}

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/RunnerInfo.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/RunnerInfo.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+/**
+ * ## Runner Info
+ *
+ * Holds information about a configured runner.
+ */
+public interface RunnerInfo {
+  /**
+   * Name of the runner in use.
+   */
+  public val name: String
+
+  /**
+   * Whether the runner is expected to exit after running.
+   */
+  public val exits: Boolean
+}

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/RunnerJob.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/RunnerJob.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+import elide.tooling.Arguments
+import elide.tooling.Inputs
+import elide.tooling.Outputs
+
+/**
+ * ## Runner Job
+ *
+ * Describes a sealed hierarchy base of job types which can be executed by a given [Runner]. Runners orchestrate the
+ * execution of guest code; each execution of guest code is represented by a [RunnerJob].
+ */
+public sealed interface RunnerJob {
+  /**
+   * ### Inputs
+   *
+   * Specifies typed inputs which relate to this runner job.
+   */
+  public val inputs: Inputs
+
+  /**
+   * ### Outputs
+   *
+   * Specifies typed outputs which relate to this runner job.
+   */
+  public val outputs: Outputs
+
+  /**
+   * ### Arguments
+   *
+   * Specifies arguments to use for this runner job.
+   */
+  public val arguments: Arguments
+
+  /**
+   * ### Runner Job (Sources)
+   *
+   * Represents a runner job which executes guest code from sources. This is typically used for languages which are
+   * interpreted, or which are compiled before execution.
+   */
+  public sealed interface RunSources : RunnerJob
+
+  /**
+   * ### Runner Job (Bytecode)
+   *
+   * Represents a runner job which executes guest code from bytecode. This is typically used for languages which are
+   * already compiled by the time they are executed.
+   */
+  public sealed interface RunBytecode : RunnerJob
+
+  /**
+   * ### Runner Job (Native)
+   *
+   * Represents a runner job which executes guest code from native binaries. This is typically used for languages which
+   * compile directly to native code.
+   */
+  public sealed interface RunNative : RunnerJob
+}

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/RunnerOutcome.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/RunnerOutcome.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+/**
+ * ## Runner Outcome
+ *
+ * Describes typed outcomes which can yield from a [RunnerJob] execution by a [Runner]. Outcomes for runners are simply
+ * modeled after program exit codes, since runners typically execute guest programs and return those details.
+ */
+public sealed interface RunnerOutcome {
+  /**
+   * Whether this outcome represents a successful execution.
+   */
+  public val isSuccess: Boolean
+
+  /**
+   * Exit code to use for this outcome.
+   */
+  public val exit: Int
+
+  /**
+   * Successful runner outcome.
+   */
+  public data object Success : RunnerOutcome {
+    override val isSuccess: Boolean get() = true
+    override val exit: Int get() = 0
+  }
+
+  /**
+   * Failed runner outcome.
+   *
+   * @property exit Exit code for this outcome.
+   * @property message Optional message for this outcome, if any.
+   */
+  @JvmRecord public data class Failure(
+    override val exit: Int,
+    val message: String? = null,
+    val cause: Throwable? = null,
+  ) : RunnerOutcome {
+    override val isSuccess: Boolean get() = false
+  }
+}

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/Runners.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/Runners.kt
@@ -32,7 +32,7 @@ public object Runners {
    *
    * @return A list of all available [Runner] instances.
    */
-  @JvmStatic public fun jvm(truffle: Boolean? = null): List<JvmRunner> = all()
+  @JvmStatic public fun jvm(job: JvmRunner.JvmRunnerJob, truffle: Boolean? = null): List<JvmRunner> = all()
     .filterIsInstance<JvmRunner>()
     .filter {
       when (truffle) {
@@ -40,5 +40,7 @@ public object Runners {
         true -> it is TruffleRunner
         false -> it !is TruffleRunner
       }
+    }.filter {
+      it.eligible(job)
     }
 }

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/Runners.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/Runners.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+import java.util.ServiceLoader
+
+/**
+ * # Runners
+ *
+ * Utility class for obtaining instances of [Runner] implementations.
+ */
+public object Runners {
+  /**
+   * Returns all available [Runner] instances.
+   *
+   * @return A list of all available [Runner] instances.
+   */
+  @JvmStatic public fun all(): List<Runner<*>> = ServiceLoader.load(Runner::class.java).toList()
+
+  /**
+   * Returns all available [Runner] instances.
+   *
+   * @return A list of all available [Runner] instances.
+   */
+  @JvmStatic public fun jvm(truffle: Boolean? = null): List<JvmRunner> = all()
+    .filterIsInstance<JvmRunner>()
+    .filter {
+      when (truffle) {
+        null -> true // no filter
+        true -> it is TruffleRunner
+        false -> it !is TruffleRunner
+      }
+    }
+}

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/TruffleRunner.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/TruffleRunner.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+/**
+ * ## Truffle Runner
+ *
+ * Marker & capability interface for a Truffle-based runner, which uses types from GraalVM's Truffle framework to model
+ * inputs and context.
+ */
+public interface TruffleRunner

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/base/RunnerInfoImpl.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/base/RunnerInfoImpl.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner.base
+
+import elide.runtime.runner.RunnerInfo
+
+// Implements `RunnerInfo` with a backing data class.
+@JvmRecord internal data class RunnerInfoImpl(
+  override val name: String,
+  override val exits: Boolean = true,
+) : RunnerInfo

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/jvm/EspressoJvmRunner.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/jvm/EspressoJvmRunner.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner.jvm
+
+import org.graalvm.polyglot.Value
+import elide.runtime.runner.AbstractRunner
+import elide.runtime.runner.JvmRunner
+import elide.runtime.runner.RunnerExecution
+import elide.runtime.runner.RunnerOutcome
+import elide.runtime.runner.TruffleRunner
+import elide.tooling.Arguments
+
+// Name of the Espresso runner.
+private const val RUNNER_ESPRESSO = "espresso"
+
+// Implements a JVM runner which uses Espresso on Truffle to run JVM bytecode.
+internal class EspressoJvmRunner : AbstractRunner<JvmRunner.JvmRunnerJob>(RUNNER_ESPRESSO), JvmRunner, TruffleRunner {
+  // Resolve the entrypoint main method to invoke.
+  private fun resolveMain(clsName: String, guestCls: Value): Pair<Value, Boolean>? {
+    return when (val mainEntry = guestCls.getMember("main/([Ljava/lang/String;)V")) {
+      null -> when (val mainNoArgEntry = guestCls.getMember("main/()V")) {
+        null -> null
+        else -> if (!mainNoArgEntry.canExecute()) {
+          error("Main no-arg entrypoint in class '$clsName' is not executable")
+        } else {
+          mainNoArgEntry to false
+        }
+      }
+      else -> {
+        if (!mainEntry.canExecute()) {
+          error("Main entrypoint in class '$clsName' is not executable")
+        } else {
+          mainEntry to true
+        }
+      }
+    }
+  }
+
+  // Invoke the main method and return a runner outcome.
+  @Suppress("TooGenericExceptionCaught")
+  private fun invokeMain(guestCls: Value, entry: Value, acceptsArgs: Boolean, args: Arguments): RunnerOutcome {
+    return try {
+      if (acceptsArgs) {
+        val argsAsArray = args.asArgumentList().toTypedArray()
+        entry.executeVoid(argsAsArray)
+      } else {
+        entry.executeVoid()
+      }
+      success()
+    } catch (err: Throwable) {
+      err(
+        "failed to invoke main method in class '${guestCls.javaClass.name}': ${err.message ?: "unknown error"}",
+        cause = err,
+      )
+    }
+  }
+
+  override suspend fun invoke(exec: RunnerExecution<JvmRunner.JvmRunnerJob>): RunnerOutcome {
+    // start by resolving the main class
+    val mainCls = exec.context
+      .getBindings("java")
+      .getMember(exec.job.mainClass)
+
+    if (mainCls == null) {
+      return err("main class not found: ${exec.job.mainClass}")
+    }
+
+    // next up, the entrypoint method
+    val entry = resolveMain(exec.job.mainClass, mainCls)
+    if (entry == null) {
+      return err("main method not found in class: ${exec.job.mainClass}")
+    }
+    val (entryMethod, acceptsArgs) = entry
+    return invokeMain(mainCls, entryMethod, acceptsArgs, exec.job.arguments)
+  }
+}

--- a/packages/runner/src/main/kotlin/elide/runtime/runner/jvm/StandardJvmRunner.kt
+++ b/packages/runner/src/main/kotlin/elide/runtime/runner/jvm/StandardJvmRunner.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner.jvm
+
+import org.graalvm.nativeimage.ImageInfo
+import java.io.File
+import java.nio.file.Path
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.coroutineContext
+import kotlin.io.path.absolutePathString
+import elide.runtime.runner.AbstractRunner
+import elide.runtime.runner.JvmRunner
+import elide.runtime.runner.RunnerExecution
+import elide.runtime.runner.RunnerOutcome
+import elide.tooling.Arguments
+
+// Name of the Standard JVM runner.
+private const val RUNNER_STD_JVM = "stockjvm"
+
+// Implements a JVM runner which uses standard JDK facilities to run programs.
+internal class StandardJvmRunner : AbstractRunner<JvmRunner.JvmRunnerJob>(RUNNER_STD_JVM), JvmRunner {
+  private val runnerOptions = atomic(JvmRunnerOptions())
+  private val resolvedJavaHome = atomic<Path?>(null)
+
+  // Install custom options for the standard JVM runner.
+  fun configureStandardJvmRunner(options: JvmRunnerOptions): StandardJvmRunner = apply {
+    runnerOptions.value = options
+    if (options.javahome != null || options.javahome != resolvedJavaHome.value) {
+      resolvedJavaHome.value = null  // refresh
+    }
+  }
+
+  // Options for the standard JVM runner.
+  data class JvmRunnerOptions(
+    // Specific Java Home to use; if none is provided, one will be resolved.
+    val javahome: Path? = null,
+
+    // Whether to use reflective invocation within this JVM.
+    val reflective: Boolean = false,
+  )
+
+  // Resolve the Java Home to use for this runner.
+  private fun javaHome(): Path? = when (val currentHome = resolvedJavaHome.value) {
+    null -> {
+      val javaHomeEnv = System.getenv("JAVA_HOME")
+      if (javaHomeEnv != null) {
+        Path.of(javaHomeEnv).also { resolvedJavaHome.value = it }
+      } else {
+        null // no Java Home available
+      }
+    }
+
+    else -> currentHome
+  }
+
+  // Operating mode: Invoke within this JVM using reflection.
+  @Suppress("TooGenericExceptionCaught")
+  private suspend fun invokeReflectively(exec: RunnerExecution<JvmRunner.JvmRunnerJob>): RunnerOutcome {
+    val cls = this::class.java.classLoader.loadClass(exec.job.mainClass)
+    if (cls == null) {
+      return err("failed to load main class (via reflection): ${exec.job.mainClass}")
+    }
+    // find static method named `main`
+    val mainMethod = cls.getDeclaredMethod("main", Array<String>::class.java)
+    if (mainMethod == null) {
+      return err("failed to find main method in class (via reflection): ${exec.job.mainClass}")
+    }
+    // invoke main method with specified args
+    val progArgs = exec.job.arguments.asArgumentList().toTypedArray()
+    return try {
+      withContext(coroutineContext) {
+        mainMethod.invoke(cls, progArgs)
+        success()
+      }
+    } catch (err: Throwable) {
+      err("failed to invoke main method in class (via reflection): ${exec.job.mainClass}", cause = err)
+    }
+  }
+
+  // Operating mode: Invoke Java via the command line.
+  @Suppress("TooGenericExceptionCaught")
+  private suspend fun invokeSubproc(exec: RunnerExecution<JvmRunner.JvmRunnerJob>): RunnerOutcome {
+    val home = javaHome() ?: return err("failed to resolve Java Home for standard JVM runner")
+    val javaBin = home.resolve("bin").resolve("java")
+
+    return withContext(coroutineContext) {
+      val progArgs = exec.job.arguments
+      val jvmArgs = exec.job.jvmArgs
+      val fullCommand = Arguments.empty().toMutable().apply {
+        add(javaBin.absolutePathString())
+        addAllStrings(jvmArgs.asArgumentList())
+
+        add("-cp")
+        add(exec.job.classpath.joinToString(separator = ":") { it.path.absolutePathString() })
+
+        exec.job.modulepath?.let { modulepath ->
+          add("--module-path")
+          add(modulepath.joinToString(separator = ":") { it.path.absolutePathString() })
+        }
+
+        if (exec.job.mainModule.isPresent) {
+          add("${exec.job.mainModule.get()}/${exec.job.mainClass}")
+        } else {
+          add(exec.job.mainClass)
+        }
+        addAllStrings(progArgs.asArgumentList())
+      }.asArgumentList()
+
+      val procBuilder = ProcessBuilder().apply {
+        // command to run
+        command(fullCommand)
+
+        // inherit IO from the parent process
+        inheritIO()
+
+        // working directory should match
+        directory(File(System.getProperty("user.dir")))
+
+        // job environment
+        exec.job.environment?.let { env ->
+          env.asSequence().forEach {
+            environment().put(it.key, it.value)
+          }
+        }
+      }
+
+      try {
+        // start and wait for process completion
+        val process = procBuilder.start()
+        val exitCode = process.waitFor()
+        if (exitCode == 0) {
+          success()
+        } else {
+          err("subprocess exited with non-zero exit code: $exitCode")
+        }
+      } catch (err: Throwable) {
+        err("failed to invoke subprocess for main class: ${exec.job.mainClass}", cause = err)
+      }
+    }
+  }
+
+  override suspend fun invoke(exec: RunnerExecution<JvmRunner.JvmRunnerJob>): RunnerOutcome = when {
+    // reflective invocation within this JVM is only supported in non-image contexts, and when activated.
+    !ImageInfo.inImageCode() && runnerOptions.value.reflective -> invokeReflectively(exec)
+
+    // otherwise, invoke via subproc.
+    else -> invokeSubproc(exec)
+  }
+}

--- a/packages/runner/src/main/resources/META-INF/services/elide.runtime.runner.Runner
+++ b/packages/runner/src/main/resources/META-INF/services/elide.runtime.runner.Runner
@@ -1,0 +1,2 @@
+elide.runtime.runner.jvm.StandardJvmRunner
+elide.runtime.runner.jvm.EspressoJvmRunner

--- a/packages/runner/src/test/kotlin/elide/runtime/runner/JvmRunnerEntrypointSample.kt
+++ b/packages/runner/src/test/kotlin/elide/runtime/runner/JvmRunnerEntrypointSample.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+object JvmRunnerEntrypointSample {
+  @JvmStatic fun main(args: Array<String>) {
+    println("Hello from JvmRunnerEntrypointSample")
+  }
+}

--- a/packages/runner/src/test/kotlin/elide/runtime/runner/JvmRunnerNoEntrypointSample.kt
+++ b/packages/runner/src/test/kotlin/elide/runtime/runner/JvmRunnerNoEntrypointSample.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+object JvmRunnerNoEntrypointSample {
+  // Nothing
+}

--- a/packages/runner/src/test/kotlin/elide/runtime/runner/JvmRunnerTest.kt
+++ b/packages/runner/src/test/kotlin/elide/runtime/runner/JvmRunnerTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.runner
+
+import org.graalvm.polyglot.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+import elide.tooling.Arguments
+import elide.tooling.Classpath
+import elide.tooling.asArgumentString
+
+class JvmRunnerTest {
+  val entrypointCls = "elide.runtime.runner.JvmRunnerEntrypointSample"
+  private fun currentClasspath(): Classpath = Classpath.fromCurrent()
+
+  private fun jvmRunnerJob(): JvmRunner.JvmRunnerJob = JvmRunner.of(
+    mainClass = entrypointCls,
+    classpath = currentClasspath(),
+    args = Arguments.empty(),
+  )
+
+  private fun truffleContext(): Context {
+    return Context.newBuilder()
+      .allowAllAccess(true)
+      .allowExperimentalOptions(true)
+      .option("java.Classpath", currentClasspath().asArgumentString())
+      .build()
+  }
+
+  private fun JvmRunner.prepare(): JvmRunner = apply {
+    configure(
+      truffleContext(),
+      Dispatchers.Default,
+    )
+  }
+
+  @Test fun testResolveAllRunners() {
+    val runners = assertNotNull(Runners.all())
+    assertTrue(runners.isNotEmpty())
+  }
+
+  @Test fun testResolveJvmRunner() {
+    val jvmRunners = assertNotNull(Runners.jvm())
+    assertTrue(jvmRunners.isNotEmpty())
+  }
+
+  @Test fun testResolveJvmTruffleRunner() {
+    val jvmRunner = assertNotNull(Runners.jvm(truffle = true)).first()
+    assertTrue(jvmRunner is TruffleRunner)
+  }
+
+  @Test fun testResolveJvmNonTruffleRunner() {
+    val jvmRunner = assertNotNull(Runners.jvm(truffle = false)).first()
+    assertTrue(jvmRunner !is TruffleRunner)
+  }
+
+  @Test fun testCreateRunnerJob() {
+    assertNotNull(jvmRunnerJob())
+  }
+
+  @Test fun testRunnerJobOnTruffle() = runTest {
+    val job = jvmRunnerJob()
+    val runner = Runners.jvm(truffle = true).first().prepare()
+    assertIs<TruffleRunner>(runner)
+    val outcome = assertNotNull(runner(job))
+    assertIs<RunnerOutcome.Success>(outcome)
+  }
+
+  @Test fun testRunnerJobOnStandardJvm() = runTest {
+    val job = jvmRunnerJob()
+    val runner = Runners.jvm(truffle = false).first().prepare()
+    assertIsNot<TruffleRunner>(runner)
+    val outcome = assertNotNull(runner(job))
+    assertIs<RunnerOutcome.Success>(outcome)
+  }
+}

--- a/packages/sqlite/build.gradle.kts
+++ b/packages/sqlite/build.gradle.kts
@@ -47,7 +47,6 @@ elide {
 
   jvm {
     alignVersions = true
-    target = JvmTarget.JVM_22
   }
 }
 

--- a/packages/tcnative/build.gradle.kts
+++ b/packages/tcnative/build.gradle.kts
@@ -28,7 +28,6 @@ elide {
 
   jvm {
     alignVersions = true
-    target = JvmTarget.JVM_22
   }
 }
 

--- a/packages/terminal/build.gradle.kts
+++ b/packages/terminal/build.gradle.kts
@@ -28,7 +28,6 @@ elide {
 
   jvm {
     alignVersions = true
-    target = JvmTarget.JVM_22
   }
 }
 

--- a/packages/transport/transport-common/build.gradle.kts
+++ b/packages/transport/transport-common/build.gradle.kts
@@ -29,7 +29,6 @@ elide {
 
   jvm {
     alignVersions = true
-    target = JvmTarget.JVM_22
   }
 
   publishing {

--- a/packages/transport/transport-epoll/build.gradle.kts
+++ b/packages/transport/transport-epoll/build.gradle.kts
@@ -29,7 +29,6 @@ elide {
 
   jvm {
     alignVersions = true
-    target = JvmTarget.JVM_22
   }
 
   publishing {

--- a/packages/transport/transport-kqueue/build.gradle.kts
+++ b/packages/transport/transport-kqueue/build.gradle.kts
@@ -29,7 +29,6 @@ elide {
 
   jvm {
     alignVersions = true
-    target = JvmTarget.JVM_22
   }
 
   publishing {

--- a/packages/transport/transport-uring/build.gradle.kts
+++ b/packages/transport/transport-uring/build.gradle.kts
@@ -29,7 +29,6 @@ elide {
 
   jvm {
     alignVersions = true
-    target = JvmTarget.JVM_22
   }
 
   publishing {


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds support for a pluggable SPI-based `Runner` interface, specialized for now to `JvmRunner`; such runners are capable of accepting JVM-like arguments and running code in a JVM-like manner. There are two initial implementations: `EspressoJvmRunner`, which uses Truffle and Espresso, and `StandardJvmRunner`, which either runs code reflectively or via CLI invocation of `java`.

By default, the `StandardJvmRunner` will be used, unless any of the following conditions are true:
1) The user is running tests; in which case, Espresso's instrumentation may be desirable for e.g. coverage
2) The user passes `--jvm:espresso` to prefer an Espresso JVM
3) The standard JVM runner isn't usable for other reasons (e.g. no JAVA_HOME is set, or no `java` bin is resolvable)

- [x] **Implement `Runner` Types**
  - [x] Add abstract runner implementation
  - [x] Add SPI-based resolution of runners
  - [x] Add JVM runner job and related structures
  - [x] Implement `EspressoJvmRunner`
  - [x] Implement `StandardJvmRunner`
    - [x] Reflective (in-proc) execution
    - [x] Subproc execution 
- [x] **Implement Runner Support in CLI**
  - [x] Add `--jvm:espresso` flag to prefer a Truffle JVM
  - [x] Resolve a JVM runner and use it instead of running directly
  - [x] Pass/fail command result based on JVM runner outcome

Fixes #1398 
