### PR TITLE
feat(cli): add `lsp` and `mcp` commands

### DIFF
--- a/gradle/elide.versions.toml
+++ b/gradle/elide.versions.toml
@@ -195,6 +195,7 @@ magicProgress = "0.3.2"
 maven-core = "3.9.9"
 maven-lib = "1.9.22"
 maven-wagon = "3.5.3"
+mcp = "0.5.0"
 mermaidDokka = "0.6.0"
 micronaut = "4.9.5"
 micronaut-aot = "2.8.0"
@@ -697,6 +698,7 @@ maven-resolver-transport-wagon = { group = "org.apache.maven.resolver", name = "
 maven-resolver-impl = { group = "org.apache.maven.resolver", name = "maven-resolver-impl", version.ref = "maven-lib" }
 maven-resolver-api = { group = "org.apache.maven.resolver", name = "maven-resolver-api", version.ref = "maven-lib" }
 magicProgress = { group = "com.github.lukfor", name = "magic-progress", version.ref = "magicProgress" }
+mcp = { group = "io.modelcontextprotocol", name = "kotlin-sdk", version.ref = "mcp" }
 mordant = { group = "com.github.ajalt.mordant", name = "mordant", version.ref = "mordant" }
 mordant-coroutines = { group = "com.github.ajalt.mordant", name = "mordant-coroutines", version.ref = "mordant" }
 mordant-markdown = { group = "com.github.ajalt.mordant", name = "mordant-markdown", version.ref = "mordant" }

--- a/packages/cli/build.gradle.kts
+++ b/packages/cli/build.gradle.kts
@@ -546,6 +546,7 @@ dependencies {
   implementation(projects.packages.builder)
   implementation(libs.bundles.maven.model)
   implementation(libs.bundles.maven.resolver)
+  implementation(libs.mcp)
 
   // GraalVM: Engines
   implementation(projects.packages.graalvm)
@@ -586,6 +587,8 @@ dependencies {
   implementation(libs.graalvm.tools.dap)
   implementation(libs.graalvm.tools.chromeinspector)
   implementation(libs.graalvm.tools.profiler)
+  implementation(libs.graalvm.tools.lsp.api)
+  implementation(libs.graalvm.tools.lsp.impl)
 
   // TODO: patched
   // implementation(libs.graalvm.tools.coverage)

--- a/packages/cli/src/main/kotlin/elide/tool/cli/Elide.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/Elide.kt
@@ -46,6 +46,8 @@ import elide.tool.cli.cmd.builder.ToolWhichCommand
 import elide.tool.cli.cmd.checks.ToolCheckCommand
 import elide.tool.cli.cmd.deps.AddCommand
 import elide.tool.cli.cmd.deps.InstallCommand
+import elide.tool.cli.cmd.dev.LspCommand
+import elide.tool.cli.cmd.dev.McpCommand
 import elide.tool.cli.cmd.discord.ToolDiscordCommand
 import elide.tool.cli.cmd.help.HelpCommand
 import elide.tool.cli.cmd.info.ToolInfoCommand
@@ -125,6 +127,8 @@ internal const val ELIDE_HEADER = ("@|bold,fg(magenta)%n" +
     JibAdapter.JibCliTool::class,
     ToolPklCommand::class,
     ToolDiscordCommand::class,
+    LspCommand::class,
+    McpCommand::class,
   ],
   customSynopsis = [
     "",

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/dev/LspCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/dev/LspCommand.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tool.cli.cmd.dev
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.ReflectiveAccess
+import picocli.CommandLine
+import picocli.CommandLine.Command
+import picocli.CommandLine.Parameters
+import jakarta.inject.Inject
+import jakarta.inject.Provider
+import kotlinx.coroutines.runBlocking
+import kotlin.io.path.name
+import elide.runtime.core.PolyglotContext
+import elide.runtime.core.PolyglotContextBuilder
+import elide.tool.cli.CommandContext
+import elide.tool.cli.CommandResult
+import elide.tool.cli.ProjectAwareSubcommand
+import elide.tool.cli.ToolState
+import elide.tool.cli.options.LspOptions
+import elide.tool.project.ProjectManager
+import elide.tooling.project.ElideConfiguredProject
+import elide.tooling.project.load
+
+/** Starts an LSP for an Elide project. */
+@Command(
+  name = "lsp",
+  description = ["Run an LSP instance for an Elide project."],
+  mixinStandardHelpOptions = true,
+  showDefaultValues = true,
+  abbreviateSynopsis = true,
+  usageHelpAutoWidth = true,
+  synopsisHeading = "",
+)
+@Introspected
+@ReflectiveAccess
+internal class LspCommand @Inject constructor(
+  private val projectManagerProvider: Provider<ProjectManager>,
+) : ProjectAwareSubcommand<ToolState, CommandContext>() {
+  /** File to run within the VM. */
+  @Parameters(
+    index = "0",
+    arity = "0..1",
+    paramLabel = "FILE|CODE",
+    description = [
+      "File to run to start the LSP; defaults to project entrypoint(s).",
+    ],
+  )
+  internal var runnable: String? = null
+
+  /** Settings which apply to LSP. */
+  @CommandLine.ArgGroup(
+    validate = false,
+    heading = "%nLanguage Server:%n",
+  )
+  internal var lspOptions: LspOptions = LspOptions()
+
+  // Configure a polyglot context for LSP services.
+  private fun PolyglotContextBuilder.configureLSP(project: ElideConfiguredProject?) {
+    // configure the host string for the lsp server
+    option("lsp", lspOptions.lspHostString())
+
+    // apply general options
+    lspOptions.apply(this)
+
+    // configure delegated second-order lsp servers
+    lspOptions.allLanguageServerDelegates(project).ifEmpty { null }?.let { delegates ->
+      option("lsp.Delegates", delegates.joinToString(",") { delegate ->
+        buildString {
+          // language id if present
+          delegate.first?.let { langId ->
+            append(langId)
+            append("@")
+          }
+          // then host string
+          append(delegate.second)
+        }
+      })
+    }
+  }
+
+  @Suppress("UNUSED_PARAMETER")
+  private suspend fun CommandContext.lspEntry(project: ElideConfiguredProject?, ctxAccessor: () -> PolyglotContext) {
+    output {
+      if (project != null) {
+        val name = project.manifest.name ?: project.root.name
+        append("Running LSP for project '$name'")
+        ctxAccessor()
+      }
+    }
+  }
+
+  override suspend fun CommandContext.invoke(state: ToolContext<ToolState>): CommandResult {
+    val project = projectManagerProvider.get().resolveProject(projectOptions().projectPath())
+    if (project == null) {
+      if (runnable == null) {
+        // nothing to start
+        return err("No LSP start entrypoint (via project or files).")
+      }
+    }
+    val configured = project?.load()
+
+    withDeferredContext(emptySet(), shared = false, cfg = { configureLSP(configured) }) { accessor ->
+      runBlocking {
+        lspEntry(configured, accessor)
+      }
+    }
+    return success()
+  }
+}

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/dev/McpCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/dev/McpCommand.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tool.cli.cmd.dev
+
+import io.ktor.utils.io.streams.asInput
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.ReflectiveAccess
+import io.modelcontextprotocol.kotlin.sdk.Implementation
+import io.modelcontextprotocol.kotlin.sdk.ReadResourceResult
+import io.modelcontextprotocol.kotlin.sdk.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.TextResourceContents
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
+import picocli.CommandLine
+import picocli.CommandLine.Command
+import java.nio.charset.StandardCharsets
+import jakarta.inject.Inject
+import jakarta.inject.Provider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.asSink
+import kotlinx.io.buffered
+import kotlin.io.path.name
+import kotlin.io.path.readText
+import elide.runtime.core.PolyglotContext
+import elide.tool.cli.CommandContext
+import elide.tool.cli.CommandResult
+import elide.tool.cli.ProjectAwareSubcommand
+import elide.tool.cli.ToolState
+import elide.tool.cli.cfg.ElideCLITool.ELIDE_TOOL_VERSION
+import elide.tool.cli.options.McpOptions
+import elide.tool.project.ProjectManager
+import elide.tooling.project.ElideConfiguredProject
+import elide.tooling.project.load
+
+/** Starts an MCP for an Elide project. */
+@Command(
+  name = "mcp",
+  description = ["Run an MCP instance for an Elide project."],
+  mixinStandardHelpOptions = true,
+  showDefaultValues = true,
+  abbreviateSynopsis = true,
+  usageHelpAutoWidth = true,
+  synopsisHeading = "",
+)
+@Introspected
+@ReflectiveAccess
+internal class McpCommand @Inject constructor(
+  private val projectManagerProvider: Provider<ProjectManager>,
+) : ProjectAwareSubcommand<ToolState, CommandContext>() {
+  /** Settings which apply to MCP. */
+  @CommandLine.ArgGroup(
+    validate = false,
+    heading = "%nModel Context:%n",
+  )
+  internal var mcpOptions: McpOptions = McpOptions()
+
+  // Configure MCP server settings based on the current project.
+  private fun buildMcpServer(): Server = Server(
+    serverInfo = Implementation(
+      name = "elide",
+      version = ELIDE_TOOL_VERSION,
+    ),
+    options = ServerOptions(
+      capabilities = ServerCapabilities(
+        resources = ServerCapabilities.Resources(
+          subscribe = false,
+          listChanged = false,
+        ),
+        tools = ServerCapabilities.Tools(
+          listChanged = false,
+        ),
+      ),
+    ),
+  )
+
+  // Run an MCP server instance based on specified flags and project options.
+  private suspend fun CommandContext.runMcp(configured: ElideConfiguredProject, accessor: () -> PolyglotContext) {
+    val name = configured.manifest.name ?: configured.root.name
+    val server = buildMcpServer()
+    val projectConfig = configured.root.resolve("elide.pkl")
+    val ctx = accessor()
+    if (mcpOptions.mcpDebug) logging.info {
+      "Starting MCP server for project '$name' with context '$ctx'"
+    }
+
+    // add project config unconditionally as resource
+    server.addResource(
+      uri = "file:///elide.pkl",
+      name = "Elide Project Manifest",
+      description = "Project configuration file for an Elide project",
+      mimeType = "application/x-elide-pkl",
+    ) { resource ->
+      ReadResourceResult(
+        contents = listOf(
+          TextResourceContents(
+            uri = resource.uri,
+            mimeType = "application/x-pkl",
+            text = kotlinx.coroutines.withContext(Dispatchers.IO) {
+              projectConfig.readText(StandardCharsets.UTF_8)
+            },
+          )
+        )
+      )
+    }
+
+    // build and run with transport
+    val (awaitClose, transport) = when {
+      else -> false to StdioServerTransport(
+        inputStream = System.`in`.asInput().buffered(),
+        outputStream = System.out.asSink().buffered(),
+      )
+    }
+    try {
+      server.connect(transport)
+      if (awaitClose) {
+        while (true) {
+          // Keep the server running until interrupted.
+          Thread.sleep(Long.MAX_VALUE)
+        }
+      }
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+      output {
+        append("MCP server interrupted; exiting")
+      }
+    }
+  }
+
+  override suspend fun CommandContext.invoke(state: ToolContext<ToolState>): CommandResult {
+    val project = projectManagerProvider.get().resolveProject(projectOptions().projectPath())
+    if (project == null) {
+      return err("No project; can't start MCP without it")
+    }
+    val configured = project.load()
+    resolveEngine().unwrap().use {
+      withDeferredContext(emptySet(), shared = true) { accessor ->
+        runBlocking {
+          runMcp(configured, accessor)
+        }
+      }
+    }
+    return success()
+  }
+}

--- a/packages/cli/src/main/kotlin/elide/tool/cli/options/LspOptions.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/options/LspOptions.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tool.cli.options
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.ReflectiveAccess
+import picocli.CommandLine.Option
+import elide.runtime.core.PolyglotContextBuilder
+import elide.tooling.project.ElideConfiguredProject
+
+/**
+ * ## LSP Options
+ *
+ * Specifies options which relate to LSP (Language Server Protocol) support in the Elide CLI.
+ */
+@Introspected @ReflectiveAccess class LspOptions : OptionsMixin<LspOptions> {
+  private companion object {
+    private const val DEFAULT_LSP_HOST = "localhost"
+    private const val DEFAULT_LSP_PORT = 8124
+  }
+  /** Debug mode for LSP usage. */
+  @Option(
+    names = ["--lsp:debug"],
+    description = ["Activate debugging for LSP services."],
+  )
+  private var lspDebug: Boolean = false
+
+  /** Specifies the host to bind to for LSP services. */
+  @Option(
+    names = ["--lsp:host"],
+    description = ["Host to use for the LSP server."],
+    paramLabel = "<host>",
+  )
+  private var lspHost: String? = null
+
+  /** Specifies the port to bind to for LSP services. */
+  @Option(
+    names = ["--lsp:port"],
+    description = ["Port to use for the LSP server."],
+    paramLabel = "<port>",
+  )
+  private var lspPort: Int? = null
+
+  /** Enable internal sources via LSP. */
+  @Option(
+    names = ["--lsp:internal"],
+    description = ["Activate tools for LSP debugging and internals."],
+  )
+  private var lspInternals: Boolean = false
+
+  /** Enable internal sources via LSP. */
+  @Option(
+    names = ["--lsp:delegate"],
+    description = ["Add a delegate second-order LSP server."],
+    paramLabel = "[languageId@][[host:]port]",
+    arity = "0..*",
+  )
+  private var lspDelegates: List<String> = emptyList()
+
+  @JvmRecord private data class LspDelegate(
+    val langId: String?,
+    val host: String?,
+    val port: Int?,
+  ) {
+    fun asString(): String = buildString {
+      if (langId != null) append("$langId@")
+      if (host != null) append(host)
+      if (port != null) append(":$port")
+    }
+  }
+
+  internal fun hostAndPort(): Pair<String, Int> {
+    return (lspHost ?: DEFAULT_LSP_HOST) to (lspPort ?: DEFAULT_LSP_PORT)
+  }
+
+  internal fun lspHostString(): String = hostAndPort().let {
+    "${it.first}:${it.second}"
+  }
+
+  internal fun apply(builder: PolyglotContextBuilder) {
+    if (lspInternals) {
+      builder.option("lsp.Internal", "true")
+      if (lspDebug)  {
+        builder.option("lsp.DeveloperMode", "true")
+      }
+    }
+  }
+
+  private fun resolveAllLanguageDelegates(project: ElideConfiguredProject?): Sequence<LspDelegate> = sequence {
+    val allDelegates = buildList {
+      addAll(lspDelegates)
+      project?.manifest?.dev?.lsp?.delegates?.let { addAll(it) }
+    }
+    for (delegate in allDelegates) {
+      val parts = delegate.split("@", limit = 2)
+      val langId = parts.getOrNull(0)
+      val hostAndPort = parts.getOrNull(1)?.split(":") ?: emptyList()
+      val host = hostAndPort.getOrNull(0)
+      val port = hostAndPort.getOrNull(1)?.toIntOrNull()
+
+      yield(LspDelegate(langId, host, port))
+    }
+  }
+
+  internal fun allLanguageServerDelegates(project: ElideConfiguredProject?): List<Pair<String?, String>> {
+    return resolveAllLanguageDelegates(project).map {
+      val langId = it.langId
+      Pair(langId, it.asString())
+    }.toList()
+  }
+}

--- a/packages/cli/src/main/kotlin/elide/tool/cli/options/McpOptions.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/options/McpOptions.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tool.cli.options
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.ReflectiveAccess
+import picocli.CommandLine.Option
+
+/**
+ * ## MCP Options
+ *
+ * Specifies options which relate to MCP (Model Context Protocol) support in the Elide CLI.
+ */
+@Introspected @ReflectiveAccess class McpOptions : OptionsMixin<McpOptions> {
+  /** Debug mode for MCP usage. */
+  @Option(
+    names = ["--mcp:debug"],
+    description = ["Activate debugging for MCP services."],
+  )
+  var mcpDebug: Boolean = false
+}

--- a/packages/cli/src/main/pkl/Dev.pkl
+++ b/packages/cli/src/main/pkl/Dev.pkl
@@ -28,11 +28,17 @@ class ProjectSourceSpec {
   subpath: String?
 }
 
+/// LSP (Language Server Protocol) settings for the project.
+class LspSettings {
+  /// Additional delegated LSP servers, in the format `[languageId@][[host]:port]`.
+  delegates: Listing<String> = new {}
+}
+
 /// Development settings for the project.
 class DevSettings {
   /// Source info for the project.
   source: ProjectSourceSpec?
 
-  // CI configuration for this project.
-  // ci: ci.ContinuousIntegration?
+  /// Settings which apply to the project's language server.
+  lsp: LspSettings?
 }

--- a/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
+++ b/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
@@ -4283,6 +4283,24 @@
       "type": "elide.tooling.project.manifest.ElidePackageManifest$Artifact"
     },
     {
+      "type": "elide.tooling.project.manifest.ElidePackageManifest$DevSettings",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": "elide.tooling.project.manifest.ElidePackageManifest$LspSettings",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": "elide.tooling.project.manifest.ElidePackageManifest$ProjectSourceSpec",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true
+    },
+    {
       "type": "elide.tooling.project.manifest.ElidePackageManifest$ContainerImage",
       "allDeclaredFields": true,
       "allDeclaredMethods": true,

--- a/packages/engine/api/engine.api
+++ b/packages/engine/api/engine.api
@@ -221,8 +221,10 @@ public final class elide/runtime/core/PolyglotContextKt {
 }
 
 public abstract interface class elide/runtime/core/PolyglotEngine {
-	public abstract fun acquire (Lkotlin/jvm/functions/Function1;)Lelide/runtime/core/PolyglotContext;
+	public fun acquire (Lkotlin/jvm/functions/Function1;)Lelide/runtime/core/PolyglotContext;
+	public abstract fun acquire (ZLkotlin/jvm/functions/Function1;)Lelide/runtime/core/PolyglotContext;
 	public static synthetic fun acquire$default (Lelide/runtime/core/PolyglotEngine;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lelide/runtime/core/PolyglotContext;
+	public static synthetic fun acquire$default (Lelide/runtime/core/PolyglotEngine;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lelide/runtime/core/PolyglotContext;
 	public abstract fun unwrap ()Lorg/graalvm/polyglot/Engine;
 }
 
@@ -1106,6 +1108,8 @@ public final class elide/runtime/plugins/AbstractLanguagePluginKt {
 	public static final fun defaultPolyglotContextBuilder ()Lorg/graalvm/polyglot/Context$Builder;
 	public static final fun defaultPolyglotEngine ()Lorg/graalvm/polyglot/Engine;
 	public static final fun defaultPolyglotEngineBuilder ()Lorg/graalvm/polyglot/Engine$Builder;
+	public static final fun initializeDefaultContext (Lorg/graalvm/polyglot/Context$Builder;Z)Lorg/graalvm/polyglot/Context$Builder;
+	public static synthetic fun initializeDefaultContext$default (Lorg/graalvm/polyglot/Context$Builder;ZILjava/lang/Object;)Lorg/graalvm/polyglot/Context$Builder;
 }
 
 public abstract class elide/runtime/plugins/JVMLanguageConfig : elide/runtime/plugins/AbstractLanguageConfig {

--- a/packages/engine/src/main/kotlin/elide/runtime/core/PolyglotEngine.kt
+++ b/packages/engine/src/main/kotlin/elide/runtime/core/PolyglotEngine.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Elide Technologies, Inc.
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
  *
  * Licensed under the MIT license (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
@@ -30,5 +30,10 @@ public interface PolyglotEngine {
   public fun unwrap(): Engine
 
   /** Acquire a new [PolyglotContext]. The returned context has all plugins applied on creation. */
-  public fun acquire(cfg: Context.Builder.() -> Unit = {}): PolyglotContext
+  public fun acquire(cfg: Context.Builder.() -> Unit = {}): PolyglotContext {
+    return acquire(shared = true, cfg = cfg)
+  }
+
+  /** Acquire a new [PolyglotContext]. The returned context has all plugins applied on creation. */
+  public fun acquire(shared: Boolean, cfg: Context.Builder.() -> Unit = {}): PolyglotContext
 }

--- a/packages/engine/src/main/kotlin/elide/runtime/plugins/AbstractLanguagePlugin.kt
+++ b/packages/engine/src/main/kotlin/elide/runtime/plugins/AbstractLanguagePlugin.kt
@@ -100,7 +100,7 @@ private val contextHostAccess = HostAccess.newBuilder(HostAccess.ALL)
 
 // Initialize default context settings.
 @OptIn(DelicateElideApi::class)
-private fun Context.Builder.initializeDefaultContext(defaults: Boolean = false): Context.Builder = apply {
+public fun Context.Builder.initializeDefaultContext(defaults: Boolean = false): Context.Builder = apply {
   allowExperimentalOptions(true)
   allowValueSharing(true)
   allowCreateThread(true)

--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -42,7 +42,7 @@ public final class elide/runtime/core/internals/graalvm/GraalVMContext : elide/r
 public final class elide/runtime/core/internals/graalvm/GraalVMEngine : elide/runtime/core/PolyglotEngine {
 	public static final field Companion Lelide/runtime/core/internals/graalvm/GraalVMEngine$Companion;
 	public synthetic fun <init> (Lelide/runtime/core/internals/MutableEngineLifecycle;Lelide/runtime/core/internals/graalvm/GraalVMConfiguration;Lorg/graalvm/polyglot/Engine;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun acquire (Lkotlin/jvm/functions/Function1;)Lelide/runtime/core/PolyglotContext;
+	public fun acquire (ZLkotlin/jvm/functions/Function1;)Lelide/runtime/core/PolyglotContext;
 	public static final fun create (Lelide/runtime/core/internals/graalvm/GraalVMConfiguration;Lelide/runtime/core/internals/MutableEngineLifecycle;)Lelide/runtime/core/internals/graalvm/GraalVMEngine;
 	public fun unwrap ()Lorg/graalvm/polyglot/Engine;
 }

--- a/packages/tooling/api/tooling.api
+++ b/packages/tooling/api/tooling.api
@@ -2974,8 +2974,8 @@ public final class elide/tooling/project/codecs/PythonRequirementsManifestCodec 
 public final class elide/tooling/project/manifest/ElidePackageManifest : elide/tooling/project/manifest/PackageManifest {
 	public static final field Companion Lelide/tooling/project/manifest/ElidePackageManifest$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$DependencyResolution;Lelide/tooling/project/manifest/ElidePackageManifest$JavaScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$TypeScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$JvmSettings;Lelide/tooling/project/manifest/ElidePackageManifest$KotlinSettings;Lelide/tooling/project/manifest/ElidePackageManifest$PythonSettings;Lelide/tooling/project/manifest/ElidePackageManifest$RubySettings;Lelide/tooling/project/manifest/ElidePackageManifest$PklSettings;Lelide/tooling/project/manifest/ElidePackageManifest$NativeImageSettings;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$TestingSettings;Lelide/tooling/project/manifest/ElidePackageManifest$LockfileSettings;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$DependencyResolution;Lelide/tooling/project/manifest/ElidePackageManifest$JavaScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$TypeScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$JvmSettings;Lelide/tooling/project/manifest/ElidePackageManifest$KotlinSettings;Lelide/tooling/project/manifest/ElidePackageManifest$PythonSettings;Lelide/tooling/project/manifest/ElidePackageManifest$RubySettings;Lelide/tooling/project/manifest/ElidePackageManifest$PklSettings;Lelide/tooling/project/manifest/ElidePackageManifest$NativeImageSettings;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$TestingSettings;Lelide/tooling/project/manifest/ElidePackageManifest$LockfileSettings;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$DependencyResolution;Lelide/tooling/project/manifest/ElidePackageManifest$JavaScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$TypeScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$JvmSettings;Lelide/tooling/project/manifest/ElidePackageManifest$KotlinSettings;Lelide/tooling/project/manifest/ElidePackageManifest$PythonSettings;Lelide/tooling/project/manifest/ElidePackageManifest$RubySettings;Lelide/tooling/project/manifest/ElidePackageManifest$PklSettings;Lelide/tooling/project/manifest/ElidePackageManifest$NativeImageSettings;Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$TestingSettings;Lelide/tooling/project/manifest/ElidePackageManifest$LockfileSettings;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$DependencyResolution;Lelide/tooling/project/manifest/ElidePackageManifest$JavaScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$TypeScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$JvmSettings;Lelide/tooling/project/manifest/ElidePackageManifest$KotlinSettings;Lelide/tooling/project/manifest/ElidePackageManifest$PythonSettings;Lelide/tooling/project/manifest/ElidePackageManifest$RubySettings;Lelide/tooling/project/manifest/ElidePackageManifest$PklSettings;Lelide/tooling/project/manifest/ElidePackageManifest$NativeImageSettings;Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$TestingSettings;Lelide/tooling/project/manifest/ElidePackageManifest$LockfileSettings;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun activeWorkspace ()Lkotlin/Pair;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lelide/tooling/project/manifest/ElidePackageManifest$TypeScriptSettings;
@@ -2985,10 +2985,11 @@ public final class elide/tooling/project/manifest/ElidePackageManifest : elide/t
 	public final fun component14 ()Lelide/tooling/project/manifest/ElidePackageManifest$RubySettings;
 	public final fun component15 ()Lelide/tooling/project/manifest/ElidePackageManifest$PklSettings;
 	public final fun component16 ()Lelide/tooling/project/manifest/ElidePackageManifest$NativeImageSettings;
-	public final fun component17 ()Ljava/util/Map;
-	public final fun component18 ()Lelide/tooling/project/manifest/ElidePackageManifest$TestingSettings;
-	public final fun component19 ()Lelide/tooling/project/manifest/ElidePackageManifest$LockfileSettings;
+	public final fun component17 ()Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings;
+	public final fun component18 ()Ljava/util/Map;
+	public final fun component19 ()Lelide/tooling/project/manifest/ElidePackageManifest$TestingSettings;
 	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Lelide/tooling/project/manifest/ElidePackageManifest$LockfileSettings;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Ljava/util/List;
@@ -2996,12 +2997,13 @@ public final class elide/tooling/project/manifest/ElidePackageManifest : elide/t
 	public final fun component7 ()Ljava/util/Map;
 	public final fun component8 ()Lelide/tooling/project/manifest/ElidePackageManifest$DependencyResolution;
 	public final fun component9 ()Lelide/tooling/project/manifest/ElidePackageManifest$JavaScriptSettings;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$DependencyResolution;Lelide/tooling/project/manifest/ElidePackageManifest$JavaScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$TypeScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$JvmSettings;Lelide/tooling/project/manifest/ElidePackageManifest$KotlinSettings;Lelide/tooling/project/manifest/ElidePackageManifest$PythonSettings;Lelide/tooling/project/manifest/ElidePackageManifest$RubySettings;Lelide/tooling/project/manifest/ElidePackageManifest$PklSettings;Lelide/tooling/project/manifest/ElidePackageManifest$NativeImageSettings;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$TestingSettings;Lelide/tooling/project/manifest/ElidePackageManifest$LockfileSettings;)Lelide/tooling/project/manifest/ElidePackageManifest;
-	public static synthetic fun copy$default (Lelide/tooling/project/manifest/ElidePackageManifest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$DependencyResolution;Lelide/tooling/project/manifest/ElidePackageManifest$JavaScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$TypeScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$JvmSettings;Lelide/tooling/project/manifest/ElidePackageManifest$KotlinSettings;Lelide/tooling/project/manifest/ElidePackageManifest$PythonSettings;Lelide/tooling/project/manifest/ElidePackageManifest$RubySettings;Lelide/tooling/project/manifest/ElidePackageManifest$PklSettings;Lelide/tooling/project/manifest/ElidePackageManifest$NativeImageSettings;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$TestingSettings;Lelide/tooling/project/manifest/ElidePackageManifest$LockfileSettings;ILjava/lang/Object;)Lelide/tooling/project/manifest/ElidePackageManifest;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$DependencyResolution;Lelide/tooling/project/manifest/ElidePackageManifest$JavaScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$TypeScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$JvmSettings;Lelide/tooling/project/manifest/ElidePackageManifest$KotlinSettings;Lelide/tooling/project/manifest/ElidePackageManifest$PythonSettings;Lelide/tooling/project/manifest/ElidePackageManifest$RubySettings;Lelide/tooling/project/manifest/ElidePackageManifest$PklSettings;Lelide/tooling/project/manifest/ElidePackageManifest$NativeImageSettings;Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$TestingSettings;Lelide/tooling/project/manifest/ElidePackageManifest$LockfileSettings;)Lelide/tooling/project/manifest/ElidePackageManifest;
+	public static synthetic fun copy$default (Lelide/tooling/project/manifest/ElidePackageManifest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$DependencyResolution;Lelide/tooling/project/manifest/ElidePackageManifest$JavaScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$TypeScriptSettings;Lelide/tooling/project/manifest/ElidePackageManifest$JvmSettings;Lelide/tooling/project/manifest/ElidePackageManifest$KotlinSettings;Lelide/tooling/project/manifest/ElidePackageManifest$PythonSettings;Lelide/tooling/project/manifest/ElidePackageManifest$RubySettings;Lelide/tooling/project/manifest/ElidePackageManifest$PklSettings;Lelide/tooling/project/manifest/ElidePackageManifest$NativeImageSettings;Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$TestingSettings;Lelide/tooling/project/manifest/ElidePackageManifest$LockfileSettings;ILjava/lang/Object;)Lelide/tooling/project/manifest/ElidePackageManifest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getArtifacts ()Ljava/util/Map;
 	public final fun getDependencies ()Lelide/tooling/project/manifest/ElidePackageManifest$DependencyResolution;
 	public final fun getDescription ()Ljava/lang/String;
+	public final fun getDev ()Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings;
 	public fun getEcosystem ()Lelide/tooling/project/ProjectEcosystem;
 	public final fun getEntrypoint ()Ljava/util/List;
 	public final fun getJavascript ()Lelide/tooling/project/manifest/ElidePackageManifest$JavaScriptSettings;
@@ -3154,6 +3156,36 @@ public final synthetic class elide/tooling/project/manifest/ElidePackageManifest
 }
 
 public final class elide/tooling/project/manifest/ElidePackageManifest$DependencyResolution$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class elide/tooling/project/manifest/ElidePackageManifest$DevSettings {
+	public static final field Companion Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings$Companion;
+	public fun <init> ()V
+	public fun <init> (Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec;Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings;)V
+	public synthetic fun <init> (Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec;Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec;
+	public final fun component2 ()Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings;
+	public final fun copy (Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec;Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings;)Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings;
+	public static synthetic fun copy$default (Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings;Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec;Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings;ILjava/lang/Object;)Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLsp ()Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings;
+	public final fun getSource ()Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class elide/tooling/project/manifest/ElidePackageManifest$DevSettings$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lelide/tooling/project/manifest/ElidePackageManifest$DevSettings;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class elide/tooling/project/manifest/ElidePackageManifest$DevSettings$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3743,6 +3775,34 @@ public final class elide/tooling/project/manifest/ElidePackageManifest$LockfileS
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class elide/tooling/project/manifest/ElidePackageManifest$LspSettings {
+	public static final field Companion Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings;
+	public static synthetic fun copy$default (Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings;Ljava/util/List;ILjava/lang/Object;)Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDelegates ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class elide/tooling/project/manifest/ElidePackageManifest$LspSettings$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lelide/tooling/project/manifest/ElidePackageManifest$LspSettings;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class elide/tooling/project/manifest/ElidePackageManifest$LspSettings$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class elide/tooling/project/manifest/ElidePackageManifest$MavenCoordinates : java/lang/Record {
 	public static final field Companion Lelide/tooling/project/manifest/ElidePackageManifest$MavenCoordinates$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
@@ -4314,6 +4374,38 @@ public final synthetic class elide/tooling/project/manifest/ElidePackageManifest
 }
 
 public final class elide/tooling/project/manifest/ElidePackageManifest$ProfileGuidedOptimization$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class elide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec {
+	public static final field Companion Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec;
+	public static synthetic fun copy$default (Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlatform ()Ljava/lang/String;
+	public final fun getProject ()Ljava/lang/String;
+	public final fun getSubpath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class elide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lelide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class elide/tooling/project/manifest/ElidePackageManifest$ProjectSourceSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/packages/tooling/src/main/kotlin/elide/tooling/project/manifest/ElidePackageManifest.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/project/manifest/ElidePackageManifest.kt
@@ -51,6 +51,7 @@ public data class ElidePackageManifest(
   val ruby: RubySettings? = null,
   val pkl: PklSettings? = null,
   val nativeImage: NativeImageSettings? = null,
+  val dev: DevSettings? = null,
   val sources: Map<String, SourceSet> = emptyMap(),
   val tests: TestingSettings? = null,
   val lockfile: LockfileSettings? = null,
@@ -75,6 +76,21 @@ public data class ElidePackageManifest(
   @Serializable public data class JarResource(
     val path: String,
     val position: String,
+  )
+
+  @Serializable public data class ProjectSourceSpec(
+    val platform: String? = null,
+    val project: String? = null,
+    val subpath: String? = null,
+  )
+
+  @Serializable public data class LspSettings(
+    val delegates: List<String>? = null,
+  )
+
+  @Serializable public data class DevSettings(
+    val source: ProjectSourceSpec? = null,
+    val lsp: LspSettings? = null,
   )
 
   @Serializable public data class Jar(


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds simple entrypoints for `elide lsp` and `elide mcp`. LSP is pretty simple, and MCP only supports stdio for now (servers need Ktor). MCP is preloaded with access to the Elide project config, but not much else yet.

## Changelog
```
feat(cli): implement `elide lsp` command
feat(cli): implement `elide mcp` command
feat(cli): add lsp-specific options to cli
feat(cli): add mcp-specific options to cli
```