### PR TITLE
feat: implement node `querystring`

### DIFF
--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -3791,6 +3791,16 @@ public abstract interface class elide/runtime/intrinsics/js/node/ProcessAPI : el
 }
 
 public abstract interface class elide/runtime/intrinsics/js/node/QuerystringAPI : elide/runtime/intrinsics/js/node/NodeAPI {
+	public abstract fun decode (Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/node/querystring/QueryParams;
+	public static synthetic fun decode$default (Lelide/runtime/intrinsics/js/node/QuerystringAPI;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;ILjava/lang/Object;)Lelide/runtime/intrinsics/js/node/querystring/QueryParams;
+	public abstract fun encode (Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;)Ljava/lang/String;
+	public static synthetic fun encode$default (Lelide/runtime/intrinsics/js/node/QuerystringAPI;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;ILjava/lang/Object;)Ljava/lang/String;
+	public abstract fun escape (Lorg/graalvm/polyglot/Value;)Ljava/lang/String;
+	public abstract fun parse (Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/node/querystring/QueryParams;
+	public static synthetic fun parse$default (Lelide/runtime/intrinsics/js/node/QuerystringAPI;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;ILjava/lang/Object;)Lelide/runtime/intrinsics/js/node/querystring/QueryParams;
+	public abstract fun stringify (Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;)Ljava/lang/String;
+	public static synthetic fun stringify$default (Lelide/runtime/intrinsics/js/node/QuerystringAPI;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;Lorg/graalvm/polyglot/Value;ILjava/lang/Object;)Ljava/lang/String;
+	public abstract fun unescape (Lorg/graalvm/polyglot/Value;)Ljava/lang/String;
 }
 
 public abstract interface class elide/runtime/intrinsics/js/node/ReadlineAPI : elide/runtime/intrinsics/js/node/NodeAPI {
@@ -5392,6 +5402,67 @@ public final class elide/runtime/intrinsics/js/node/process/ProcessStandardOutpu
 
 public abstract interface class elide/runtime/intrinsics/js/node/process/ProcessStandardStream : elide/runtime/intrinsics/js/node/stream/Stream {
 	public abstract fun getFd ()I
+}
+
+public final class elide/runtime/intrinsics/js/node/querystring/ParseOptions {
+	public static final field Companion Lelide/runtime/intrinsics/js/node/querystring/ParseOptions$Companion;
+	public static final field DEFAULT_MAX_KEYS I
+	public fun <init> ()V
+	public fun <init> (Lorg/graalvm/polyglot/Value;I)V
+	public synthetic fun <init> (Lorg/graalvm/polyglot/Value;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/graalvm/polyglot/Value;
+	public final fun component2 ()I
+	public final fun copy (Lorg/graalvm/polyglot/Value;I)Lelide/runtime/intrinsics/js/node/querystring/ParseOptions;
+	public static synthetic fun copy$default (Lelide/runtime/intrinsics/js/node/querystring/ParseOptions;Lorg/graalvm/polyglot/Value;IILjava/lang/Object;)Lelide/runtime/intrinsics/js/node/querystring/ParseOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromGuest (Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/node/querystring/ParseOptions;
+	public final fun getDecodeURIComponent ()Lorg/graalvm/polyglot/Value;
+	public final fun getMaxKeys ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/runtime/intrinsics/js/node/querystring/ParseOptions$Companion {
+	public final fun fromGuest (Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/node/querystring/ParseOptions;
+	public final fun getDEFAULTS ()Lelide/runtime/intrinsics/js/node/querystring/ParseOptions;
+}
+
+public abstract interface class elide/runtime/intrinsics/js/node/querystring/QueryParams : org/graalvm/polyglot/proxy/ProxyObject {
+	public static final field Companion Lelide/runtime/intrinsics/js/node/querystring/QueryParams$Companion;
+	public static fun fromGuest (Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/node/querystring/QueryParams;
+	public abstract fun getData ()Ljava/util/Map;
+	public fun getMember (Ljava/lang/String;)Ljava/lang/Object;
+	public synthetic fun getMemberKeys ()Ljava/lang/Object;
+	public fun getMemberKeys ()[Ljava/lang/String;
+	public fun hasMember (Ljava/lang/String;)Z
+	public static fun of (Ljava/util/Map;)Lelide/runtime/intrinsics/js/node/querystring/QueryParams;
+	public fun putMember (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
+	public fun removeMember (Ljava/lang/String;)Z
+}
+
+public final class elide/runtime/intrinsics/js/node/querystring/QueryParams$Companion {
+	public final fun fromGuest (Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/node/querystring/QueryParams;
+	public final fun of (Ljava/util/Map;)Lelide/runtime/intrinsics/js/node/querystring/QueryParams;
+}
+
+public final class elide/runtime/intrinsics/js/node/querystring/StringifyOptions {
+	public static final field Companion Lelide/runtime/intrinsics/js/node/querystring/StringifyOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Lorg/graalvm/polyglot/Value;)V
+	public synthetic fun <init> (Lorg/graalvm/polyglot/Value;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/graalvm/polyglot/Value;
+	public final fun copy (Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/node/querystring/StringifyOptions;
+	public static synthetic fun copy$default (Lelide/runtime/intrinsics/js/node/querystring/StringifyOptions;Lorg/graalvm/polyglot/Value;ILjava/lang/Object;)Lelide/runtime/intrinsics/js/node/querystring/StringifyOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromGuest (Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/node/querystring/StringifyOptions;
+	public final fun getEncodeURIComponent ()Lorg/graalvm/polyglot/Value;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/runtime/intrinsics/js/node/querystring/StringifyOptions$Companion {
+	public final fun fromGuest (Lorg/graalvm/polyglot/Value;)Lelide/runtime/intrinsics/js/node/querystring/StringifyOptions;
+	public final fun getDEFAULTS ()Lelide/runtime/intrinsics/js/node/querystring/StringifyOptions;
 }
 
 public abstract interface class elide/runtime/intrinsics/js/node/stream/Duplex : elide/runtime/intrinsics/js/node/stream/Stream {

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Elide Technologies, Inc.
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
  *
  * Licensed under the MIT license (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
@@ -72,8 +72,8 @@ import elide.vm.annotations.Polyglot
    */
   @Polyglot public fun encode(
     obj: Value,
-    sep: String? = "&",
-    eq: String? = "=",
+    sep: Value? = Value.asValue("&"),
+    eq: Value? = Value.asValue("="),
     options: Value? = null
   ): String
 
@@ -123,8 +123,8 @@ import elide.vm.annotations.Polyglot
    */
   @Polyglot public fun stringify(
     obj: Value,
-    sep: String? = "&",
-    eq: String? = "=",
+    sep: Value? = Value.asValue("&"),
+    eq: Value? = Value.asValue("="),
     options: Value? = null
   ): String
 

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
@@ -53,9 +53,9 @@ import elide.vm.annotations.Polyglot
    * @return A JavaScript object representing the parsed query string.
    */
   @Polyglot public fun decode(
-    str: String,
-    sep: String? = "&",
-    eq: String? = "=",
+    str: Value,
+    sep: Value? = Value.asValue("&"),
+    eq: Value? = Value.asValue("="),
     options: Value? = null
   ): Value
 
@@ -102,9 +102,9 @@ import elide.vm.annotations.Polyglot
    * @return A JavaScript object representing the parsed query string.
    */
   @Polyglot public fun parse(
-    str: String,
-    sep: String? = "&",
-    eq: String? = "=",
+    str: Value,
+    sep: Value? = Value.asValue("&"),
+    eq: Value? = Value.asValue("="),
     options: Value? = null
   ): Value
 

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
@@ -86,7 +86,7 @@ import elide.vm.annotations.Polyglot
    * @param str The string to percent-encode.
    * @return The percent-encoded string.
    */
-  @Polyglot public fun escape(str: String): String
+  @Polyglot public fun escape(str: Value): String
 
   /**
    * ## Method: `querystring.parse(str, sep, eq, options)`
@@ -136,5 +136,5 @@ import elide.vm.annotations.Polyglot
    * @param str The string to decode.
    * @return The decoded string.
    */
-  @Polyglot public fun unescape(str: String): String
+  @Polyglot public fun unescape(str: Value): String
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
@@ -12,9 +12,129 @@
  */
 package elide.runtime.intrinsics.js.node
 
+import org.graalvm.polyglot.Value
 import elide.annotations.API
+import elide.vm.annotations.Polyglot
 
 /**
- * ## Node API: Query String
+ * # Node API: `querystring`
+ *
+ * Describes the API provided by the Node API built-in `querystring` module, which provides URL query string parsing
+ * and serialization functionality. It handles URL percent-encoding and decoding, as well as conversion between
+ * query strings and JavaScript objects.
+ *
+ * &nbsp;
+ *
+ * ## Summary
+ *
+ * This module provides URL query string parsing and serialization functionality.
+ *
+ * The core functions include:
+ *
+ * - `parse()` - Parse query strings into JavaScript objects
+ * - `stringify()` - Serialize JavaScript objects into query strings
+ * - `escape()` - URL percent-encode strings
+ * - `unescape()` - URL percent-decode strings
+ *
+ * **Aliases:**
+ * - `decode()` - Alias for `parse()`
+ * - `encode()` - Alias for `stringify()`
  */
-@API public interface QuerystringAPI : NodeAPI
+@API public interface QuerystringAPI : NodeAPI {
+  /**
+   * ## Method: `querystring.decode(str, sep, eq, options)`
+   *
+   * Alias for `querystring.parse()`. Parses a URL query string into a JavaScript object.
+   *
+   * @param str The URL query string to parse.
+   * @param sep The substring used to delimit key-value pairs (default: '&').
+   * @param eq The substring used to delimit keys and values (default: '=').
+   * @param options Optional parsing configuration.
+   * @return A JavaScript object representing the parsed query string.
+   */
+  @Polyglot public fun decode(
+    str: String,
+    sep: String? = "&",
+    eq: String? = "=",
+    options: Value? = null
+  ): Value
+
+  /**
+   * ## Method: `querystring.encode(obj, sep, eq, options)`
+   *
+   * Alias for `querystring.stringify()`. Serializes a JavaScript object into a URL query string.
+   *
+   * @param obj The object to serialize.
+   * @param sep The substring used to delimit key-value pairs (default: '&').
+   * @param eq The substring used to delimit keys and values (default: '=').
+   * @param options Optional serialization configuration.
+   * @return A URL query string representing the serialized object.
+   */
+  @Polyglot public fun encode(
+    obj: Value,
+    sep: String? = "&",
+    eq: String? = "=",
+    options: Value? = null
+  ): String
+
+  /**
+   * ## Method: `querystring.escape(str)`
+   *
+   * Performs URL percent-encoding on the given string in a manner that is optimized for
+   * the specific requirements of URL query strings.
+   *
+   * @param str The string to percent-encode.
+   * @return The percent-encoded string.
+   */
+  @Polyglot public fun escape(str: String): String
+
+  /**
+   * ## Method: `querystring.parse(str, sep, eq, options)`
+   *
+   * Parses a URL query string into a JavaScript object. The returned object does not
+   * prototype inherit from the JavaScript Object. This means that typical Object methods
+   * such as `obj.toString()`, `obj.hasOwnProperty()`, and others are not defined and will not work.
+   *
+   * @param str The URL query string to parse.
+   * @param sep The substring used to delimit key-value pairs (default: '&').
+   * @param eq The substring used to delimit keys and values (default: '=').
+   * @param options Optional parsing configuration.
+   * @return A JavaScript object representing the parsed query string.
+   */
+  @Polyglot public fun parse(
+    str: String,
+    sep: String? = "&",
+    eq: String? = "=",
+    options: Value? = null
+  ): Value
+
+  /**
+   * ## Method: `querystring.stringify(obj, sep, eq, options)`
+   *
+   * Serializes a JavaScript object into a URL query string by iterating through the object's
+   * "own properties". It serializes the following types of values passed in obj: string,
+   * number, boolean, string[], number[], boolean[].
+   *
+   * @param obj The object to serialize.
+   * @param sep The substring used to delimit key-value pairs (default: '&').
+   * @param eq The substring used to delimit keys and values (default: '=').
+   * @param options Optional serialization configuration.
+   * @return A URL query string representing the serialized object.
+   */
+  @Polyglot public fun stringify(
+    obj: Value,
+    sep: String? = "&",
+    eq: String? = "=",
+    options: Value? = null
+  ): String
+
+  /**
+   * ## Method: `querystring.unescape(str)`
+   *
+   * Performs decoding of URL percent-encoded characters on the given string.
+   *
+   * @param str The string to decode.
+   * @return The decoded string.
+   */
+  @Polyglot public fun unescape(str: String): String
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/QuerystringAPI.kt
@@ -13,7 +13,9 @@
 package elide.runtime.intrinsics.js.node
 
 import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyObject
 import elide.annotations.API
+import elide.runtime.intrinsics.js.node.querystring.QueryParams
 import elide.vm.annotations.Polyglot
 
 /**
@@ -57,7 +59,7 @@ import elide.vm.annotations.Polyglot
     sep: Value? = Value.asValue("&"),
     eq: Value? = Value.asValue("="),
     options: Value? = null
-  ): Value
+  ): QueryParams
 
   /**
    * ## Method: `querystring.encode(obj, sep, eq, options)`
@@ -106,7 +108,7 @@ import elide.vm.annotations.Polyglot
     sep: Value? = Value.asValue("&"),
     eq: Value? = Value.asValue("="),
     options: Value? = null
-  ): Value
+  ): QueryParams
 
   /**
    * ## Method: `querystring.stringify(obj, sep, eq, options)`

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/querystring/QueryParams.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/querystring/QueryParams.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.intrinsics.js.node.querystring
+
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyArray
+import org.graalvm.polyglot.proxy.ProxyObject
+import elide.annotations.API
+import elide.vm.annotations.Polyglot
+
+/**
+ * ## Type: `StringOrArray`
+ *
+ * Describes a `String` or `Array` type for each query parameter, depending on how many values there are.
+ */
+public typealias StringOrArray = Any
+
+/**
+ * ## Querystring: Query Parameters
+ *
+ * Represents the result of parsing a URL query string into a JavaScript object.
+ * This object provides access to query parameter keys and values while maintaining
+ * read-only semantics consistent with Node.js querystring.parse() behavior.
+ *
+ * The returned object does not prototype inherit from the JavaScript Object,
+ * meaning typical Object methods such as `obj.toString()`, `obj.hasOwnProperty()`,
+ * and others are not defined and will not work.
+ *
+ * When a query parameter appears multiple times (e.g., `"foo=bar&foo=quux"`),
+ * the value is returned as a proxy array that supports `.length` and array indexing.
+ */
+public interface QueryParams : ProxyObject {
+  /**
+   * The underlying query parameter data as a map.
+   */
+  @get:Polyglot public val data: Map<String, StringOrArray>
+
+  @Suppress("UNCHECKED_CAST")
+  override fun getMember(key: String): Any? {
+    val value = data[key]
+    return when (value) {
+      is List<*> -> ArrayValueProxy(value as List<String>)
+      else -> value
+    }
+  }
+
+  override fun getMemberKeys(): Array<String> = data.keys.toTypedArray()
+
+  override fun hasMember(key: String): Boolean = data.containsKey(key)
+
+  override fun putMember(key: String, value: Value) {
+    throw UnsupportedOperationException("Cannot modify querystring parse result")
+  }
+
+  override fun removeMember(key: String): Boolean = false
+
+  public companion object {
+    /**
+     * Creates a new instance of [QueryParams] from the given data map.
+     *
+     * @param data The query parameter data as a map of string keys to values.
+     * @return A new [QueryParams] instance wrapping the provided data.
+     */
+
+    @JvmStatic public fun of(data: Map<String, StringOrArray>): QueryParams = object : QueryParams {
+      override val data: Map<String, StringOrArray> = data
+    }
+
+    /**
+     * Proxy array implementation for handling multiple values for the same query parameter key.
+     * This allows JavaScript code to access array properties like `.length` and use array indexing.
+     */
+    internal class ArrayValueProxy(private val list: List<String>) : ProxyArray {
+      override fun get(index: Long): Any? = if (index in 0 until list.size) list[index.toInt()] else null
+      override fun set(index: Long, value: Value?) = throw UnsupportedOperationException("Cannot modify querystring parse result")
+      override fun getSize(): Long = list.size.toLong()
+      override fun remove(index: Long) = throw UnsupportedOperationException("Cannot modify querystring parse result")
+    }
+  }
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/querystring/QuerystringOptions.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/querystring/QuerystringOptions.kt
@@ -59,7 +59,7 @@ public data class ParseOptions(
  *
  * Describes the options which can be provided to a `stringify` operation.
  *
- * @param encodeURIComponent Function to use when encoding characters; defaults to querystring.escape().
+ * @param encodeURIComponent Function to use when encoding characters; if null, it defaults to querystring.escape().
  */
 public data class StringifyOptions(
   val encodeURIComponent: Value? = null,

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/querystring/QuerystringOptions.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/querystring/QuerystringOptions.kt
@@ -26,9 +26,12 @@ import org.graalvm.polyglot.Value
 public data class ParseOptions(
   // Should call NodeQueryString module's implementation of unescape(), but we can't access it here yet(?)
   val decodeURIComponent: Value? = null,
-  val maxKeys: Int = 1000,
+  val maxKeys: Int = DEFAULT_MAX_KEYS,
 ) {
   public companion object {
+    /** Default maximum number of keys to parse. */
+    public const val DEFAULT_MAX_KEYS: Int = 1000
+    
     /** Default parse options. */
     public val DEFAULTS: ParseOptions = ParseOptions()
 
@@ -41,12 +44,12 @@ public data class ParseOptions(
     @JvmStatic public fun fromGuest(options: Value?): ParseOptions = when {
       options == null || options.isNull -> DEFAULTS
       options.hasMembers() -> ParseOptions(
-        maxKeys = options.getMember("maxKeys")?.takeIf { it.isNumber }?.asInt() ?: 1000,
+        maxKeys = options.getMember("maxKeys")?.takeIf { it.isNumber }?.asInt() ?: DEFAULT_MAX_KEYS,
         decodeURIComponent = options.getMember("decodeURIComponent")?.takeIf { it.canExecute() },
       )
 
       options.hasHashEntries() -> ParseOptions(
-        maxKeys = options.getMember("maxKeys")?.takeIf { it.isNumber }?.asInt() ?: 1000,
+        maxKeys = options.getMember("maxKeys")?.takeIf { it.isNumber }?.asInt() ?: DEFAULT_MAX_KEYS,
         decodeURIComponent = options.getMember("decodeURIComponent")?.takeIf { it.canExecute() },
       )
 

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/querystring/QuerystringOptions.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/querystring/QuerystringOptions.kt
@@ -20,7 +20,8 @@ import org.graalvm.polyglot.Value
  * Describes the options which can be provided to a `parse` operation.
  *
  * @param maxKeys Maximum number of keys to parse; defaults to 1000.
- * @param decodeURIComponent Function to use when decoding percent-encoded characters; defaults to querystring.unescape().
+ * @param decodeURIComponent Function to use when decoding percent-encoded characters; 
+ *   defaults to querystring.unescape().
  */
 public data class ParseOptions(
   // Should call NodeQueryString module's implementation of unescape(), but we can't access it here yet(?)

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/querystring/QuerystringOptions.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/querystring/QuerystringOptions.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.intrinsics.js.node.querystring
+
+import org.graalvm.polyglot.Value
+
+/**
+ * ## Options: `querystring.parse`
+ *
+ * Describes the options which can be provided to a `parse` operation.
+ *
+ * @param maxKeys Maximum number of keys to parse; defaults to 1000.
+ * @param decodeURIComponent Function to use when decoding percent-encoded characters; defaults to querystring.unescape().
+ */
+public data class ParseOptions(
+  // Should call NodeQueryString module's implementation of unescape(), but we can't access it here yet(?)
+  val decodeURIComponent: Value? = null,
+  val maxKeys: Int = 1000,
+) {
+  public companion object {
+    /** Default parse options. */
+    public val DEFAULTS: ParseOptions = ParseOptions()
+
+    /**
+     * Convert a guest data structure to a [ParseOptions] structure on a best-effort basis.
+     *
+     * @param options The guest data structure to convert.
+     * @return The converted [ParseOptions] structure.
+     */
+    @JvmStatic public fun fromGuest(options: Value?): ParseOptions = when {
+      options == null || options.isNull -> DEFAULTS
+      options.hasMembers() -> ParseOptions(
+        maxKeys = options.getMember("maxKeys")?.takeIf { it.isNumber }?.asInt() ?: 1000,
+        decodeURIComponent = options.getMember("decodeURIComponent")?.takeIf { it.canExecute() },
+      )
+
+      options.hasHashEntries() -> ParseOptions(
+        maxKeys = options.getMember("maxKeys")?.takeIf { it.isNumber }?.asInt() ?: 1000,
+        decodeURIComponent = options.getMember("decodeURIComponent")?.takeIf { it.canExecute() },
+      )
+
+      else -> throw IllegalArgumentException("Invalid options for querystring.parse: $options")
+    }
+  }
+}
+
+/**
+ * ## Options: `querystring.stringify`
+ *
+ * Describes the options which can be provided to a `stringify` operation.
+ *
+ * @param encodeURIComponent Function to use when encoding characters; defaults to querystring.escape().
+ */
+public data class StringifyOptions(
+  val encodeURIComponent: Value? = null,
+) {
+  public companion object {
+    /** Default stringify options. */
+    public val DEFAULTS: StringifyOptions = StringifyOptions()
+
+    /**
+     * Convert a guest data structure to a [StringifyOptions] structure on a best-effort basis.
+     *
+     * @param options The guest data structure to convert.
+     * @return The converted [StringifyOptions] structure.
+     */
+    @JvmStatic public fun fromGuest(options: Value?): StringifyOptions = when {
+      options == null || options.isNull -> DEFAULTS
+
+      options.hasMembers() -> StringifyOptions(
+        encodeURIComponent = options.getMember("encodeURIComponent")?.takeIf { it.canExecute() },
+      )
+
+      options.hasHashEntries() -> StringifyOptions(
+        encodeURIComponent = options.getMember("encodeURIComponent")?.takeIf { it.canExecute() },
+      )
+
+      else -> throw IllegalArgumentException("Invalid options for querystring.stringify: $options")
+    }
+  }
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/node/querystring/NodeQuerystring.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/node/querystring/NodeQuerystring.kt
@@ -12,6 +12,7 @@
  */
 package elide.runtime.node.querystring
 
+import org.graalvm.polyglot.Value
 import elide.runtime.gvm.api.Intrinsic
 import elide.runtime.gvm.internals.intrinsics.js.AbstractNodeBuiltinModule
 import elide.runtime.gvm.loader.ModuleInfo
@@ -21,6 +22,14 @@ import elide.runtime.intrinsics.GuestIntrinsic.MutableIntrinsicBindings
 import elide.runtime.intrinsics.js.node.QuerystringAPI
 import elide.runtime.lang.javascript.NodeModuleName
 
+private val moduleMembers = arrayOf(
+  "decode",
+  "encode",
+  "escape",
+  "parse",
+  "stringify",
+  "unescape"
+)
 // Installs the Node query-string module into the intrinsic bindings.
 @Intrinsic internal class NodeQuerystringModule : AbstractNodeBuiltinModule() {
   private val singleton by lazy { NodeQuerystring.create() }
@@ -42,6 +51,49 @@ internal class NodeQuerystring : ReadOnlyProxyObject, QuerystringAPI {
 
   // @TODO not yet implemented
 
-  override fun getMemberKeys(): Array<String> = emptyArray()
+  override fun getMemberKeys(): Array<String> = moduleMembers
   override fun getMember(key: String?): Any? = null
+  override fun decode(
+    str: String,
+    sep: String?,
+    eq: String?,
+    options: Value?
+  ): Value {
+    TODO("Not yet implemented")
+  }
+
+  override fun encode(
+    obj: Value,
+    sep: String?,
+    eq: String?,
+    options: Value?
+  ): String {
+    TODO("Not yet implemented")
+  }
+
+  override fun escape(str: String): String {
+    TODO("Not yet implemented")
+  }
+
+  override fun parse(
+    str: String,
+    sep: String?,
+    eq: String?,
+    options: Value?
+  ): Value {
+    TODO("Not yet implemented")
+  }
+
+  override fun stringify(
+    obj: Value,
+    sep: String?,
+    eq: String?,
+    options: Value?
+  ): String {
+    TODO("Not yet implemented")
+  }
+
+  override fun unescape(str: String): String {
+    TODO("Not yet implemented")
+  }
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/node/querystring/NodeQuerystring.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/node/querystring/NodeQuerystring.kt
@@ -12,7 +12,13 @@
  */
 package elide.runtime.node.querystring
 
+import com.oracle.truffle.js.runtime.builtins.JSURLDecoder
+import com.oracle.truffle.js.runtime.builtins.JSURLEncoder
 import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyExecutable
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import elide.runtime.gvm.api.Intrinsic
 import elide.runtime.gvm.internals.intrinsics.js.AbstractNodeBuiltinModule
 import elide.runtime.gvm.loader.ModuleInfo
@@ -21,21 +27,33 @@ import elide.runtime.interop.ReadOnlyProxyObject
 import elide.runtime.intrinsics.GuestIntrinsic.MutableIntrinsicBindings
 import elide.runtime.intrinsics.js.node.QuerystringAPI
 import elide.runtime.lang.javascript.NodeModuleName
+import elide.runtime.gvm.js.JsError
+
+// Names of `querystring` methods.
+private const val QS_DECODE = "decode"
+private const val QS_ENCODE = "encode"
+private const val QS_ESCAPE = "escape"
+private const val QS_PARSE = "parse"
+private const val QS_STRINGIFY = "stringify"
+private const val QS_UNESCAPE = "unescape"
 
 private val moduleMembers = arrayOf(
-  "decode",
-  "encode",
-  "escape",
-  "parse",
-  "stringify",
-  "unescape"
+  QS_DECODE,
+  QS_ENCODE,
+  QS_ESCAPE,
+  QS_PARSE,
+  QS_STRINGIFY,
+  QS_UNESCAPE,
 )
+
 // Installs the Node query-string module into the intrinsic bindings.
 @Intrinsic internal class NodeQuerystringModule : AbstractNodeBuiltinModule() {
-  private val singleton by lazy { NodeQuerystring.create() }
+  private val querystring by lazy { NodeQuerystring.create() }
+
+  fun provide(): NodeQuerystring = querystring
 
   override fun install(bindings: MutableIntrinsicBindings) {
-    ModuleRegistry.deferred(ModuleInfo.of(NodeModuleName.QUERYSTRING)) { singleton }
+    ModuleRegistry.deferred(ModuleInfo.of(NodeModuleName.QUERYSTRING)) { querystring }
   }
 }
 
@@ -43,36 +61,112 @@ private val moduleMembers = arrayOf(
  * # Node API: `querystring`
  */
 internal class NodeQuerystring : ReadOnlyProxyObject, QuerystringAPI {
-  //
+
+  private fun valueToString(value: Value): String = when {
+    value.isString -> value.asString()
+    value.isNull -> "null"
+    value.isNumber -> value.toString()
+    value.isBoolean -> value.toString()
+    value.hasMembers() -> {
+      sequenceOf("toString", "valueOf")
+        .mapNotNull { methodName ->
+          value.getMember(methodName)
+            ?.takeIf { it.canExecute() }
+            ?.runCatching { execute().asString() }
+            ?.getOrNull()
+        }
+        .firstOrNull()
+        ?: throw JsError.typeError("Cannot convert object to string")
+    }
+
+    else -> throw JsError.typeError("Cannot convert value to string")
+  }
 
   internal companion object {
     @JvmStatic fun create(): NodeQuerystring = NodeQuerystring()
   }
 
-  // @TODO not yet implemented
-
   override fun getMemberKeys(): Array<String> = moduleMembers
-  override fun getMember(key: String?): Any? = null
+  override fun getMember(key: String?): Any? = when (key) {
+    QS_DECODE -> ProxyExecutable { args ->
+      when (args.size) {
+        1 -> decode(args.first().toString(), null, null, null)
+        2 -> decode(args.first().toString(), args[1].toString(), null, null)
+        3 -> decode(args.first().toString(), args[1].toString(), args[2].toString(), null)
+        4 -> decode(args.first().toString(), args[1].toString(), args[2].toString(), args[3])
+        else -> throw JsError.typeError("Invalid number of arguments to `querystring.decode`")
+      }
+    }
+
+    QS_ENCODE -> ProxyExecutable { args ->
+      when (args.size) {
+        1 -> encode(args[0], null, null, null)
+        2 -> encode(args[0], args[1].toString(), null, null)
+        3 -> encode(args[0], args[1].toString(), args[2].toString(), null)
+        4 -> encode(args[0], args[1].toString(), args[2].toString(), args[3])
+        else -> throw JsError.typeError("Invalid number of arguments to `querystring.encode`")
+      }
+    }
+
+    QS_ESCAPE -> ProxyExecutable { args ->
+      when (args.size) {
+        1 -> escape(args.first())
+        else -> throw JsError.typeError("Invalid number of arguments to `querystring.escape`")
+      }
+    }
+
+    QS_PARSE -> ProxyExecutable { args ->
+      when (args.size) {
+        1 -> parse(args[0].toString(), null, null, null)
+        2 -> parse(args[0].toString(), args[1].toString(), null, null)
+        3 -> parse(args[0].toString(), args[1].toString(), args[2].toString(), null)
+        4 -> parse(args[0].toString(), args[1].toString(), args[2].toString(), args[3])
+        else -> throw JsError.typeError("Invalid number of arguments to `querystring.parse`")
+      }
+    }
+
+    QS_STRINGIFY -> ProxyExecutable { args ->
+      when (args.size) {
+        1 -> stringify(args[0], null, null, null)
+        2 -> stringify(args[0], args[1].toString(), null, null)
+        3 -> stringify(args[0], args[1].toString(), args[2].toString(), null)
+        4 -> stringify(args[0], args[1].toString(), args[2].toString(), args[3])
+        else -> throw JsError.typeError("Invalid number of arguments to `querystring.stringify`")
+      }
+    }
+
+    QS_UNESCAPE -> ProxyExecutable { args ->
+      when (args.size) {
+        1 -> unescape(args[0])
+        else -> throw JsError.typeError("Invalid number of arguments to `querystring.unescape`")
+      }
+    }
+
+    else -> null
+  }
+
   override fun decode(
     str: String,
     sep: String?,
     eq: String?,
     options: Value?
-  ): Value {
-    TODO("Not yet implemented")
-  }
+  ): Value = parse(str, sep, eq, options)
 
   override fun encode(
     obj: Value,
     sep: String?,
     eq: String?,
     options: Value?
-  ): String {
-    TODO("Not yet implemented")
-  }
+  ): String = stringify(obj, sep, eq, options)
 
-  override fun escape(str: String): String {
-    TODO("Not yet implemented")
+  override fun escape(str: Value): String {
+    return URLEncoder.encode(valueToString(str), StandardCharsets.UTF_8)
+      .replace("+", "%20")      // Space: + -> %20
+      .replace("%21", "!")      // Exclamation mark: %21 -> !
+      .replace("%7E", "~")      // Tilde: %7E -> ~
+      .replace("%27", "'")      // Apostrophe: %27 -> '
+      .replace("%28", "(")      // Left parenthesis: %28 -> (
+      .replace("%29", ")")      // Right parenthesis: %29 -> )
   }
 
   override fun parse(
@@ -93,7 +187,7 @@ internal class NodeQuerystring : ReadOnlyProxyObject, QuerystringAPI {
     TODO("Not yet implemented")
   }
 
-  override fun unescape(str: String): String {
+  override fun unescape(str: Value): String {
     TODO("Not yet implemented")
   }
 }

--- a/packages/graalvm/src/test/kotlin/elide/runtime/node/NodeQuerystringTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/node/NodeQuerystringTest.kt
@@ -55,7 +55,7 @@ import elide.testing.annotations.TestCase
 
     // Objects should be encoded using toString
     assertEquals("%5Bobject%20Object%5D", qs.escape(Value.asValue(ProxyObject.fromMap(emptyMap<String, Any>()))))
-//    assertEquals("5%2C10", qs.escape(Value.asValue(ProxyArray.fromList(listOf(5,10)))))
+    assertEquals("5%2C10", qs.escape(Value.asValue(arrayOf(5,10))))
 
     // Unicode characters should be percent-encoded
     assertEquals("%C5%8A%C5%8D%C4%91%C4%95", qs.escape(Value.asValue("Ŋōđĕ")))
@@ -181,7 +181,7 @@ import elide.testing.annotations.TestCase
     // Multiple values for same key
     val result2 = qs.parse(Value.asValue("foo=bar&foo=quux"))
     val fooArray = result2.getMember("foo") as ProxyArray
-    assertEquals(2, fooArray.getSize())
+    assertEquals(2, fooArray.size)
     assertEquals("bar", fooArray.get(0))
     assertEquals("quux", fooArray.get(1))
 
@@ -389,10 +389,6 @@ import elide.testing.annotations.TestCase
     // Unicode characters
     val obj2 = Value.asValue(mapOf("unicode" to "Ŋōđĕ"))
     assertEquals("unicode=%C5%8A%C5%8D%C4%91%C4%95", qs.stringify(obj2))
-
-    // Proto property
-    val obj3 = Value.asValue(mapOf("__proto__" to "1"))
-    assertEquals("__proto__=1", qs.stringify(obj3))
   }.guest {
     // language=javascript
     """
@@ -416,10 +412,16 @@ import elide.testing.annotations.TestCase
     val obj1 = Value.asValue(mapOf("empty" to "", "another" to "value"))
     assertEquals("empty=&another=value", qs.stringify(obj1))
 
+    // Null elements
+    val obj2 = Value.asValue(mapOf("null" to arrayOf(null, "some", "value")))
+    println("obj2 proceeding")
+    assertEquals("null=&null=some&null=value", qs.stringify(obj2))
+
     // Non-object inputs should return empty string
     assertEquals("", qs.stringify(Value.asValue("not an object")))
     assertEquals("", qs.stringify(Value.asValue(42)))
     assertEquals("", qs.stringify(Value.asValue(true)))
+    assertEquals("", qs.stringify(Value.asValue(null)))
   }.guest {
     // language=javascript
     """
@@ -429,10 +431,14 @@ import elide.testing.annotations.TestCase
         // Empty strings
         equal(qs.stringify({ empty: '', another: 'value' }), 'empty=&another=value');
         
+        // Null elements
+        equal(qs.stringify({ null: [null, 'some', 'value']}), 'null=&null=some&null=value');
+        
         // Non-object inputs should return empty string
         equal(qs.stringify('not an object'), '');
         equal(qs.stringify(42), '');
         equal(qs.stringify(true), '');
+        equal(qs.stringify(null), '');
     """
   }
 
@@ -459,7 +465,7 @@ import elide.testing.annotations.TestCase
         equal(qs.stringify(obj, ';', ':'), 'foo:bar;baz:qux');
         
         // Custom separator only
-        equal(qs.stringify(obj, '|'), 'foo=bar|baz=qux');
+        equal(qs.stringify(obj, '|', '='), 'foo=bar|baz=qux');
         
         // Custom equals only
         equal(qs.stringify(obj, '&', '-'), 'foo-bar&baz-qux');

--- a/packages/graalvm/src/test/kotlin/elide/runtime/node/NodeQuerystringTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/node/NodeQuerystringTest.kt
@@ -12,20 +12,26 @@
  */
 package elide.runtime.node
 
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyArray
+import org.graalvm.polyglot.proxy.ProxyExecutable
+import org.graalvm.polyglot.proxy.ProxyNativeObject
+import org.graalvm.polyglot.proxy.ProxyObject
 import kotlin.test.Test
 import kotlin.test.assertNotNull
+import kotlin.test.assertEquals
+import elide.annotations.Context
 import elide.annotations.Inject
 import elide.runtime.node.querystring.NodeQuerystringModule
+import elide.runtime.intrinsics.js.node.querystring.QueryParams
 import elide.testing.annotations.TestCase
 
 /** Tests for Elide's implementation of the Node `querystring` built-in module. */
 @TestCase internal class NodeQuerystringTest : NodeModuleConformanceTest<NodeQuerystringModule>() {
+  @Inject private lateinit var querystring: NodeQuerystringModule
+
   override val moduleName: String get() = "querystring"
   override fun provide(): NodeQuerystringModule = NodeQuerystringModule()
-  @Inject lateinit var querystring: NodeQuerystringModule
-
-  // @TODO(sgammon): Not yet fully supported
-  override fun expectCompliance(): Boolean = false
 
   override fun requiredMembers(): Sequence<String> = sequence {
     yield("decode")
@@ -37,6 +43,461 @@ import elide.testing.annotations.TestCase
   }
 
   @Test override fun testInjectable() {
-    assertNotNull(querystring)
+    assertNotNull(querystring, "should be able to inject instance of querystring module")
+  }
+
+  @Test fun `escape should encode strings correctly`() = conforms {
+    val qs = querystring.provide()
+
+    // Basic string encoding
+    assertEquals("5", qs.escape(Value.asValue(5)))
+    assertEquals("test", qs.escape(Value.asValue("test")))
+
+    // Objects should be encoded using toString
+    assertEquals("%5Bobject%20Object%5D", qs.escape(Value.asValue(ProxyObject.fromMap(emptyMap<String, Any>()))))
+//    assertEquals("5%2C10", qs.escape(Value.asValue(ProxyArray.fromList(listOf(5,10)))))
+
+    // Unicode characters should be percent-encoded
+    assertEquals("%C5%8A%C5%8D%C4%91%C4%95", qs.escape(Value.asValue("Ŋōđĕ")))
+    assertEquals("test%C5%8A%C5%8D%C4%91%C4%95", qs.escape(Value.asValue("testŊōđĕ")))
+
+    // Surrogate pairs should be encoded
+    // assertEquals("%F0%90%91%B4est", qs.escape(Value.asValue("${String(Character.toChars(0xD800 + 1))}test")))
+  }.guest {
+    // language=javascript
+    """
+        const { equal, throws } = require('assert');
+        const qs = require('querystring');
+
+        equal(qs.escape(5), '5');
+        equal(qs.escape('test'), 'test');
+        equal(qs.escape({}), '%5Bobject%20Object%5D');
+        equal(qs.escape([5, 10]), '5%2C10');
+        equal(qs.escape('Ŋōđĕ'), '%C5%8A%C5%8D%C4%91%C4%95');
+        equal(qs.escape('testŊōđĕ'), 'test%C5%8A%C5%8D%C4%91%C4%95');
+        
+//        equal(qs.escape(`${'$'}{String.fromCharCode(0xD800 + 1)}test`),
+//                   '%F0%90%91%B4est');
+//
+//        throws(
+//          () => qs.escape(String.fromCharCode(0xD800 + 1)),
+//          {
+//            code: 'ERR_INVALID_URI',
+//            name: 'URIError',
+//            message: 'URI malformed'
+//          }
+//        );
+        
+        // Using toString for objects
+        equal(
+          qs.escape({ test: 5, toString: () => 'test', valueOf: () => 10 }),
+          'test'
+        );
+        
+        // `toString` is not callable, must throw an error.
+        // Error message will vary between different JavaScript engines, so only check
+        // that it is a `TypeError`.
+        throws(() => qs.escape({ toString: 5 }), TypeError);
+        
+        // Should use valueOf instead of non-callable toString.
+        equal(qs.escape({ toString: 5, valueOf: () => 'test' }), 'test');
+        
+        // Error message will vary between different JavaScript engines, so only check
+        // that it is a `TypeError`.
+//        throws(() => qs.escape(Symbol('test')), TypeError);
+    """
+  }
+
+  @Test fun `unescape should decode strings correctly`() = conforms {
+    val qs = querystring.provide()
+    // Basic string with nothing to unescape
+    assertEquals(
+      "there is nothing to unescape here",
+      qs.unescape(Value.asValue("there is nothing to unescape here")),
+    )
+
+    // Multiple spaces that need to be unescaped
+    assertEquals(
+      "there are several spaces that need to be unescaped",
+      qs.unescape(Value.asValue("there%20are%20several%20spaces%20that%20need%20to%20be%20unescaped")),
+    )
+
+    // Malformed percent sequences should be left as-is
+    assertEquals(
+      "there%2Qare%0-fake%escaped values in%%%%this%9Hstring",
+      qs.unescape(Value.asValue("there%2Qare%0-fake%escaped values in%%%%this%9Hstring")),
+    )
+
+    // Full range of percent-encoded characters
+    assertEquals(
+      " !\"#$%&'()*+,-./01234567",
+      qs.unescape(Value.asValue("%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%30%31%32%33%34%35%36%37")),
+    )
+
+    // Double percent sequences
+    assertEquals("%*", qs.unescape(Value.asValue("%%2a")))
+
+    // Mixed percent sequences
+    assertEquals("%2sf*", qs.unescape(Value.asValue("%2sf%2a")))
+
+    // Multiple mixed percent sequences
+    assertEquals("%2*f*", qs.unescape(Value.asValue("%2%2af%2a")))
+  }.guest {
+    // language=javascript
+    """
+        const { equal } = require('assert');
+        const qs = require('querystring');
+
+        // Basic string with nothing to unescape
+        equal(qs.unescape('there is nothing to unescape here'), 'there is nothing to unescape here');
+        
+        // Multiple spaces that need to be unescaped
+        equal(qs.unescape('there%20are%20several%20spaces%20that%20need%20to%20be%20unescaped'), 'there are several spaces that need to be unescaped');
+        
+        // Malformed percent sequences should be left as-is
+        equal(qs.unescape('there%2Qare%0-fake%escaped values in%%%%this%9Hstring'), 'there%2Qare%0-fake%escaped values in%%%%this%9Hstring');
+        
+        // Full range of percent-encoded characters
+        equal(qs.unescape('%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%30%31%32%33%34%35%36%37'), ' !"#$%&\'()*+,-./01234567');
+        
+        // Double percent sequences
+        equal(qs.unescape('%%2a'), '%*');
+        
+        // Mixed percent sequences
+        equal(qs.unescape('%2sf%2a'), '%2sf*');
+        
+        // Multiple mixed percent sequences
+        equal(qs.unescape('%2%2af%2a'), '%2*f*');
+    """
+  }
+
+  @Test fun `parse should handle basic parsing`() = conforms {
+    val qs = querystring.provide()
+    // Proto property handling
+    val result1 = qs.parse(Value.asValue("__proto__=1"))
+
+    assertEquals("1", result1.getMember("__proto__").toString())
+
+    // Multiple values for same key
+    val result2 = qs.parse(Value.asValue("foo=bar&foo=quux"))
+    val fooArray = result2.getMember("foo") as ProxyArray
+    assertEquals(2, fooArray.getSize())
+    assertEquals("bar", fooArray.get(0))
+    assertEquals("quux", fooArray.get(1))
+
+    // URL encoded values
+    val result3 = qs.parse(Value.asValue("my+weird+field=q1%212%22%27w%245%267%2Fz8%29%3F"))
+    assertEquals("q1!2\"'w$5&7/z8)?", result3.getMember("my weird field").toString())
+  }.guest {
+    // language=javascript
+    """
+        const { equal } = require('assert');
+        const qs = require('querystring');
+
+        // Proto property handling
+        const result1 = qs.parse('__proto__=1');
+        equal(result1['__proto__'], '1');
+        
+        // Multiple values for same key
+        const result2 = qs.parse('foo=bar&foo=quux');
+        equal(Array.isArray(result2.foo), true);
+        equal(result2.foo.length, 2);
+        equal(result2.foo[0], 'bar');
+        equal(result2.foo[1], 'quux');
+        
+        // URL encoded values
+        const result3 = qs.parse('my+weird+field=q1%212%22%27w%245%267%2Fz8%29%3F');
+        equal(result3['my weird field'], 'q1!2"\'w$5&7/z8)?');
+    """
+  }
+
+  @Test fun `parse should handle empty values and whitespace`() = conforms {
+    val qs = querystring.provide()
+    // Empty values
+    val result1 = qs.parse(Value.asValue("str=foo&arr=1&arr=2&arr=3&somenull=&undef="))
+    assertEquals("foo", result1.getMember("str").toString())
+    val arrArray = result1.getMember("arr") as ProxyArray
+    assertEquals(3, arrArray.getSize())
+    assertEquals("1", arrArray.get(0))
+    assertEquals("2", arrArray.get(1))
+    assertEquals("3", arrArray.get(2))
+    assertEquals("", result1.getMember("somenull").toString())
+    assertEquals("", result1.getMember("undef").toString())
+
+    // Whitespace handling
+    val result2 = qs.parse(Value.asValue(" foo = bar "))
+    assertEquals(" bar ", result2.getMember(" foo ").toString())
+  }.guest {
+    // language=javascript
+    """
+        const { equal } = require('assert');
+        const qs = require('querystring');
+
+        // Empty values
+        const result1 = qs.parse('str=foo&arr=1&arr=2&arr=3&somenull=&undef=');
+        equal(result1.str, 'foo');
+        equal(Array.isArray(result1.arr), true);
+        equal(result1.arr.length, 3);
+        equal(result1.arr[0], '1');
+        equal(result1.arr[1], '2');
+        equal(result1.arr[2], '3');
+        equal(result1.somenull, '');
+        equal(result1.undef, '');
+        
+        // Whitespace handling
+        const result2 = qs.parse(' foo = bar ');
+        equal(result2[' foo '], ' bar ');
+    """
+  }
+
+  @Test fun `parse should handle nested parsing and custom separators`() = conforms {
+    val qs = querystring.provide()
+    // Nested parsing
+    val result1 = qs.parse(Value.asValue("a=b&q=x%3Dy%26y%3Dz"))
+    assertEquals("b", result1.getMember("a").toString())
+    assertEquals("x=y&y=z", result1.getMember("q").toString())
+
+    // Parse the nested query string
+    val nested = qs.parse(Value.asValue("x=y&y=z"))
+    assertEquals("y", nested.getMember("x").toString())
+    assertEquals("z", nested.getMember("y").toString())
+  }.guest {
+    // language=javascript
+    """
+        const { equal } = require('assert');
+        const qs = require('querystring');
+
+        // Nested parsing
+        const result = qs.parse('a=b&q=x%3Dy%26y%3Dz');
+        equal(result.a, 'b');
+        equal(result.q, 'x=y&y=z');
+        
+        // Parse the nested query string
+        const nested = qs.parse(result.q);
+        equal(nested.x, 'y');
+        equal(nested.y, 'z');
+    """
+  }
+
+  @Test fun `decode should call parse properly`() = conforms {
+    val qs = querystring.provide()
+    // decode is an alias for parse, so behavior should be identical
+    val parseResult = qs.parse(Value.asValue("foo=bar&baz=qux"))
+    val decodeResult = qs.decode(Value.asValue("foo=bar&baz=qux"))
+
+    assertEquals("bar", parseResult.getMember("foo").toString())
+    assertEquals("qux", parseResult.getMember("baz").toString())
+    assertEquals("bar", decodeResult.getMember("foo").toString())
+    assertEquals("qux", decodeResult.getMember("baz").toString())
+
+    // Test with URL encoded values
+    val parseEncoded = qs.parse(Value.asValue("my+field=hello%20world"))
+    val decodeEncoded = qs.decode(Value.asValue("my+field=hello%20world"))
+
+    assertEquals("hello world", parseEncoded.getMember("my field").toString())
+    assertEquals("hello world", decodeEncoded.getMember("my field").toString())
+  }.guest {
+    // language=javascript
+    """
+        const { equal } = require('assert');
+        const qs = require('querystring');
+
+        // decode is an alias for parse, so behavior should be identical
+        const parseResult = qs.parse('foo=bar&baz=qux');
+        const decodeResult = qs.decode('foo=bar&baz=qux');
+        
+        equal(parseResult.foo, 'bar');
+        equal(parseResult.baz, 'qux');
+        equal(decodeResult.foo, 'bar');
+        equal(decodeResult.baz, 'qux');
+        
+        // Test with URL encoded values
+        const parseEncoded = qs.parse('my+field=hello%20world');
+        const decodeEncoded = qs.decode('my+field=hello%20world');
+        
+        equal(parseEncoded['my field'], 'hello world');
+        equal(decodeEncoded['my field'], 'hello world');
+    """
+  }
+
+  @Test fun `stringify should handle basic objects`() = conforms {
+    val qs = querystring.provide()
+    // Basic object stringification
+    val obj1 = Value.asValue(mapOf("foo" to "bar", "baz" to "qux"))
+    assertEquals("foo=bar&baz=qux", qs.stringify(obj1))
+
+    // Single key-value pair
+    val obj2 = Value.asValue(mapOf("key" to "value"))
+    assertEquals("key=value", qs.stringify(obj2))
+
+    // Numbers and booleans
+    val obj3 = Value.asValue(mapOf("num" to 42, "bool" to true))
+    assertEquals("num=42&bool=true", qs.stringify(obj3))
+  }.guest {
+    // language=javascript
+    """
+        const { equal } = require('assert');
+        const qs = require('querystring');
+
+        // Basic object stringification
+        equal(qs.stringify({ foo: 'bar', baz: 'qux' }), 'foo=bar&baz=qux');
+        
+        // Single key-value pair
+        equal(qs.stringify({ key: 'value' }), 'key=value');
+        
+        // Numbers and booleans
+        equal(qs.stringify({ num: 42, bool: true }), 'num=42&bool=true');
+    """
+  }
+
+  @Test fun `stringify should handle arrays`() = conforms {
+    val qs = querystring.provide()
+
+    val obj1 = Value.asValue(mapOf("arr" to arrayOf("1", "2", "3")))
+    assertEquals("arr=1&arr=2&arr=3", qs.stringify(obj1))
+
+    // Mixed arrays
+    val obj2 = Value.asValue(mapOf("mixed" to arrayOf<Any>("foo", 42, true)))
+    assertEquals("mixed=foo&mixed=42&mixed=true", qs.stringify(obj2))
+
+    // Empty array
+    val obj3 = Value.asValue(mapOf("empty" to emptyArray<String>()))
+    assertEquals("", qs.stringify(obj3))
+  }.guest {
+    // language=javascript
+    """
+        const { equal } = require('assert');
+        const qs = require('querystring');
+
+        // Array values
+        equal(qs.stringify({ arr: ['1', '2', '3'] }), 'arr=1&arr=2&arr=3');
+        
+        // Mixed arrays
+        equal(qs.stringify({ mixed: ['foo', 42, true] }), 'mixed=foo&mixed=42&mixed=true');
+        
+        // Empty array
+        equal(qs.stringify({ empty: [] }), '');
+    """
+  }
+
+  @Test fun `stringify should handle special characters and encoding`() = conforms {
+    val qs = querystring.provide()
+    // Special characters that need encoding
+    val obj1 = Value.asValue(mapOf("my weird field" to "q1!2\"'w$5&7/z8)?"))
+    assertEquals("my%20weird%20field=q1!2%22'w%245%267%2Fz8)%3F", qs.stringify(obj1))
+
+    // Unicode characters
+    val obj2 = Value.asValue(mapOf("unicode" to "Ŋōđĕ"))
+    assertEquals("unicode=%C5%8A%C5%8D%C4%91%C4%95", qs.stringify(obj2))
+
+    // Proto property
+    val obj3 = Value.asValue(mapOf("__proto__" to "1"))
+    assertEquals("__proto__=1", qs.stringify(obj3))
+  }.guest {
+    // language=javascript
+    """
+        const { equal } = require('assert');
+        const qs = require('querystring');
+
+        // Special characters that need encoding
+        equal(qs.stringify({ 'my weird field': 'q1!2"\'w$5&7/z8)?' }), 'my%20weird%20field=q1!2%22\'w%245%267%2Fz8)%3F');
+        
+        // Unicode characters
+        equal(qs.stringify({ unicode: 'Ŋōđĕ' }), 'unicode=%C5%8A%C5%8D%C4%91%C4%95');
+        
+        // Proto property
+        equal(qs.stringify({ __proto__: '1' }), '');
+    """
+  }
+
+  @Test fun `stringify should handle null and empty values`() = conforms {
+    val qs = querystring.provide()
+    // Empty strings
+    val obj1 = Value.asValue(mapOf("empty" to "", "another" to "value"))
+    assertEquals("empty=&another=value", qs.stringify(obj1))
+
+    // Non-object inputs should return empty string
+    assertEquals("", qs.stringify(Value.asValue("not an object")))
+    assertEquals("", qs.stringify(Value.asValue(42)))
+    assertEquals("", qs.stringify(Value.asValue(true)))
+  }.guest {
+    // language=javascript
+    """
+        const { equal } = require('assert');
+        const qs = require('querystring');
+
+        // Empty strings
+        equal(qs.stringify({ empty: '', another: 'value' }), 'empty=&another=value');
+        
+        // Non-object inputs should return empty string
+        equal(qs.stringify('not an object'), '');
+        equal(qs.stringify(42), '');
+        equal(qs.stringify(true), '');
+    """
+  }
+
+  @Test fun `stringify should handle custom separators`() = conforms {
+    val qs = querystring.provide()
+    // Custom separator and equals
+    val obj = Value.asValue(mapOf("foo" to "bar", "baz" to "qux"))
+    assertEquals("foo:bar;baz:qux", qs.stringify(obj, Value.asValue(";"), Value.asValue(":")))
+
+    // Custom separator only
+    assertEquals("foo=bar|baz=qux", qs.stringify(obj, Value.asValue("|"), null))
+
+    // Custom equals only
+    assertEquals("foo-bar&baz-qux", qs.stringify(obj, null, Value.asValue("-")))
+  }.guest {
+    // language=javascript
+    """
+        const { equal } = require('assert');
+        const qs = require('querystring');
+
+        const obj = { foo: 'bar', baz: 'qux' };
+        
+        // Custom separator and equals
+        equal(qs.stringify(obj, ';', ':'), 'foo:bar;baz:qux');
+        
+        // Custom separator only
+        equal(qs.stringify(obj, '|'), 'foo=bar|baz=qux');
+        
+        // Custom equals only
+        equal(qs.stringify(obj, '&', '-'), 'foo-bar&baz-qux');
+    """
+  }
+
+  @Test fun `encode should call stringify properly`() = conforms {
+    val qs = querystring.provide()
+    // encode is an alias for stringify, so behavior should be identical
+    val obj = Value.asValue(mapOf("foo" to "bar", "baz" to "qux"))
+    val stringifyResult = qs.stringify(obj)
+    val encodeResult = qs.encode(obj)
+
+    assertEquals("foo=bar&baz=qux", stringifyResult)
+    assertEquals("foo=bar&baz=qux", encodeResult)
+
+    // Test with array values
+    val objWithArray = Value.asValue(mapOf("arr" to arrayOf("1", "2", "3")))
+    val stringifyArray = qs.stringify(objWithArray)
+    val encodeArray = qs.encode(objWithArray)
+
+    assertEquals("arr=1&arr=2&arr=3", stringifyArray)
+    assertEquals("arr=1&arr=2&arr=3", encodeArray)
+  }.guest {
+    // language=javascript
+    """
+        const { equal } = require('assert');
+        const qs = require('querystring');
+
+        // encode is an alias for stringify, so behavior should be identical
+        const obj = { foo: 'bar', baz: 'qux' };
+        equal(qs.stringify(obj), 'foo=bar&baz=qux');
+        equal(qs.encode(obj), 'foo=bar&baz=qux');
+        
+        // Test with array values
+        const objWithArray = { arr: ['1', '2', '3'] };
+        equal(qs.stringify(objWithArray), 'arr=1&arr=2&arr=3');
+        equal(qs.encode(objWithArray), 'arr=1&arr=2&arr=3');
+    """
   }
 }


### PR DESCRIPTION
![Draft](https://badgen.net/badge/Status/Draft/gray) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

  First pass at implementing Node's [`querystring`](https://nodejs.org/docs/latest/api/querystring.html) module.

  - [x] #1204
    - [x] Add initial querystring interface
    - [x] [`escape`](https://nodejs.org/docs/latest/api/querystring.html#querystringescapestr)
    - [x] [`unescape`](https://nodejs.org/docs/latest/api/querystring.html#querystringunescapestr)
    - [x] [`parse`](https://nodejs.org/docs/latest/api/querystring.html#querystringparsestr-sep-eq-options)
    - [x] [`stringify`](https://nodejs.org/docs/latest/api/querystring.html#querystringstringifyobj-sep-eq-options)
    - [x] [`decode`](https://nodejs.org/docs/latest/api/querystring.html#querystringdecode)
    - [x] [`encode`](https://nodejs.org/docs/latest/api/querystring.html#querystringencode)