### PR TITLE
fix(cli): crash with `elide init` w.r.t. mcp config

### DIFF
--- a/packages/tooling/src/main/kotlin/elide/tooling/project/agents/AgentAdvice.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/project/agents/AgentAdvice.kt
@@ -113,7 +113,7 @@ public interface AgentAdviceBuilder: RenderableAdvice {
    *
    * @param content Text content to append.
    */
-  public fun text(content: String): Text = Text(content.trimIndent().replace("\n\n\n", "\n\n"))
+  public fun text(content: String): Text = Text(content.trimIndent().replace(Regex("\n{2,}"), "\n\n"))
 
   /**
    * Append a portion of text to the advice under build.

--- a/packages/tooling/src/main/kotlin/elide/tooling/project/mcp/McpProjectConfig.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/project/mcp/McpProjectConfig.kt
@@ -12,7 +12,9 @@
  */
 package elide.tooling.project.mcp
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.ClassDiscriminatorMode
 import kotlinx.serialization.json.Json
 
 /**
@@ -38,9 +40,11 @@ import kotlinx.serialization.json.Json
       )
     )
 
+    @OptIn(ExperimentalSerializationApi::class)
     private val json by lazy {
       Json {
         prettyPrint = true
+        classDiscriminatorMode = ClassDiscriminatorMode.NONE
       }
     }
 

--- a/packages/tooling/src/main/kotlin/elide/tooling/project/mcp/ModelContextProtocol.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/project/mcp/ModelContextProtocol.kt
@@ -47,7 +47,7 @@ import elide.tooling.project.ElideConfiguredProject
  *
  * Public API for the configuration, execution, and operation of Model Context Protocol (MCP) servers for configured
  * Elide projects. MCP provides a standardized way for AI agents to interact with software projects. This API allows
- * for the configuration and execution of an MCP server, which an AI agent can connet to, and use to perform various
+ * for the configuration and execution of an MCP server, which an AI agent can connect to and use to perform various
  * tasks within the context of the project.
  *
  * ## Supported Features
@@ -211,7 +211,11 @@ public object ModelContextProtocol {
           }
 
           post("/message") {
-            val sessionId: String = call.request.queryParameters["sessionId"]!!
+            val sessionId: String? = call.request.queryParameters["sessionId"]
+            if (sessionId == null) {
+              call.respond(HttpStatusCode.BadRequest, "Missing sessionId query parameter")
+              return@post
+            }
             val transport = servers[sessionId]?.transport as? SseServerTransport
             if (transport == null) {
               call.respond(HttpStatusCode.NotFound, "Session not found")


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

MCP configuration introduced a bug because of a clash with the `type` parameter to server blocks.