### PR TITLE
fix: restore `audit` mode for detekt checks

### DIFF
--- a/.github/workflows/checks.detekt.yml
+++ b/.github/workflows/checks.detekt.yml
@@ -54,7 +54,7 @@ jobs:
         uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
         with:
           disable-sudo: true
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
             api.foojay.io:443
             api.github.com:443


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Restores `audit` mode for Detekt in CI, because something important is apparently getting blocked. It appears flaky because when Gradle (itself) is cached, there is no failure.