### PR TITLE
fix: Common kotlin compiler arguments runtime reflection

### DIFF
--- a/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
+++ b/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
@@ -10396,7 +10396,9 @@
     },
     {
       "type": "org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments",
-      "allDeclaredFields": true
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true
     },
     {
       "type": "org.jetbrains.kotlin.cli.common.arguments.CommonToolArguments",


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Using common kotlin compiler arguments causes a runtime reflection issue.

fixes #1538

## Changelog

- fix: register `CommonCompilerArguments` methods for runtime reflection