### PR TITLE
fix(python): context creation during js import

### DIFF
--- a/packages/cli/src/test/kotlin/elide/tool/cli/AbstractEntryTest.kt
+++ b/packages/cli/src/test/kotlin/elide/tool/cli/AbstractEntryTest.kt
@@ -1,6 +1,5 @@
 package elide.tool.cli
 
-import io.micronaut.configuration.picocli.PicocliRunner
 import org.apache.commons.io.output.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Path

--- a/packages/cli/src/test/kotlin/elide/tool/cli/ElideSmokeTests.kt
+++ b/packages/cli/src/test/kotlin/elide/tool/cli/ElideSmokeTests.kt
@@ -85,11 +85,11 @@ import elide.testing.annotations.TestCase
       testFile("stdlib.cjs"),
       testFile("stdlib.mjs"),
       testFile("py_json.py"),
+      testFile("fibgen.mts"),
       testFile("sample.test.mts", listOf("test")),
     )
 
     private val knownBroken = sortedSetOf<String>(
-      "say_hello.mts",
       "main.kts",
       "main-another.kts",
     )

--- a/packages/graalvm-js/src/main/kotlin/elide/runtime/lang/javascript/ElideInteropModuleLoader.kt
+++ b/packages/graalvm-js/src/main/kotlin/elide/runtime/lang/javascript/ElideInteropModuleLoader.kt
@@ -190,6 +190,7 @@ internal object ElideInteropModuleLoader : DelegatedModuleLoaderRegistry.Delegat
         return Undefined.instance
       }
 
+      @Suppress("TooGenericExceptionCaught")
       private fun setInteropModuleDefaultExport(frame: VirtualFrame, module: JSModuleRecord) {
         val surface = facade ?: error("Foreign module facade not initialized")
         val currentEnv = realm.env
@@ -200,7 +201,11 @@ internal object ElideInteropModuleLoader : DelegatedModuleLoaderRegistry.Delegat
         // make sure the language has initialized in the current context
         currentEnv.initializeLanguage(langInfo)
         val py = PythonLanguage.get(null)
-        val pyCtx = PythonContext(py, currentEnv)
+        val pyCtx = try {
+          PythonContext.get(null)
+        } catch (e: Exception) {
+          error("Could not initialize Python context: ${e.message}")
+        }
         val src = Source.newBuilder(surface.lang, file)
           .cached(true)
           .build()

--- a/tools/scripts/fibgen.mts
+++ b/tools/scripts/fibgen.mts
@@ -1,0 +1,8 @@
+import fibgen from "./fibgen.py"
+
+function doFibgen() {
+  fibgen.fib_as_list().forEach((i) => console.log("fib", i))
+}
+
+doFibgen()
+

--- a/tools/scripts/fibgen.py
+++ b/tools/scripts/fibgen.py
@@ -1,0 +1,24 @@
+def fib(limit=10000, previous=1, current=0):
+
+  ''' Generate items in the fibonacci sequence,
+      from the pair (`previous`, `current`) to `limit`.
+      All parameters are ``int``s, and one need only
+      pass a 'limit,' which is also optional and defaults
+      to ``10,000``.
+      
+      :param limit: Value limit to generate numbers to.
+      :param previous: Former value in the moving window.
+      :param current: Latter value in the moving window.
+      :returns: ``int`` values that are successively greater
+      members of the Fibonacci sequence. '''
+
+  if limit and (current >= limit):
+    pass
+  else:
+    yield previous + current
+    for next in fib(limit, current, (previous + current)):
+      yield next
+
+def fib_as_list(limit=10000): 
+  return [i for i in fib(limit)]
+


### PR DESCRIPTION
## Summary

Adds interop smoke tests for Python with generator functions; fixes a condition where the Python context could not be created because lang configuration options had not initialized yet.

## Changelog
```
fix(python): create context via `PythonContext.get(null`)
chore: add python generator sample
```