### PR TITLE
fix: macos hard-crash related to tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ debug = true
 incremental = true
 
 [profile.release]
-opt-level = 3
+opt-level = 2
 lto = true
 strip = "debuginfo"
 debug = true
@@ -50,6 +50,15 @@ codegen-units = 1
 opt-level = "s"
 
 [profile.release.package.local-ai]
+opt-level = "s"
+
+[profile.release.package.trace]
+opt-level = "s"
+
+[profile.release.package.exec]
+opt-level = "s"
+
+[profile.release.package.umbrella]
 opt-level = "s"
 
 [profile.dev.package.builder]


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Reduces our optimization level in Rust land, and forces `trace`, `exec`, and `umbrella` to build in "small" mode; this fixes a native crash (for unclear reasons) related to Orogene, tracing, and Elide's builder. The crash warrants further investigation, but, for now, this is a release blocker, so we have a WA.

- Fixes and closes elide-dev/elide#1554