### PR TITLE
fix(cli): reachability metadata for fetch headers

### DIFF
--- a/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
+++ b/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
@@ -1788,6 +1788,24 @@
       ]
     },
     {
+      "type": "elide.runtime.gvm.internals.intrinsics.js.fetch.$FetchHeadersIntrinsic$Definition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "elide.runtime.gvm.internals.intrinsics.js.fetch.$FetchHeadersIntrinsic$Introspection",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
       "type": "elide.runtime.gvm.internals.intrinsics.js.fetch.$FetchIntrinsic$Definition",
       "methods": [
         {
@@ -1804,6 +1822,18 @@
           "parameterTypes": []
         }
       ]
+    },
+    {
+      "type": "elide.runtime.gvm.internals.intrinsics.js.fetch.FetchHeadersIntrinsic"
+    },
+    {
+      "type": "elide.runtime.gvm.internals.intrinsics.js.fetch.FetchIntrinsic"
+    },
+    {
+      "type": "elide.runtime.gvm.internals.intrinsics.js.fetch.FetchRequestIntrinsic"
+    },
+    {
+      "type": "elide.runtime.gvm.internals.intrinsics.js.fetch.FetchResponseIntrinsic"
     },
     {
       "type": "elide.runtime.gvm.internals.intrinsics.js.stream.$CoreStreamsIntrinsic$Definition",
@@ -12963,6 +12993,9 @@
       "glob": "META-INF/micronaut/"
     },
     {
+      "glob": "META-INF/native/libnetty_tcnative_linux_x86_64.so"
+    },
+    {
       "glob": "META-INF/native/libnetty_transport_native_epoll_x86_64.so"
     },
     {
@@ -13738,6 +13771,27 @@
     },
     {
       "glob": "com/oracle/graal/python/builtins/objects/module/Frozen_POLYGLOT.bin"
+    },
+    {
+      "glob": "com/oracle/graal/python/builtins/objects/module/Frozen_POLYGLOT_DATETIME.bin"
+    },
+    {
+      "glob": "com/oracle/graal/python/builtins/objects/module/Frozen_POLYGLOT_TIME.bin"
+    },
+    {
+      "glob": "com/oracle/graal/python/builtins/objects/module/Frozen_PY_ABC.bin"
+    },
+    {
+      "glob": "com/oracle/graal/python/builtins/objects/module/Frozen_SITEBUILTINS.bin"
+    },
+    {
+      "glob": "com/oracle/graal/python/builtins/objects/module/Frozen_SYSCONFIGDATA.bin"
+    },
+    {
+      "glob": "com/oracle/graal/python/builtins/objects/module/Frozen_WEAKREFSET.bin"
+    },
+    {
+      "glob": "com/oracle/graal/python/builtins/objects/module/Frozen__HELLO__.bin"
     },
     {
       "glob": "com/oracle/graal/python/builtins/objects/module/Frozen__PHELLO__.bin"

--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -896,6 +896,32 @@ public final synthetic class elide/runtime/gvm/internals/intrinsics/js/crypto/$W
 	public fun isBuildable ()Z
 }
 
+public synthetic class elide/runtime/gvm/internals/intrinsics/js/fetch/$FetchHeadersIntrinsic$Factory$ReflectConfig : io/micronaut/core/graal/GraalReflectionConfigurer {
+	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
+	public fun <init> ()V
+	public fun getAnnotationMetadata ()Lio/micronaut/core/annotation/AnnotationMetadata;
+}
+
+public final synthetic class elide/runtime/gvm/internals/intrinsics/js/fetch/$FetchHeadersIntrinsic$Introspection : io/micronaut/inject/beans/AbstractInitializableBeanIntrospectionAndReference {
+	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
+	public fun <init> ()V
+	public fun hasBuilder ()Z
+	public fun instantiate ()Ljava/lang/Object;
+	public fun isBuildable ()Z
+}
+
+public synthetic class elide/runtime/gvm/internals/intrinsics/js/fetch/$FetchHeadersIntrinsic$ReflectConfig : io/micronaut/core/graal/GraalReflectionConfigurer {
+	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
+	public fun <init> ()V
+	public fun getAnnotationMetadata ()Lio/micronaut/core/annotation/AnnotationMetadata;
+}
+
+public synthetic class elide/runtime/gvm/internals/intrinsics/js/fetch/$FetchIntrinsic$Companion$ReflectConfig : io/micronaut/core/graal/GraalReflectionConfigurer {
+	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
+	public fun <init> ()V
+	public fun getAnnotationMetadata ()Lio/micronaut/core/annotation/AnnotationMetadata;
+}
+
 public synthetic class elide/runtime/gvm/internals/intrinsics/js/fetch/$FetchIntrinsic$Definition : io/micronaut/context/AbstractInitializableBeanDefinitionAndReference {
 	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
 	public fun <init> ()V
@@ -913,6 +939,12 @@ public final synthetic class elide/runtime/gvm/internals/intrinsics/js/fetch/$Fe
 	public fun hasBuilder ()Z
 	public fun instantiate ()Ljava/lang/Object;
 	public fun isBuildable ()Z
+}
+
+public synthetic class elide/runtime/gvm/internals/intrinsics/js/fetch/$FetchIntrinsic$ReflectConfig : io/micronaut/core/graal/GraalReflectionConfigurer {
+	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
+	public fun <init> ()V
+	public fun getAnnotationMetadata ()Lio/micronaut/core/annotation/AnnotationMetadata;
 }
 
 public synthetic class elide/runtime/gvm/internals/intrinsics/js/stream/$CoreStreamsIntrinsic$Definition : io/micronaut/context/AbstractInitializableBeanDefinitionAndReference {

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchHeadersIntrinsic.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchHeadersIntrinsic.kt
@@ -12,6 +12,8 @@
  */
 package elide.runtime.gvm.internals.intrinsics.js.fetch
 
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.ReflectiveAccess
 import org.graalvm.polyglot.Value
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
@@ -25,7 +27,7 @@ import elide.runtime.intrinsics.js.MultiMapLike
 import elide.vm.annotations.Polyglot
 
 /** Implementation of `Headers` intrinsic from the Fetch API. */
-internal class FetchHeadersIntrinsic private constructor (
+@ReflectiveAccess @Introspected internal class FetchHeadersIntrinsic private constructor (
   initialData: JsMutableMultiMap<String, String>?,
 
   // Internal data map.

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchIntrinsic.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchIntrinsic.kt
@@ -12,9 +12,10 @@
  */
 package elide.runtime.gvm.internals.intrinsics.js.fetch
 
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.ReflectiveAccess
 import org.graalvm.polyglot.Value
 import org.graalvm.polyglot.proxy.ProxyInstantiable
-import java.io.InputStream
 import java.nio.charset.StandardCharsets
 import elide.runtime.core.DelicateElideApi
 import elide.runtime.gvm.api.Intrinsic
@@ -31,8 +32,7 @@ import elide.vm.annotations.Polyglot
  *
  * TBD.
  */
-@Intrinsic
-internal class FetchIntrinsic : FetchAPI, AbstractJsIntrinsic() {
+@Intrinsic @ReflectiveAccess @Introspected internal class FetchIntrinsic : FetchAPI, AbstractJsIntrinsic() {
   internal companion object {
     /** Global where the fetch method is available. */
     private const val GLOBAL_FETCH = "fetch"
@@ -130,11 +130,7 @@ internal class FetchIntrinsic : FetchAPI, AbstractJsIntrinsic() {
     FetchRequestIntrinsic(url)
   )
 
-  override fun fetch(request: FetchRequest): JsPromise<FetchResponse> {
-    TODO("Fetch is not implemented yet")
-  }
+  override fun fetch(request: FetchRequest): JsPromise<FetchResponse> = handleFetch(Value.asValue(request))
 
-  override fun fetch(url: URL): JsPromise<FetchResponse> {
-    TODO("Not yet implemented")
-  }
+  override fun fetch(url: URL): JsPromise<FetchResponse> = handleFetch(Value.asValue(url))
 }


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Fixes crash via use of `new Headers()`, because of missing reachability metadata.

- Fixes: elide-dev/elide#1559