### PR TITLE
fix: guest error handling (js)

### DIFF
--- a/packages/cli/src/main/kotlin/elide/tool/cli/AbstractToolCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/AbstractToolCommand.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
+import elide.tool.cli.cmd.repl.HandledExit
 import elide.tool.cli.err.AbstractToolError
 import elide.tool.cli.state.CommandOptions
 import elide.tool.cli.state.CommandState
@@ -175,6 +176,9 @@ abstract class AbstractToolCommand<Context>:
       }.let {
         if (it.isFailure) {
           val err = it.exceptionOrNull()
+          if (err != null && HandledExit.isHandledExit(err)) {
+            throw err  // re-throw for outer
+          }
           val stack = err?.stackTrace?.joinToString("\n") ?: "(unknown)"
           val label = err ?: "(unknown)"
           logging.error("Uncaught fatal exception: $label\n$stack")

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/HandledExit.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/HandledExit.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tool.cli.cmd.repl
+
+// Internal signal which lets the outer entrypoint know that the runner has exited in a handled manner, and asks that
+// the final exit code be set to the provided value.
+internal class HandledExit private constructor (
+  internal val exitCode: Int,
+  internal val causeMessage: String? = null,
+  cause: Throwable? = null,
+) : RuntimeException(SENTINEL, cause, true, false) {
+  companion object {
+    private const val SENTINEL = "ಠ_ಠ"
+
+    @JvmStatic fun isHandledExit(exc: Throwable): Boolean {
+      return exc is HandledExit && exc.message == SENTINEL
+    }
+
+    @JvmStatic fun notify(exitCode: Int, message: String? = null, cause: Throwable? = null): Nothing {
+      throw HandledExit(
+        exitCode = exitCode,
+        causeMessage = message,
+        cause = cause,
+      )
+    }
+  }
+}

--- a/packages/cli/src/main/kotlin/elide/tool/err/ErrorHandler.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/err/ErrorHandler.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.Transient
 import kotlin.system.exitProcess
 import elide.runtime.Logger
 import elide.tool.cli.GuestLanguage
+import elide.tool.cli.cmd.repl.HandledExit
 import elide.tool.cli.err.AbstractToolError
 import elide.tool.err.ErrorHandler.Action.*
 import elide.tool.err.ErrorHandler.ErrorActionStrategy.*
@@ -653,7 +654,10 @@ interface ErrorHandler : IExitCodeExceptionMapper, Thread.UncaughtExceptionHandl
       exitCode
     }
 
-    else -> {
+    else -> if (exception is HandledExit) {
+      logging.debug(exception.message)
+      exception.exitCode
+    } else {
       logging.error("Exiting with code -1 due to uncaught $exception")
       -1
     }

--- a/third_party/oracle/README.md
+++ b/third_party/oracle/README.md
@@ -2,5 +2,11 @@
 
 This root exits to document the versions of GraalVM patches are built from:
 
-- [`oracle/graal`](https://github.com/oracle/graal): 804dab21e1ebb363172794e9be20b5ea070d807d
+- [`oracle/graal`](https://github.com/oracle/graal): 5b5add29fa0830a5e33330d3bb7261ed2b78d69d
+  - Current patch revision: `4b135ed165a7cdeb8328c45276294aedb53fe279` ([fork](https://github.com/elide-dev/graal))
+  - JDK24 branch: `fix/all-jdk24.2.2`
+  - JDK25 branch: `fix/all-jdk25`
 - [`oracle/graaljs`](https://github.com/oracle/graaljs): 992edb8044fce8761adcb816420e1ec2e0649cab
+  - Current patch revision: `ef48323dd078ea935aa9e898b34534d63330320d` ([fork](https://github.com/elide-dev/graaljs))
+  - JDK24 branch: `fix/all-jdk24.2.2`
+  - JDK25 branch: `fix/all-jdk25`


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Restores pretty error handling. Given the script,

```js
console.log("hi", missing)
```

And,
```
elide run ./err.js
```

Before this PR:
```
Uncaught fatal exception: org.graalvm.polyglot.PolyglotException: ReferenceError: missing is not defined
<js>.:program(err.js:1)
org.graalvm.polyglot/org.graalvm.polyglot.Value.execute(Value.java:1047)
elide.tool.cli.cmd.repl.ToolShellCommand.execWrapped(ToolShellCommand.kt:1656)
elide.tool.cli.cmd.repl.ToolShellCommand.executeSource(ToolShellCommand.kt:1870)
elide.tool.cli.cmd.repl.ToolShellCommand.invoke$lambda$191$lambda$174(ToolShellCommand.kt:2808)
elide.tool.cli.AbstractSubcommand.withDeferredContext(AbstractSubcommand.kt:686)
elide.tool.cli.AbstractSubcommand.withDeferredContext$default(AbstractSubcommand
...
elide.tool.cli.MainKt.main(main.kt:335)
java.base@24.0.2/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
ReferenceError: missing is not defined
        at <js> :program(tools/scripts/err.js:1:18-24)
        at org.graalvm.polyglot/org.graalvm.polyglot.Value.execute(Value.java:1047)
...
```

After this PR:
```
╔════════════════════════════════════════════════════════════════════════════════════╗
→  1┊ console.log("hi", missing)                                                     ║
╟────────────────────────────────────────────────────────────────────────────────────╢
║ ReferenceError: missing is not defined                                             ║
╟────────────────────────────────────────────────────────────────────────────────────╢
║ Stacktrace:                                                                        ║
║   ReferenceError: missing is not defined                                           ║
║       at err.js:1                                                                  ║
╚════════════════════════════════════════════════════════════════════════════════════╝
```

## Changelog
```
fix: HostException visibility for error handling
chore: update `third_party/oracle/README.md`
```