### PR TITLE
feat(graalvm-kt): support for powerassert

### DIFF
--- a/gradle/elide.versions.toml
+++ b/gradle/elide.versions.toml
@@ -582,6 +582,7 @@ kotlin-compiler-runner = { group = "org.jetbrains.kotlin", name = "kotlin-compil
 kotlin-compiler-testing = { group = "com.github.tschuchortdev", name = "kotlin-compile-testing", version.ref = "kotlin-compile-testing" }
 kotlin-compiler-testing-ksp = { group = "com.github.tschuchortdev", name = "kotlin-compile-testing-ksp", version.ref = "kotlin-compile-testing" }
 kotlin-serialization-embedded = { group = "org.jetbrains.kotlin", name = "kotlin-serialization-compiler-plugin-embeddable", version.ref = "kotlin-sdk" }
+kotlin-powerAssert-embedded = { group = "org.jetbrains.kotlin", name = "kotlin-power-assert-compiler-plugin-embeddable", version.ref = "kotlin-sdk" }
 kotlin-main-kts = { group = "org.jetbrains.kotlin", name = "kotlin-main-kts", version.ref = "kotlin-sdk" }
 kotlin-scripting-common = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-common", version.ref = "kotlin-sdk" }
 kotlin-scripting-runtime = { group = "org.jetbrains.kotlin", name = "kotlin-script-runtime", version.ref = "kotlin-sdk" }

--- a/packages/builder/api/builder.api
+++ b/packages/builder/api/builder.api
@@ -2397,7 +2397,7 @@ public final class elide/tooling/kotlin/KotlinCompiler : elide/tooling/AbstractT
 	public fun <init> (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Lkotlin/jvm/functions/Function1;Ljava/nio/file/Path;Z)V
 	public synthetic fun <init> (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Lkotlin/jvm/functions/Function1;Ljava/nio/file/Path;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun classesDir (Ljava/nio/file/Path;)Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;
-	public static final fun configureDefaultPlugins (Lorg/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments;ZZ)Ljava/util/Set;
+	public static final fun configureDefaultPlugins (Lorg/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments;ZZZ)Ljava/util/Set;
 	public static final fun create (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Ljava/nio/file/Path;ZLkotlin/jvm/functions/Function1;)Lelide/tooling/kotlin/KotlinCompiler;
 	public final fun getInputs ()Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;
 	public final fun getOutputs ()Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;
@@ -2410,8 +2410,8 @@ public final class elide/tooling/kotlin/KotlinCompiler : elide/tooling/AbstractT
 
 public final class elide/tooling/kotlin/KotlinCompiler$Companion {
 	public final fun classesDir (Ljava/nio/file/Path;)Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;
-	public final fun configureDefaultPlugins (Lorg/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments;ZZ)Ljava/util/Set;
-	public static synthetic fun configureDefaultPlugins$default (Lelide/tooling/kotlin/KotlinCompiler$Companion;Lorg/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments;ZZILjava/lang/Object;)Ljava/util/Set;
+	public final fun configureDefaultPlugins (Lorg/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments;ZZZ)Ljava/util/Set;
+	public static synthetic fun configureDefaultPlugins$default (Lelide/tooling/kotlin/KotlinCompiler$Companion;Lorg/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments;ZZZILjava/lang/Object;)Ljava/util/Set;
 	public final fun create (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Ljava/nio/file/Path;ZLkotlin/jvm/functions/Function1;)Lelide/tooling/kotlin/KotlinCompiler;
 	public static synthetic fun create$default (Lelide/tooling/kotlin/KotlinCompiler$Companion;Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Ljava/nio/file/Path;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lelide/tooling/kotlin/KotlinCompiler;
 	public final fun outputJar (Ljava/nio/file/Path;)Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;

--- a/packages/builder/build.gradle.kts
+++ b/packages/builder/build.gradle.kts
@@ -106,6 +106,8 @@ dependencies {
   implementation(libs.highlights)
   implementation(libs.ktoml)
   implementation(libs.kotlin.compiler.embedded)
+  implementation(libs.kotlin.serialization.embedded)
+  implementation(libs.kotlin.powerAssert.embedded)
   implementation(libs.kotlinx.serialization.core)
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.kotlinx.serialization.protobuf)

--- a/packages/builder/src/main/kotlin/elide/tooling/jvm/JvmBuildConfigurator.kt
+++ b/packages/builder/src/main/kotlin/elide/tooling/jvm/JvmBuildConfigurator.kt
@@ -533,12 +533,12 @@ internal class JvmBuildConfigurator : BuildConfigurator {
       incrementalCompilation = state.manifest.kotlin?.features?.incremental ?: true
 
       // handle built-in plugins
-      if (state.manifest.kotlin?.features?.enableDefaultPlugins == true) {
+      if (state.manifest.kotlin?.features?.enableDefaultPlugins != false) {
         effectiveKnownPlugins.addAll(
           KotlinCompiler.configureDefaultPlugins(
             this,
             tests,
-            enableSerialization = state.manifest.kotlin?.features?.serialization == true,
+            enableSerialization = state.manifest.kotlin?.features?.serialization != false,
           ),
         )
       }

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
@@ -1820,7 +1820,7 @@ internal class ToolShellCommand @Inject constructor(
           }
           output {
             append(formatMaybe(
-              "✗  ${test.qualifiedName} ($msg)",
+              "✗  ${test.qualifiedName}\n$msg",
               TextStyles.bold + TextColors.red,
               false,
             ))

--- a/packages/cli/src/projects/ktjvm/src/test/kotlin/sample/testGreeting.kt
+++ b/packages/cli/src/projects/ktjvm/src/test/kotlin/sample/testGreeting.kt
@@ -6,6 +6,6 @@ class SampleTest {
   @Test fun testGreeting() {
     val greeting = render_greeting()
     assertNotNull(greeting)
-    assertEquals("Hello, World", greeting)
+    assertEquals("Hello World", greeting)
   }
 }

--- a/packages/graalvm-kt/build.gradle.kts
+++ b/packages/graalvm-kt/build.gradle.kts
@@ -129,6 +129,7 @@ dependencies {
   implementation(libs.kotlin.scripting.compiler.embeddable)
   implementation(libs.kotlin.compiler.embedded)
   implementation(libs.kotlin.serialization.embedded)
+  implementation(libs.kotlin.powerAssert.embedded)
   implementation(libs.kotlin.scripting.dependencies)
   implementation(libs.kotlin.scripting.dependencies.maven) {
     exclude(group = "com.google.inject", module = "guice")
@@ -167,6 +168,7 @@ dependencies {
 
   // @TODO(sgammon): needed at build time, but not runtime
   embeddedKotlin(libs.kotlin.serialization.embedded)
+  embeddedKotlin(libs.kotlin.powerAssert.embedded)
 
   embeddedJava(libs.jacoco.agent)
   embeddedJava(libs.junit.jupiter.api)

--- a/packages/tooling/src/main/kotlin/elide/tooling/project/manifest/ElidePackageManifest.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/project/manifest/ElidePackageManifest.kt
@@ -448,7 +448,7 @@ public data class ElidePackageManifest(
     val testing: Boolean = true,
     val kotlinx: Boolean = true,
     val enableDefaultPlugins: Boolean = true,
-    val experimental: Boolean = false,
+    val experimental: Boolean = true,
     val incremental: Boolean = true,
     val serialization: Boolean = kotlinx && enableDefaultPlugins && experimental,
     val coroutines: Boolean = kotlinx,


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds support for Kotlin Power Assert when running `elide test ...` on Kotlin code. Continuance of #1374.

**Before**

<img width="733" height="188" alt="Screenshot 2025-07-20 at 2 14 36 AM" src="https://github.com/user-attachments/assets/0ea2d67c-5e62-44ba-bac6-abb2181eef42" />

---

**After**

<img width="652" height="266" alt="Screenshot 2025-07-20 at 2 11 09 AM" src="https://github.com/user-attachments/assets/c9037bbc-4dcb-4d4f-8e53-519f56346ec8" />