### PR TITLE
fix: static native linux build (musl)

### DIFF
--- a/packages/builder/src/main/kotlin/elide/tooling/web/WebBuilder.kt
+++ b/packages/builder/src/main/kotlin/elide/tooling/web/WebBuilder.kt
@@ -62,12 +62,10 @@ private object WebBuilderInternals {
     true -> true // built-in if running in native mode
     else -> when (initialized.value) {
       true -> true // already initialized
-      false -> synchronized(this) {
-        NativeLibraries.loadLibrary(NATIVE_WEB_LIB).also {
-          when (it) {
-            true -> initialized.value = true
-            else -> error("Failed to load lib$NATIVE_WEB_LIB")
-          }
+      false -> NativeLibraries.loadLibrary(NATIVE_WEB_LIB).also {
+        when (it) {
+          true -> initialized.value = true
+          else -> error("Failed to load lib$NATIVE_WEB_LIB")
         }
       }
     }

--- a/packages/cli/src/main/kotlin/elide/tool/feature/MediaBuilderFeature.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/feature/MediaBuilderFeature.kt
@@ -48,6 +48,7 @@ import elide.tooling.img.Images
   )
 
   override fun beforeAnalysis(access: BeforeAnalysisAccess) {
+    if (staticJni) return
     Images.load()
   }
 }

--- a/packages/cli/src/main/kotlin/elide/tool/feature/WebBuilderFeature.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/feature/WebBuilderFeature.kt
@@ -51,6 +51,7 @@ import elide.tooling.web.WebBuilder
 
   override fun beforeAnalysis(access: BeforeAnalysisAccess) {
     super.beforeAnalysis(access)
+    if (staticJni) return
     WebBuilder.load()
   }
 }

--- a/packages/engine/src/main/kotlin/elide/runtime/core/lib/NativeLibraries.kt
+++ b/packages/engine/src/main/kotlin/elide/runtime/core/lib/NativeLibraries.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Elide Technologies, Inc.
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
  *
  * Licensed under the MIT license (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
@@ -11,6 +11,8 @@
  * License for the specific language governing permissions and limitations under the License.
  */
 package elide.runtime.core.lib
+
+import org.graalvm.nativeimage.ImageInfo
 
 /**
  * # Native Libraries
@@ -37,8 +39,11 @@ public object NativeLibraries {
    * @return A boolean value indicating whether the library was loaded successfully.
    */
   public fun resolve(name: String, callback: ((Boolean) -> Unit)? = null): Boolean {
-    return runCatching { System.loadLibrary(name) }.isSuccess.also {
-      callback?.invoke(it)
+    return when (ImageInfo.inImageRuntimeCode() && System.getProperty("elide.staticJni") == "true") {
+      true -> true
+      false -> runCatching { System.loadLibrary(name) }.isSuccess.also {
+        callback?.invoke(it)
+      }
     }
   }
 


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

At one point our musl-targeted Linux build was broken by upstream stuff; in the intervening time, we made changes which made us further incompatible with a static target. Upstream fixed their thing, and now we need to propagate fixes downstream to re-enable the static Linux native build.

As a result, this PR is small, because it only accounts for our own errors on that path. Between this and the GVM update in the last PR, our static musl build works smoothly again.

- Fixes: elide-dev/elide#1439