### PR TITLE
fix: sqlite results should `JSON.stringify`

### DIFF
--- a/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
+++ b/packages/cli/src/main/resources/META-INF/native-image/dev/elide/elide-cli/reachability-metadata.json
@@ -9063,7 +9063,13 @@
       "type": "kotlin.String"
     },
     {
-      "type": "kotlin.Unit"
+      "type": "kotlin.Unit",
+      "methods": [
+        {
+          "name": "toString",
+          "parameterTypes": []
+        }
+      ]
     },
     {
       "type": "kotlin.collections.List"
@@ -12064,6 +12070,9 @@
       "type": "org.pkl.core.runtime.VmLanguageProvider"
     },
     {
+      "type": "org.sqlite.JDBC"
+    },
+    {
       "type": "oshi.jna.ByRef$CloseableIntByReference",
       "allDeclaredMethods": true,
       "allPublicMethods": true,
@@ -13188,6 +13197,9 @@
       "glob": "META-INF/services/java.nio.file.spi.FileSystemProvider"
     },
     {
+      "glob": "META-INF/services/java.sql.Driver"
+    },
+    {
       "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
     },
     {
@@ -14136,6 +14148,9 @@
     },
     {
       "type": "[Lcom.sun.management.internal.DiagnosticCommandInfo;"
+    },
+    {
+      "type": "[Z"
     },
     {
       "type": "[[J"
@@ -15101,6 +15116,15 @@
       ]
     },
     {
+      "type": "java.lang.Throwable",
+      "methods": [
+        {
+          "name": "toString",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
       "type": "java.net.InetSocketAddress",
       "methods": [
         {
@@ -15161,6 +15185,164 @@
     },
     {
       "type": "jdk.internal.loader.ClassLoaders$AppClassLoader"
+    },
+    {
+      "type": "org.sqlite.BusyHandler",
+      "methods": [
+        {
+          "name": "callback",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.sqlite.Collation",
+      "methods": [
+        {
+          "name": "xCompare",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.sqlite.Function",
+      "fields": [
+        {
+          "name": "args"
+        },
+        {
+          "name": "context"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "xFunc",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.sqlite.Function$Aggregate",
+      "methods": [
+        {
+          "name": "clone",
+          "parameterTypes": []
+        },
+        {
+          "name": "xFinal",
+          "parameterTypes": []
+        },
+        {
+          "name": "xStep",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.sqlite.Function$Window",
+      "methods": [
+        {
+          "name": "xInverse",
+          "parameterTypes": []
+        },
+        {
+          "name": "xValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.sqlite.ProgressHandler",
+      "methods": [
+        {
+          "name": "progress",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.sqlite.core.DB",
+      "methods": [
+        {
+          "name": "onCommit",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "onUpdate",
+          "parameterTypes": [
+            "int",
+            "java.lang.String",
+            "java.lang.String",
+            "long"
+          ]
+        },
+        {
+          "name": "throwex",
+          "parameterTypes": []
+        },
+        {
+          "name": "throwex",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.sqlite.core.DB$ProgressObserver",
+      "methods": [
+        {
+          "name": "progress",
+          "parameterTypes": [
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.sqlite.core.NativeDB",
+      "fields": [
+        {
+          "name": "busyHandler"
+        },
+        {
+          "name": "commitListener"
+        },
+        {
+          "name": "pointer"
+        },
+        {
+          "name": "progressHandler"
+        },
+        {
+          "name": "updateListener"
+        }
+      ],
+      "methods": [
+        {
+          "name": "stringToUtf8ByteArray",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "throwex",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
     },
     {
       "type": "sun.launcher.LauncherHelper",

--- a/packages/cli/src/test/kotlin/elide/tool/cli/ElideSmokeTests.kt
+++ b/packages/cli/src/test/kotlin/elide/tool/cli/ElideSmokeTests.kt
@@ -82,6 +82,7 @@ import elide.testing.annotations.TestCase
       testFile("sqlite.cjs"),
       testFile("sqlite.mjs"),
       testFile("sqlite.ts"),
+      testFile("sqlite-json.mts"),
       testFile("stdlib.cjs"),
       testFile("stdlib.mjs"),
       testFile("py_json.py"),

--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -7016,7 +7016,7 @@ public synthetic class elide/runtime/intrinsics/sqlite/$SQLiteTransactor$Reflect
 public abstract interface class elide/runtime/intrinsics/sqlite/SQLiteAPI : org/graalvm/polyglot/proxy/ProxyObject {
 }
 
-public abstract interface class elide/runtime/intrinsics/sqlite/SQLiteDatabase : elide/runtime/intrinsics/js/Disposable, java/io/Closeable, java/lang/AutoCloseable, org/graalvm/polyglot/proxy/ProxyObject {
+public abstract interface class elide/runtime/intrinsics/sqlite/SQLiteDatabase : elide/runtime/interop/ReadOnlyProxyObject, elide/runtime/intrinsics/js/Disposable, java/io/Closeable, java/lang/AutoCloseable {
 	public static final field DEFAULT_CREATE Z
 	public static final field DEFAULT_READONLY Z
 	public static final field DEFAULT_THROW_ON_ERROR Z
@@ -7027,18 +7027,15 @@ public abstract interface class elide/runtime/intrinsics/sqlite/SQLiteDatabase :
 	public abstract fun connection ()Lorg/sqlite/SQLiteConnection;
 	public abstract fun deserialize ([BLjava/lang/String;)V
 	public static synthetic fun deserialize$default (Lelide/runtime/intrinsics/sqlite/SQLiteDatabase;[BLjava/lang/String;ILjava/lang/Object;)V
-	public abstract fun exec (Lelide/runtime/intrinsics/sqlite/SQLiteStatement;[Ljava/lang/Object;)V
-	public abstract fun exec (Ljava/lang/String;[Ljava/lang/Object;)V
+	public abstract fun exec (Lelide/runtime/intrinsics/sqlite/SQLiteStatement;[Ljava/lang/Object;)Lcom/oracle/truffle/js/runtime/objects/JSDynamicObject;
+	public abstract fun exec (Ljava/lang/String;[Ljava/lang/Object;)Lcom/oracle/truffle/js/runtime/objects/JSDynamicObject;
 	public abstract fun getActive ()Z
 	public synthetic fun getMemberKeys ()Ljava/lang/Object;
 	public fun getMemberKeys ()[Ljava/lang/String;
-	public fun hasMember (Ljava/lang/String;)Z
-	public abstract fun loadExtension (Ljava/lang/String;)V
+	public abstract fun loadExtension (Ljava/lang/String;)Lcom/oracle/truffle/js/runtime/objects/JSDynamicObject;
 	public abstract fun prepare (Ljava/lang/String;[Ljava/lang/Object;)Lelide/runtime/intrinsics/sqlite/SQLiteStatement;
-	public fun putMember (Ljava/lang/String;Lorg/graalvm/polyglot/Value;)V
 	public abstract fun query (Lelide/runtime/intrinsics/sqlite/SQLiteStatement;[Ljava/lang/Object;)Lelide/runtime/intrinsics/sqlite/SQLiteStatement;
 	public abstract fun query (Ljava/lang/String;[Ljava/lang/Object;)Lelide/runtime/intrinsics/sqlite/SQLiteStatement;
-	public fun removeMember (Ljava/lang/String;)Z
 	public abstract fun serialize (Ljava/lang/String;)[B
 	public static synthetic fun serialize$default (Lelide/runtime/intrinsics/sqlite/SQLiteDatabase;Ljava/lang/String;ILjava/lang/Object;)[B
 	public abstract fun transaction (Lelide/runtime/intrinsics/sqlite/SQLiteTransactor;)Lelide/runtime/intrinsics/sqlite/SQLiteTransaction;
@@ -7052,7 +7049,7 @@ public final class elide/runtime/intrinsics/sqlite/SQLiteDatabase$Defaults {
 	public static final field MAIN_SCHEMA Ljava/lang/String;
 }
 
-public abstract interface class elide/runtime/intrinsics/sqlite/SQLiteObject : elide/runtime/intrinsics/js/MapLike {
+public abstract interface class elide/runtime/intrinsics/sqlite/SQLiteObject : elide/runtime/interop/ReadOnlyProxyObject, elide/runtime/intrinsics/js/MapLike {
 	public abstract fun asList ()Ljava/util/List;
 	public abstract fun getColumnTypes ()Ljava/util/Map;
 	public abstract fun getColumns ()[Ljava/lang/String;

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/sqlite/SQLiteDatabase.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/sqlite/SQLiteDatabase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Elide Technologies, Inc.
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
  *
  * Licensed under the MIT license (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
@@ -12,14 +12,14 @@
  */
 package elide.runtime.intrinsics.sqlite
 
+import com.oracle.truffle.js.runtime.objects.JSDynamicObject
 import io.micronaut.core.annotation.ReflectiveAccess
-import org.graalvm.polyglot.Value
-import org.graalvm.polyglot.proxy.ProxyObject
 import org.intellij.lang.annotations.Language
 import org.sqlite.SQLiteConnection
 import org.sqlite.core.DB
 import java.io.Closeable
 import elide.annotations.API
+import elide.runtime.interop.ReadOnlyProxyObject
 import elide.runtime.intrinsics.js.Disposable
 import elide.vm.annotations.Polyglot
 
@@ -101,7 +101,7 @@ private val SQLITE_DATABASE_PROPS_AND_METHODS = arrayOf(
  * @see SQLiteTransactor Transactor Interface
  * @see SQLiteType SQLite Types
  */
-@API @ReflectiveAccess public interface SQLiteDatabase: Closeable, AutoCloseable, ProxyObject, Disposable {
+@API @ReflectiveAccess public interface SQLiteDatabase: Closeable, AutoCloseable, ReadOnlyProxyObject, Disposable {
   /** Hard-coded defaults for SQLite. */
   public companion object Defaults {
     public const val DEFAULT_CREATE: Boolean = false
@@ -137,7 +137,7 @@ private val SQLITE_DATABASE_PROPS_AND_METHODS = arrayOf(
    *
    * @param extension Extension path or name to load.
    */
-  @Polyglot public fun loadExtension(extension: String)
+  @Polyglot public fun loadExtension(extension: String): JSDynamicObject
 
   /**
    * ## Prepare Statement
@@ -201,7 +201,7 @@ private val SQLITE_DATABASE_PROPS_AND_METHODS = arrayOf(
    * @param statement SQL query to execute.
    * @param args Arguments to bind to the statement.
    */
-  @Polyglot public fun exec(@Language("sql") statement: String, vararg args: Any?)
+  @Polyglot public fun exec(@Language("sql") statement: String, vararg args: Any?): JSDynamicObject
 
   /**
    * ## Execute (Statement)
@@ -214,7 +214,7 @@ private val SQLITE_DATABASE_PROPS_AND_METHODS = arrayOf(
    * @param statement Prepared statement to execute.
    * @param args Arguments to bind to the statement.
    */
-  @Polyglot public fun exec(statement: SQLiteStatement, vararg args: Any?)
+  @Polyglot public fun exec(statement: SQLiteStatement, vararg args: Any?): JSDynamicObject
 
   /**
    * ## Execute Transaction
@@ -282,13 +282,4 @@ private val SQLITE_DATABASE_PROPS_AND_METHODS = arrayOf(
   // -- Proxy Object Interface
 
   override fun getMemberKeys(): Array<String> = SQLITE_DATABASE_PROPS_AND_METHODS
-  override fun hasMember(key: String?): Boolean = key != null && key in SQLITE_DATABASE_PROPS_AND_METHODS
-
-  override fun putMember(key: String?, value: Value?) {
-    // no-op
-  }
-
-  override fun removeMember(key: String?): Boolean {
-    return false  // not supported
-  }
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/sqlite/SQLiteObject.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/sqlite/SQLiteObject.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Elide Technologies, Inc.
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
  *
  * Licensed under the MIT license (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
@@ -14,6 +14,7 @@ package elide.runtime.intrinsics.sqlite
 
 import io.micronaut.core.annotation.ReflectiveAccess
 import elide.annotations.API
+import elide.runtime.interop.ReadOnlyProxyObject
 import elide.runtime.intrinsics.js.MapLike
 
 /**
@@ -27,7 +28,7 @@ import elide.runtime.intrinsics.js.MapLike
  *
  * @see MapLike Map-like base interface
  */
-@API @ReflectiveAccess public interface SQLiteObject: MapLike<String, Any?> {
+@API @ReflectiveAccess public interface SQLiteObject: MapLike<String, Any?>, ReadOnlyProxyObject {
   /** Host-side only: array of columns specified by this object. */
   public val columns: Array<String>
 

--- a/tools/scripts/sqlite-json.mts
+++ b/tools/scripts/sqlite-json.mts
@@ -1,0 +1,10 @@
+/// <reference path="../../packages/types/index.d.ts" />
+import { Database } from "elide:sqlite"
+
+const db: Database = new Database()
+db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);")
+db.exec("INSERT INTO test (name) VALUES ('foo');")
+const query = db.query("SELECT * FROM test LIMIT 1;")
+const result = query.get() as { name: string }
+const asJson = JSON.stringify(result)
+console.log(asJson)


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Makes `SQLiteObject` instances `ReadOnlyProxyObject`s, which lets them stringify properly during `JSON.stringify`.

- Fixes: elide-dev/elide#1356

## Changelog
```
fix(cli): add reachability metadata for `kotlin.Unit.toString()`
fix(graalvm): make sqlite results read-only proxy objects
fix(graalvm): make sqlite layer return undefined instead of unit
test(graalvm): add test for sqlite JSON serialization
test(cli): add smoke test for sqlite JSON serialization
```