### PR TITLE
feat: test post-processors

### DIFF
--- a/packages/builder/api/builder.api
+++ b/packages/builder/api/builder.api
@@ -2661,114 +2661,56 @@ public abstract class elide/tooling/runner/AbstractTestRunner : elide/tooling/ru
 	public synthetic fun <init> (Lelide/tooling/runner/TestRunner$Config;Ljava/util/concurrent/Executor;Lelide/tooling/config/TestConfigurator$TestEventController;Lkotlin/jvm/functions/Function0;Lkotlin/time/TimeSource;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun awaitSettled (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun close ()V
-	protected final fun fail (Ljava/lang/Throwable;)Lelide/runtime/intrinsics/testing/TestResult;
-	public static synthetic fun fail$default (Lelide/tooling/runner/AbstractTestRunner;Ljava/lang/Throwable;ILjava/lang/Object;)Lelide/runtime/intrinsics/testing/TestResult;
+	protected final fun fail (Ljava/lang/Throwable;)Lelide/tooling/testing/TestResult;
+	public static synthetic fun fail$default (Lelide/tooling/runner/AbstractTestRunner;Ljava/lang/Throwable;ILjava/lang/Object;)Lelide/tooling/testing/TestResult;
 	public fun getConfig ()Lelide/tooling/runner/TestRunner$Config;
 	protected final fun getContextProvider ()Lkotlin/jvm/functions/Function0;
 	public fun getEvents ()Lelide/tooling/config/TestConfigurator$TestEventController;
 	public fun getExecutor ()Ljava/util/concurrent/Executor;
-	protected final fun pass ()Lelide/runtime/intrinsics/testing/TestResult;
+	protected final fun pass ()Lelide/tooling/testing/TestResult;
 	protected fun resolve (Lelide/runtime/core/PolyglotContext;Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;)Lelide/runtime/intrinsics/testing/TestEntrypoint;
 	protected abstract fun runTest (Lkotlinx/coroutines/CoroutineScope;Lelide/tooling/runner/AbstractTestRunner$TestRunRequest;)Lkotlinx/coroutines/Deferred;
-	protected fun runnable (Lelide/runtime/core/PolyglotContext;Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;)Lelide/runtime/intrinsics/testing/Reason;
-	protected final fun skip (Lelide/runtime/intrinsics/testing/Reason;)Lelide/runtime/intrinsics/testing/TestResult;
+	protected fun runnable (Lelide/runtime/core/PolyglotContext;Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;)Lelide/tooling/testing/Reason;
+	protected final fun skip (Lelide/tooling/testing/Reason;)Lelide/tooling/testing/TestResult;
 	protected final fun testExec (Lelide/tooling/runner/AbstractTestRunner$TestRunRequest;)V
 	protected final fun testFailed (Lelide/tooling/runner/AbstractTestRunner$TestRunRequest;Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun testSeen (Lelide/tooling/runner/AbstractTestRunner$TestRunRequest;)V
-	protected final fun testSkipped (Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/Reason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun testSkipped (Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/tooling/testing/Reason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun testSucceeded (Lelide/tooling/runner/AbstractTestRunner$TestRunRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun tests (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/flow/Flow;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class elide/tooling/runner/AbstractTestRunner$TestCaseResult : java/lang/Record {
-	public synthetic fun <init> (Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestResult;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun case ()Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;
-	public final fun component1 ()Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;
-	public final fun component2 ()Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;
-	public final fun component3 ()Lelide/runtime/intrinsics/testing/TestResult;
-	public final fun component4-UwyO8pc ()J
-	public final fun copy-Wn2Vu4Y (Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestResult;J)Lelide/tooling/runner/AbstractTestRunner$TestCaseResult;
-	public static synthetic fun copy-Wn2Vu4Y$default (Lelide/tooling/runner/AbstractTestRunner$TestCaseResult;Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestResult;JILjava/lang/Object;)Lelide/tooling/runner/AbstractTestRunner$TestCaseResult;
-	public final fun duration ()J
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public final fun result ()Lelide/runtime/intrinsics/testing/TestResult;
-	public final fun scope ()Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;
-	public fun toString ()Ljava/lang/String;
-}
-
 protected final class elide/tooling/runner/AbstractTestRunner$TestExecutionResult : java/lang/Record {
-	public synthetic fun <init> (Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;Lelide/runtime/intrinsics/testing/TestResult;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/tooling/testing/TestScope;Lelide/tooling/testing/TestResult;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;
-	public final fun component2 ()Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;
-	public final fun component3 ()Lelide/runtime/intrinsics/testing/TestResult;
+	public final fun component2 ()Lelide/tooling/testing/TestScope;
+	public final fun component3 ()Lelide/tooling/testing/TestResult;
 	public final fun component4-UwyO8pc ()J
-	public final fun copy-Wn2Vu4Y (Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;Lelide/runtime/intrinsics/testing/TestResult;J)Lelide/tooling/runner/AbstractTestRunner$TestExecutionResult;
-	public static synthetic fun copy-Wn2Vu4Y$default (Lelide/tooling/runner/AbstractTestRunner$TestExecutionResult;Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;Lelide/runtime/intrinsics/testing/TestResult;JILjava/lang/Object;)Lelide/tooling/runner/AbstractTestRunner$TestExecutionResult;
+	public final fun copy-Wn2Vu4Y (Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/tooling/testing/TestScope;Lelide/tooling/testing/TestResult;J)Lelide/tooling/runner/AbstractTestRunner$TestExecutionResult;
+	public static synthetic fun copy-Wn2Vu4Y$default (Lelide/tooling/runner/AbstractTestRunner$TestExecutionResult;Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/tooling/testing/TestScope;Lelide/tooling/testing/TestResult;JILjava/lang/Object;)Lelide/tooling/runner/AbstractTestRunner$TestExecutionResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public final fun result ()Lelide/runtime/intrinsics/testing/TestResult;
-	public final fun scope ()Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;
+	public final fun result ()Lelide/tooling/testing/TestResult;
+	public final fun scope ()Lelide/tooling/testing/TestScope;
 	public final fun test ()Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;
 	public final fun timing ()J
 	public fun toString ()Ljava/lang/String;
 }
 
 protected final class elide/tooling/runner/AbstractTestRunner$TestRunRequest : java/lang/Record {
-	public fun <init> (Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestEntrypoint;Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;Lelide/runtime/core/PolyglotContext;)V
+	public fun <init> (Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestEntrypoint;Lelide/tooling/testing/TestScope;Lelide/runtime/core/PolyglotContext;)V
 	public final fun component1 ()Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;
 	public final fun component2 ()Lelide/runtime/intrinsics/testing/TestEntrypoint;
-	public final fun component3 ()Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;
+	public final fun component3 ()Lelide/tooling/testing/TestScope;
 	public final fun component4 ()Lelide/runtime/core/PolyglotContext;
 	public final fun context ()Lelide/runtime/core/PolyglotContext;
-	public final fun copy (Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestEntrypoint;Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;Lelide/runtime/core/PolyglotContext;)Lelide/tooling/runner/AbstractTestRunner$TestRunRequest;
-	public static synthetic fun copy$default (Lelide/tooling/runner/AbstractTestRunner$TestRunRequest;Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestEntrypoint;Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;Lelide/runtime/core/PolyglotContext;ILjava/lang/Object;)Lelide/tooling/runner/AbstractTestRunner$TestRunRequest;
+	public final fun copy (Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestEntrypoint;Lelide/tooling/testing/TestScope;Lelide/runtime/core/PolyglotContext;)Lelide/tooling/runner/AbstractTestRunner$TestRunRequest;
+	public static synthetic fun copy$default (Lelide/tooling/runner/AbstractTestRunner$TestRunRequest;Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;Lelide/runtime/intrinsics/testing/TestEntrypoint;Lelide/tooling/testing/TestScope;Lelide/runtime/core/PolyglotContext;ILjava/lang/Object;)Lelide/tooling/runner/AbstractTestRunner$TestRunRequest;
 	public final fun entry ()Lelide/runtime/intrinsics/testing/TestEntrypoint;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public final fun scope ()Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;
+	public final fun scope ()Lelide/tooling/testing/TestScope;
 	public final fun test ()Lelide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest;
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class elide/tooling/runner/AbstractTestRunner$TestRunResult : java/lang/Record {
-	public synthetic fun <init> (Lelide/runtime/intrinsics/testing/TestResult;ILelide/tooling/runner/AbstractTestRunner$TestStats;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lelide/runtime/intrinsics/testing/TestResult;ILelide/tooling/runner/AbstractTestRunner$TestStats;Ljava/util/List;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lelide/runtime/intrinsics/testing/TestResult;
-	public final fun component2-pVg5ArA ()I
-	public final fun component3 ()Lelide/tooling/runner/AbstractTestRunner$TestStats;
-	public final fun component4 ()Ljava/util/List;
-	public final fun component5 ()Z
-	public final fun copy-roUYKiI (Lelide/runtime/intrinsics/testing/TestResult;ILelide/tooling/runner/AbstractTestRunner$TestStats;Ljava/util/List;Z)Lelide/tooling/runner/AbstractTestRunner$TestRunResult;
-	public static synthetic fun copy-roUYKiI$default (Lelide/tooling/runner/AbstractTestRunner$TestRunResult;Lelide/runtime/intrinsics/testing/TestResult;ILelide/tooling/runner/AbstractTestRunner$TestStats;Ljava/util/List;ZILjava/lang/Object;)Lelide/tooling/runner/AbstractTestRunner$TestRunResult;
-	public final fun earlyExit ()Z
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun exitCode ()I
-	public fun hashCode ()I
-	public final fun result ()Lelide/runtime/intrinsics/testing/TestResult;
-	public final fun results ()Ljava/util/List;
-	public final fun stats ()Lelide/tooling/runner/AbstractTestRunner$TestStats;
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class elide/tooling/runner/AbstractTestRunner$TestStats : java/lang/Record {
-	public synthetic fun <init> (IIIIIJLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1-pVg5ArA ()I
-	public final fun component2-pVg5ArA ()I
-	public final fun component3-pVg5ArA ()I
-	public final fun component4-pVg5ArA ()I
-	public final fun component5-pVg5ArA ()I
-	public final fun component6-UwyO8pc ()J
-	public final fun copy-NqIEkfQ (IIIIIJ)Lelide/tooling/runner/AbstractTestRunner$TestStats;
-	public static synthetic fun copy-NqIEkfQ$default (Lelide/tooling/runner/AbstractTestRunner$TestStats;IIIIIJILjava/lang/Object;)Lelide/tooling/runner/AbstractTestRunner$TestStats;
-	public final fun duration ()J
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun executions ()I
-	public final fun fails ()I
-	public fun hashCode ()I
-	public final fun passes ()I
-	public final fun skips ()I
-	public final fun tests ()I
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/packages/builder/src/main/kotlin/elide/tooling/builder/TestDriver.kt
+++ b/packages/builder/src/main/kotlin/elide/tooling/builder/TestDriver.kt
@@ -43,7 +43,6 @@ import elide.tooling.registry.ResolverRegistry
  *   }
  * }
  * ```
- *
  */
 public object TestDriver {
   @JvmStatic

--- a/packages/builder/src/main/kotlin/elide/tooling/coverage/CoverageReportProcessor.kt
+++ b/packages/builder/src/main/kotlin/elide/tooling/coverage/CoverageReportProcessor.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.coverage
+
+import elide.tooling.Tool
+import elide.tooling.testing.TestPostProcessingOptions
+import elide.tooling.testing.TestPostProcessor
+import elide.tooling.testing.TestPostProcessorFactory
+import elide.tooling.testing.TestRunResult
+
+// Implements coverage reporting steps which take place after tests have run.
+internal class CoverageReportProcessor : TestPostProcessor {
+  override suspend fun invoke(options: TestPostProcessingOptions, results: TestRunResult): Tool.Result {
+    // @TODO coverage report processor is not implemented yet
+    return Tool.Result.Success
+  }
+
+  // Create a coverage report processor if coverage is enabled.
+  class Factory : TestPostProcessorFactory<CoverageReportProcessor> {
+    override fun create(options: TestPostProcessingOptions): TestPostProcessor? = when (options.coverageEnabled) {
+      false -> null
+      else -> CoverageReportProcessor()
+    }
+  }
+}

--- a/packages/builder/src/main/kotlin/elide/tooling/reporting/TestReportProcessor.kt
+++ b/packages/builder/src/main/kotlin/elide/tooling/reporting/TestReportProcessor.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.reporting
+
+import elide.tooling.Tool
+import elide.tooling.testing.TestPostProcessingOptions
+import elide.tooling.testing.TestPostProcessor
+import elide.tooling.testing.TestPostProcessorFactory
+import elide.tooling.testing.TestRunResult
+
+// Test post-processor which produces test result reports.
+internal class TestReportProcessor : TestPostProcessor {
+  override suspend fun invoke(options: TestPostProcessingOptions, results: TestRunResult): Tool.Result {
+    // @TODO not yet implemented
+    return Tool.Result.Success
+  }
+
+  // Create a coverage report processor if coverage is enabled.
+  class Factory : TestPostProcessorFactory<TestReportProcessor> {
+    override fun create(options: TestPostProcessingOptions): TestPostProcessor? = when (options.reportingEnabled) {
+      false -> null
+      else -> TestReportProcessor()
+    }
+  }
+}

--- a/packages/builder/src/main/kotlin/elide/tooling/runner/AbstractTestRunner.kt
+++ b/packages/builder/src/main/kotlin/elide/tooling/runner/AbstractTestRunner.kt
@@ -34,12 +34,16 @@ import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 import elide.runtime.core.DelicateElideApi
 import elide.runtime.core.PolyglotContext
-import elide.runtime.intrinsics.testing.Reason
 import elide.runtime.intrinsics.testing.TestEntrypoint
-import elide.runtime.intrinsics.testing.TestResult
 import elide.runtime.intrinsics.testing.TestingRegistrar.*
 import elide.tooling.config.TestConfigurator
 import elide.tooling.config.TestConfigurator.TestEventController
+import elide.tooling.testing.Reason
+import elide.tooling.testing.TestCaseResult
+import elide.tooling.testing.TestResult
+import elide.tooling.testing.TestRunResult
+import elide.tooling.testing.TestScope
+import elide.tooling.testing.TestStats
 
 // Provides abstract base behavior for test runner implementations.
 public abstract class AbstractTestRunner (
@@ -72,57 +76,6 @@ public abstract class AbstractTestRunner (
     val entry: TestEntrypoint,
     val scope: TestScope<*>,
     val context: PolyglotContext,
-  )
-
-  /**
-   * Stats describing a test run.
-   *
-   * @property tests Total number of tests seen.
-   * @property executions Total number of tests ran.
-   * @property passes Total number of tests that passed.
-   * @property fails Total number of tests that failed.
-   * @property skips Total number of tests that were skipped.
-   * @property duration Total duration of the test run.
-   */
-  @JvmRecord public data class TestStats(
-    public val tests: UInt,
-    public val executions: UInt,
-    public val passes: UInt,
-    public val fails: UInt,
-    public val skips: UInt,
-    public val duration: Duration,
-  )
-
-  /**
-   * Results of an individual test case run.
-   *
-   * @property scope The scope in which the test was a member.
-   * @property case The test case that was executed.
-   * @property result The result of the test case execution.
-   * @property duration The duration of the test case execution.
-   */
-  @JvmRecord public data class TestCaseResult(
-    public val scope: TestScope<*>,
-    public val case: RegisteredTest,
-    public val result: TestResult,
-    public val duration: Duration,
-  )
-
-  /**
-   * Results of a test run.
-   *
-   * @property result The overall result of the test run.
-   * @property exitCode The exit code of the test run.
-   * @property stats Statistics about the test run.
-   * @property results Results of individual test cases.
-   * @property earlyExit Whether the test run exited early (e.g. due to a failure during `failFast` mode).
-   */
-  @JvmRecord public data class TestRunResult(
-    public val result: TestResult,
-    public val exitCode: UInt,
-    public val stats: TestStats,
-    public val results: List<TestCaseResult>,
-    public val earlyExit: Boolean = false,
   )
 
   // Running count of all seen tests.
@@ -212,7 +165,6 @@ public abstract class AbstractTestRunner (
       results = testResults.map {
         TestCaseResult(
           scope = it.scope,
-          case = it.test,
           result = it.result,
           duration = it.timing,
         )

--- a/packages/builder/src/main/kotlin/elide/tooling/runner/SerialTestRunner.kt
+++ b/packages/builder/src/main/kotlin/elide/tooling/runner/SerialTestRunner.kt
@@ -23,9 +23,9 @@ import kotlinx.coroutines.async
 import kotlin.time.measureTimedValue
 import elide.runtime.core.DelicateElideApi
 import elide.runtime.core.PolyglotContext
-import elide.runtime.intrinsics.testing.TestResult
 import elide.tooling.cli.Statics
 import elide.tooling.config.TestConfigurator.TestEventController
+import elide.tooling.testing.TestResult
 
 // Implements a `TestRunner` which runs tests in order, serially.
 public class SerialTestRunner internal constructor (

--- a/packages/builder/src/main/kotlin/elide/tooling/runner/TestRunner.kt
+++ b/packages/builder/src/main/kotlin/elide/tooling/runner/TestRunner.kt
@@ -27,10 +27,10 @@ import elide.runtime.Logging
 import elide.runtime.core.DelicateElideApi
 import elide.runtime.core.PolyglotContext
 import elide.runtime.intrinsics.testing.TestingRegistrar.RegisteredTest
-import elide.runtime.intrinsics.testing.TestingRegistrar.TestScope
 import elide.tooling.config.TestConfigurator.*
 import elide.tooling.project.ElideProject
-import elide.tooling.runner.AbstractTestRunner.TestRunResult
+import elide.tooling.testing.TestRunResult
+import elide.tooling.testing.TestScope
 
 // Default test parallelism to apply.
 private val defaultParallelism by lazy {

--- a/packages/builder/src/main/kotlin/elide/tooling/runner/ThreadedTestRunner.kt
+++ b/packages/builder/src/main/kotlin/elide/tooling/runner/ThreadedTestRunner.kt
@@ -25,9 +25,9 @@ import kotlin.time.Duration
 import kotlin.time.measureTimedValue
 import elide.runtime.core.DelicateElideApi
 import elide.runtime.core.PolyglotContext
-import elide.runtime.intrinsics.testing.TestResult
 import elide.tooling.cli.Statics
 import elide.tooling.config.TestConfigurator.TestEventController
+import elide.tooling.testing.TestResult
 
 // Implements a `TestRunner` which runs tests in parallel across threads.
 public class ThreadedTestRunner internal constructor (

--- a/packages/builder/src/main/resources/META-INF/services/elide.tooling.testing.TestPostProcessorFactory
+++ b/packages/builder/src/main/resources/META-INF/services/elide.tooling.testing.TestPostProcessorFactory
@@ -1,0 +1,2 @@
+elide.tooling.reporting.TestReportProcessor$Factory
+elide.tooling.coverage.CoverageReportProcessor$Factory

--- a/packages/cli/src/main/kotlin/elide/tool/cli/options/TestingOptions.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/options/TestingOptions.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tool.cli.options
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.ReflectiveAccess
+import picocli.CommandLine.Option
+
+/**
+ * ## Testing Options
+ *
+ * Controls CLI options related to testing; this includes test reporting and coverage, as well as test execution
+ * controls or filters.
+ *
+ * @property enableCoverage Whether coverage is enabled.
+ * @property coverageFormat Format of coverage report to produce.
+ * @property threadedTestMode Whether to use the threaded test runner (experimental).
+ */
+@Introspected @ReflectiveAccess class TestingOptions : OptionsMixin<TestingOptions> {
+  /** Activates coverage in test mode. */
+  @Option(
+    names = ["--coverage"],
+    description = ["Enable or disable coverage during `elide test`"],
+    negatable = true,
+    defaultValue = "false",
+  )
+  internal var enableCoverage: Boolean = false
+
+  /** Activates coverage in test mode. */
+  @Option(
+    names = ["--coverage-format"],
+    description = ["Coverage format to emit; defaults to 'json'"],
+    defaultValue = "json",
+  )
+  internal var coverageFormat: String = "json"
+
+  /** Activates coverage in test mode. */
+  @Option(
+    names = ["--experimental-threaded-testing"],
+    description = ["Test in threaded mode (experimental)"],
+    negatable = true,
+    defaultValue = "false",
+  )
+  internal var threadedTestMode: Boolean = false
+
+  /** Activates coverage in test mode. */
+  @Option(
+    names = ["--test-report"],
+    description = ["Enable test reports; pass format. Formats are 'xml'."],
+  )
+  internal var testReports: String? = null
+}

--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -7145,112 +7145,8 @@ public synthetic class elide/runtime/intrinsics/testing/$TestingAPI$TestGraphNod
 	public fun getAnnotationMetadata ()Lio/micronaut/core/annotation/AnnotationMetadata;
 }
 
-public abstract interface class elide/runtime/intrinsics/testing/AssumptionState {
-}
-
-public final class elide/runtime/intrinsics/testing/AssumptionState$Ignored : elide/runtime/intrinsics/testing/AssumptionState {
-	public static final field INSTANCE Lelide/runtime/intrinsics/testing/AssumptionState$Ignored;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class elide/runtime/intrinsics/testing/AssumptionState$IgnoredWithReasoning : elide/runtime/intrinsics/testing/AssumptionState {
-	public static final synthetic fun box-impl (Lelide/runtime/intrinsics/testing/Reason;)Lelide/runtime/intrinsics/testing/AssumptionState$IgnoredWithReasoning;
-	public static fun constructor-impl (Lelide/runtime/intrinsics/testing/Reason;)Lelide/runtime/intrinsics/testing/Reason;
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lelide/runtime/intrinsics/testing/Reason;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lelide/runtime/intrinsics/testing/Reason;Lelide/runtime/intrinsics/testing/Reason;)Z
-	public final fun getReason ()Lelide/runtime/intrinsics/testing/Reason;
-	public fun hashCode ()I
-	public static fun hashCode-impl (Lelide/runtime/intrinsics/testing/Reason;)I
-	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lelide/runtime/intrinsics/testing/Reason;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lelide/runtime/intrinsics/testing/Reason;
-}
-
-public final class elide/runtime/intrinsics/testing/AssumptionState$Valid : elide/runtime/intrinsics/testing/AssumptionState {
-	public static final field INSTANCE Lelide/runtime/intrinsics/testing/AssumptionState$Valid;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public abstract interface class elide/runtime/intrinsics/testing/Reason {
-	public abstract fun message ()Ljava/lang/String;
-}
-
-public final class elide/runtime/intrinsics/testing/Reason$ReasonMessage : elide/runtime/intrinsics/testing/Reason {
-	public static final synthetic fun box-impl (Ljava/lang/String;)Lelide/runtime/intrinsics/testing/Reason$ReasonMessage;
-	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
-	public final fun getMessage ()Ljava/lang/String;
-	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/lang/String;)I
-	public fun message ()Ljava/lang/String;
-	public static fun message-impl (Ljava/lang/String;)Ljava/lang/String;
-	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/lang/String;
-}
-
-public final class elide/runtime/intrinsics/testing/Reason$ViolatedAssumptions : elide/runtime/intrinsics/testing/Reason {
-	public static final synthetic fun box-impl (Ljava/util/List;)Lelide/runtime/intrinsics/testing/Reason$ViolatedAssumptions;
-	public static fun constructor-impl (Ljava/util/List;)Ljava/util/List;
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/util/List;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/util/List;Ljava/util/List;)Z
-	public final fun getList ()Ljava/util/List;
-	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/util/List;)I
-	public fun message ()Ljava/lang/String;
-	public static fun message-impl (Ljava/util/List;)Ljava/lang/String;
-	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/util/List;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/util/List;
-}
-
 public abstract interface class elide/runtime/intrinsics/testing/TestEntrypoint {
-	public abstract fun invoke ()Lelide/runtime/intrinsics/testing/TestResult;
-}
-
-public abstract interface class elide/runtime/intrinsics/testing/TestResult {
-}
-
-public final class elide/runtime/intrinsics/testing/TestResult$Fail : java/lang/Record, elide/runtime/intrinsics/testing/TestResult {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun cause ()Ljava/lang/Throwable;
-	public final fun component1 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/Throwable;)Lelide/runtime/intrinsics/testing/TestResult$Fail;
-	public static synthetic fun copy$default (Lelide/runtime/intrinsics/testing/TestResult$Fail;Ljava/lang/Throwable;ILjava/lang/Object;)Lelide/runtime/intrinsics/testing/TestResult$Fail;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class elide/runtime/intrinsics/testing/TestResult$Pass : elide/runtime/intrinsics/testing/TestResult {
-	public static final field INSTANCE Lelide/runtime/intrinsics/testing/TestResult$Pass;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class elide/runtime/intrinsics/testing/TestResult$Skip : elide/runtime/intrinsics/testing/TestResult {
-	public static final synthetic fun box-impl (Lelide/runtime/intrinsics/testing/Reason;)Lelide/runtime/intrinsics/testing/TestResult$Skip;
-	public static fun constructor-impl (Lelide/runtime/intrinsics/testing/Reason;)Lelide/runtime/intrinsics/testing/Reason;
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lelide/runtime/intrinsics/testing/Reason;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lelide/runtime/intrinsics/testing/Reason;Lelide/runtime/intrinsics/testing/Reason;)Z
-	public final fun getReason ()Lelide/runtime/intrinsics/testing/Reason;
-	public fun hashCode ()I
-	public static fun hashCode-impl (Lelide/runtime/intrinsics/testing/Reason;)I
-	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lelide/runtime/intrinsics/testing/Reason;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lelide/runtime/intrinsics/testing/Reason;
+	public abstract fun invoke ()Lelide/tooling/testing/TestResult;
 }
 
 public abstract interface class elide/runtime/intrinsics/testing/TestingAPI {
@@ -7421,7 +7317,7 @@ public abstract interface class elide/runtime/intrinsics/testing/TestingRegistra
 	public static fun deferred (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lelide/runtime/intrinsics/testing/TestingRegistrar$TestInfo;
 	public abstract fun freeze ()Lelide/runtime/intrinsics/testing/TestingRegistrar;
 	public abstract fun grouped ()Lkotlin/sequences/Sequence;
-	public static fun guest (Lorg/graalvm/polyglot/Value;Ljava/lang/String;Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;)Lelide/runtime/intrinsics/testing/TestingRegistrar$TestInfo;
+	public static fun guest (Lorg/graalvm/polyglot/Value;Ljava/lang/String;Lelide/tooling/testing/TestScope;)Lelide/runtime/intrinsics/testing/TestingRegistrar$TestInfo;
 	public static fun namedScope (Ljava/lang/String;Ljava/lang/String;)Lelide/runtime/intrinsics/testing/TestingRegistrar$NamedScope;
 	public static fun namedScope (Lorg/graalvm/polyglot/Value;Ljava/lang/String;)Lelide/runtime/intrinsics/testing/TestingRegistrar$NamedScope;
 	public static fun qualifiedNameForBlock (Lorg/graalvm/polyglot/Value;Ljava/lang/String;)Ljava/lang/String;
@@ -7435,22 +7331,13 @@ public abstract interface class elide/runtime/intrinsics/testing/TestingRegistra
 
 public final class elide/runtime/intrinsics/testing/TestingRegistrar$Companion {
 	public final fun deferred (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lelide/runtime/intrinsics/testing/TestingRegistrar$TestInfo;
-	public final fun guest (Lorg/graalvm/polyglot/Value;Ljava/lang/String;Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;)Lelide/runtime/intrinsics/testing/TestingRegistrar$TestInfo;
-	public static synthetic fun guest$default (Lelide/runtime/intrinsics/testing/TestingRegistrar$Companion;Lorg/graalvm/polyglot/Value;Ljava/lang/String;Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;ILjava/lang/Object;)Lelide/runtime/intrinsics/testing/TestingRegistrar$TestInfo;
+	public final fun guest (Lorg/graalvm/polyglot/Value;Ljava/lang/String;Lelide/tooling/testing/TestScope;)Lelide/runtime/intrinsics/testing/TestingRegistrar$TestInfo;
+	public static synthetic fun guest$default (Lelide/runtime/intrinsics/testing/TestingRegistrar$Companion;Lorg/graalvm/polyglot/Value;Ljava/lang/String;Lelide/tooling/testing/TestScope;ILjava/lang/Object;)Lelide/runtime/intrinsics/testing/TestingRegistrar$TestInfo;
 	public final fun namedScope (Ljava/lang/String;Ljava/lang/String;)Lelide/runtime/intrinsics/testing/TestingRegistrar$NamedScope;
 	public final fun namedScope (Lorg/graalvm/polyglot/Value;Ljava/lang/String;)Lelide/runtime/intrinsics/testing/TestingRegistrar$NamedScope;
 	public static synthetic fun namedScope$default (Lelide/runtime/intrinsics/testing/TestingRegistrar$Companion;Lorg/graalvm/polyglot/Value;Ljava/lang/String;ILjava/lang/Object;)Lelide/runtime/intrinsics/testing/TestingRegistrar$NamedScope;
 	public final fun qualifiedNameForBlock (Lorg/graalvm/polyglot/Value;Ljava/lang/String;)Ljava/lang/String;
 	public final fun qualifiedNameToSimpleName (Ljava/lang/String;)Ljava/lang/String;
-}
-
-public final class elide/runtime/intrinsics/testing/TestingRegistrar$GlobalTestScope : elide/runtime/intrinsics/testing/TestingRegistrar$TestScope {
-	public static final field INSTANCE Lelide/runtime/intrinsics/testing/TestingRegistrar$GlobalTestScope;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getQualifiedName ()Ljava/lang/String;
-	public fun getSimpleName ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class elide/runtime/intrinsics/testing/TestingRegistrar$NamedScope : java/lang/Record, elide/runtime/intrinsics/testing/TestingRegistrar$RegisteredScope {
@@ -7469,14 +7356,14 @@ public abstract interface class elide/runtime/intrinsics/testing/TestingRegistra
 	public abstract fun getGuestValueFactory ()Lkotlin/jvm/functions/Function1;
 }
 
-public abstract interface class elide/runtime/intrinsics/testing/TestingRegistrar$RegisteredScope : elide/runtime/interop/ReadOnlyProxyObject, elide/runtime/intrinsics/testing/TestingAPI$TestGraphNode$Suite, elide/runtime/intrinsics/testing/TestingRegistrar$TestScope, java/lang/Comparable {
+public abstract interface class elide/runtime/intrinsics/testing/TestingRegistrar$RegisteredScope : elide/runtime/interop/ReadOnlyProxyObject, elide/runtime/intrinsics/testing/TestingAPI$TestGraphNode$Suite, elide/tooling/testing/TestScope, java/lang/Comparable {
 	public synthetic fun getMember (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getMember (Ljava/lang/String;)Lorg/graalvm/polyglot/Value;
 	public synthetic fun getMemberKeys ()Ljava/lang/Object;
 	public fun getMemberKeys ()[Ljava/lang/String;
 }
 
-public abstract interface class elide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest : elide/runtime/intrinsics/testing/TestingAPI$TestGraphNode$Test, elide/runtime/intrinsics/testing/TestingRegistrar$TestScope, java/lang/Comparable {
+public abstract interface class elide/runtime/intrinsics/testing/TestingRegistrar$RegisteredTest : elide/runtime/intrinsics/testing/TestingAPI$TestGraphNode$Test, elide/tooling/testing/TestScope, java/lang/Comparable {
 	public abstract fun getEntryFactory ()Lkotlin/jvm/functions/Function1;
 	public abstract fun getQualifiedName ()Ljava/lang/String;
 	public abstract fun getSimpleName ()Ljava/lang/String;
@@ -7504,21 +7391,6 @@ public final class elide/runtime/intrinsics/testing/TestingRegistrar$TestInfo : 
 	public fun qualifiedName ()Ljava/lang/String;
 	public fun simpleName ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
-}
-
-public abstract interface class elide/runtime/intrinsics/testing/TestingRegistrar$TestScope : java/lang/Comparable {
-	public fun compareTo (Lelide/runtime/intrinsics/testing/TestingRegistrar$TestScope;)I
-	public synthetic fun compareTo (Ljava/lang/Object;)I
-	public abstract fun getQualifiedName ()Ljava/lang/String;
-	public abstract fun getSimpleName ()Ljava/lang/String;
-	public fun qualifiedNameFor (Ljava/lang/String;)Ljava/lang/String;
-	public fun qualifiedNameFor (Lorg/graalvm/polyglot/Value;Ljava/lang/String;)Ljava/lang/String;
-}
-
-public final class elide/runtime/intrinsics/testing/ViolatedAssumption : java/lang/RuntimeException {
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun reasonMessage ()Ljava/lang/String;
 }
 
 public synthetic class elide/runtime/javascript/$MessageChannelBuiltin$Definition : io/micronaut/context/AbstractInitializableBeanDefinitionAndReference {

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/testing/TestingModule.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/testing/TestingModule.kt
@@ -46,6 +46,8 @@ import elide.runtime.intrinsics.testing.TestingRegistrar
 import elide.runtime.intrinsics.testing.TestingRegistrar.*
 import elide.runtime.node.asserts.NodeAssertModule
 import elide.runtime.node.asserts.assertionError
+import elide.tooling.testing.GlobalTestScope
+import elide.tooling.testing.TestScope
 import elide.vm.annotations.Polyglot
 
 // Constants.

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/testing/TestEntrypoint.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/testing/TestEntrypoint.kt
@@ -12,6 +12,8 @@
  */
 package elide.runtime.intrinsics.testing
 
+import elide.tooling.testing.TestResult
+
 /**
  * ## Test Entrypoint
  *

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/testing/TestingRegistrar.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/testing/TestingRegistrar.kt
@@ -19,6 +19,8 @@ import elide.runtime.core.DelicateElideApi
 import elide.runtime.core.PolyglotContext
 import elide.runtime.core.PolyglotValue
 import elide.runtime.interop.ReadOnlyProxyObject
+import elide.tooling.testing.TestResult
+import elide.tooling.testing.TestScope
 
 /**
  * # Testing Registrar
@@ -100,70 +102,6 @@ public interface TestingRegistrar {
     override fun close() {
       parent.resetScope()
     }
-  }
-
-  /**
-   * ## Test Scope
-   *
-   * Describes, in a sealed hierarchy, all scopes which apply to testing; this includes [RegisteredScope] instances
-   * which describe logical groupings of tests, and also tests themselves, via [RegisteredTest].
-   */
-  public sealed interface TestScope<T>: Comparable<T> where T: TestScope<T> {
-    /**
-     * ### Simple name.
-     *
-     * Every test and test scope provides a simple display name.
-     */
-    public val simpleName: String
-
-    /**
-     * ### Qualified name.
-     *
-     * Every test and test scope provides a well-qualified name.
-     */
-    public val qualifiedName: String
-
-    /**
-     * Return a generated qualified test name based on this scope and any parent scopes.
-     *
-     * @param block Block to generate a qualified name for.
-     * @param label Optional label to append to the qualified name.
-     * @return Qualified name for the test.
-     */
-    public fun qualifiedNameFor(block: PolyglotValue, label: String?): String {
-      if (qualifiedName.isEmpty() || qualifiedName.isBlank()) {
-        val srcfile = block.sourceLocation.source.name
-        return "$srcfile > ${label ?: block.metaSimpleName}"
-      }
-      return qualifiedName + (label?.let { " > $it" } ?: "")
-    }
-
-    /**
-     * Return a generated qualified test name based on this scope and any parent scopes.
-     *
-     * @param label Optional label to append to the qualified name.
-     * @return Qualified name for the test.
-     */
-    public fun qualifiedNameFor(label: String?): String? {
-      if (qualifiedName.isNotEmpty() && label?.isNotEmpty() == true) {
-        return qualifiedName + label.let { " > $it" }
-      }
-      return null
-    }
-
-    override fun compareTo(other: T): Int {
-      return qualifiedName.compareTo(other.qualifiedName)
-    }
-  }
-
-  /**
-   * ## Global Test Scope
-   *
-   * Fallback singleton scope for all tests which have no other scope.
-   */
-  public data object GlobalTestScope: TestScope<GlobalTestScope> {
-    override val qualifiedName: String get() = ""
-    override val simpleName: String get() = ""
   }
 
   /**

--- a/packages/graalvm/src/main/kotlin/elide/runtime/plugins/Coverage.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/plugins/Coverage.kt
@@ -55,6 +55,8 @@ private const val DEFAULT_COVERAGE_FORMAT = "json"
         option("coverage.Output", outFmt)
         if (outFmt in sortedSetOf("json", "lcov")) {
           option("coverage.OutputFile", out.resolve("coverage.$outFmt").absolutePathString())
+        } else {
+          error("Unsupported coverage output format: '$outFmt'. Supported formats include 'json' and 'lcov'")
         }
       }
     }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/plugins/CoverageConfig.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/plugins/CoverageConfig.kt
@@ -21,8 +21,23 @@ import elide.runtime.core.DelicateElideApi
  * This container is meant to be used by the [Coverage] plugin.
  */
 @DelicateElideApi public class CoverageConfig {
+  /**
+   * Whether coverage is enabled.
+   */
   public var enabled: Boolean = true
+
+  /**
+   * Format to use for coverage; supported values are `json` and `lcov`.
+   */
   public var format: String? = null
+
+  /**
+   * Filter to apply to files when producing coverage information.
+   */
   public var filterFile: String? = null
+
+  /**
+   * Output directory where coverage reports and other ephemera should be placed.
+   */
   public var outputDirectory: Path? = null
 }

--- a/packages/tooling/api/tooling.api
+++ b/packages/tooling/api/tooling.api
@@ -6380,6 +6380,221 @@ public final class elide/tooling/project/mcp/ModelContextProtocol$McpServingMode
 	public static fun values ()[Lelide/tooling/project/mcp/ModelContextProtocol$McpServingMode;
 }
 
+public abstract interface class elide/tooling/testing/AssumptionState {
+}
+
+public final class elide/tooling/testing/AssumptionState$Ignored : elide/tooling/testing/AssumptionState {
+	public static final field INSTANCE Lelide/tooling/testing/AssumptionState$Ignored;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/tooling/testing/AssumptionState$IgnoredWithReasoning : elide/tooling/testing/AssumptionState {
+	public static final synthetic fun box-impl (Lelide/tooling/testing/Reason;)Lelide/tooling/testing/AssumptionState$IgnoredWithReasoning;
+	public static fun constructor-impl (Lelide/tooling/testing/Reason;)Lelide/tooling/testing/Reason;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Lelide/tooling/testing/Reason;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Lelide/tooling/testing/Reason;Lelide/tooling/testing/Reason;)Z
+	public final fun getReason ()Lelide/tooling/testing/Reason;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Lelide/tooling/testing/Reason;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Lelide/tooling/testing/Reason;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Lelide/tooling/testing/Reason;
+}
+
+public final class elide/tooling/testing/AssumptionState$Valid : elide/tooling/testing/AssumptionState {
+	public static final field INSTANCE Lelide/tooling/testing/AssumptionState$Valid;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/tooling/testing/GlobalTestScope : elide/tooling/testing/TestScope {
+	public static final field INSTANCE Lelide/tooling/testing/GlobalTestScope;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getQualifiedName ()Ljava/lang/String;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class elide/tooling/testing/Reason {
+	public abstract fun message ()Ljava/lang/String;
+}
+
+public final class elide/tooling/testing/Reason$ReasonMessage : elide/tooling/testing/Reason {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lelide/tooling/testing/Reason$ReasonMessage;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun message ()Ljava/lang/String;
+	public static fun message-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class elide/tooling/testing/Reason$ViolatedAssumptions : elide/tooling/testing/Reason {
+	public static final synthetic fun box-impl (Ljava/util/List;)Lelide/tooling/testing/Reason$ViolatedAssumptions;
+	public static fun constructor-impl (Ljava/util/List;)Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/util/List;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/util/List;Ljava/util/List;)Z
+	public final fun getList ()Ljava/util/List;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/util/List;)I
+	public fun message ()Ljava/lang/String;
+	public static fun message-impl (Ljava/util/List;)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/util/List;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/util/List;
+}
+
+public final class elide/tooling/testing/TestCaseResult : java/lang/Record {
+	public synthetic fun <init> (Lelide/tooling/testing/TestScope;Lelide/tooling/testing/TestResult;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lelide/tooling/testing/TestScope;
+	public final fun component2 ()Lelide/tooling/testing/TestResult;
+	public final fun component3-UwyO8pc ()J
+	public final fun copy-SxA4cEA (Lelide/tooling/testing/TestScope;Lelide/tooling/testing/TestResult;J)Lelide/tooling/testing/TestCaseResult;
+	public static synthetic fun copy-SxA4cEA$default (Lelide/tooling/testing/TestCaseResult;Lelide/tooling/testing/TestScope;Lelide/tooling/testing/TestResult;JILjava/lang/Object;)Lelide/tooling/testing/TestCaseResult;
+	public final fun duration ()J
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun result ()Lelide/tooling/testing/TestResult;
+	public final fun scope ()Lelide/tooling/testing/TestScope;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/tooling/testing/TestPostProcessingOptions : java/lang/Record {
+	public fun <init> ()V
+	public fun <init> (ZZ)V
+	public synthetic fun <init> (ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun copy (ZZ)Lelide/tooling/testing/TestPostProcessingOptions;
+	public static synthetic fun copy$default (Lelide/tooling/testing/TestPostProcessingOptions;ZZILjava/lang/Object;)Lelide/tooling/testing/TestPostProcessingOptions;
+	public final fun coverageEnabled ()Z
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun reportingEnabled ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class elide/tooling/testing/TestPostProcessor {
+	public abstract fun invoke (Lelide/tooling/testing/TestPostProcessingOptions;Lelide/tooling/testing/TestRunResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class elide/tooling/testing/TestPostProcessorFactory {
+	public abstract fun create (Lelide/tooling/testing/TestPostProcessingOptions;)Lelide/tooling/testing/TestPostProcessor;
+	public fun eligible (Lelide/tooling/testing/TestPostProcessingOptions;)Z
+}
+
+public final class elide/tooling/testing/TestPostProcessors {
+	public static final field INSTANCE Lelide/tooling/testing/TestPostProcessors;
+	public static final fun all ()Lkotlin/sequences/Sequence;
+	public static final fun matching (Lelide/tooling/testing/TestPostProcessingOptions;)Lkotlin/sequences/Sequence;
+	public static final fun suite (Lelide/tooling/testing/TestPostProcessingOptions;)Lkotlin/sequences/Sequence;
+}
+
+public abstract interface class elide/tooling/testing/TestResult {
+}
+
+public final class elide/tooling/testing/TestResult$Fail : java/lang/Record, elide/tooling/testing/TestResult {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun cause ()Ljava/lang/Throwable;
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lelide/tooling/testing/TestResult$Fail;
+	public static synthetic fun copy$default (Lelide/tooling/testing/TestResult$Fail;Ljava/lang/Throwable;ILjava/lang/Object;)Lelide/tooling/testing/TestResult$Fail;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/tooling/testing/TestResult$Pass : elide/tooling/testing/TestResult {
+	public static final field INSTANCE Lelide/tooling/testing/TestResult$Pass;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/tooling/testing/TestResult$Skip : elide/tooling/testing/TestResult {
+	public static final synthetic fun box-impl (Lelide/tooling/testing/Reason;)Lelide/tooling/testing/TestResult$Skip;
+	public static fun constructor-impl (Lelide/tooling/testing/Reason;)Lelide/tooling/testing/Reason;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Lelide/tooling/testing/Reason;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Lelide/tooling/testing/Reason;Lelide/tooling/testing/Reason;)Z
+	public final fun getReason ()Lelide/tooling/testing/Reason;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Lelide/tooling/testing/Reason;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Lelide/tooling/testing/Reason;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Lelide/tooling/testing/Reason;
+}
+
+public final class elide/tooling/testing/TestRunResult : java/lang/Record {
+	public synthetic fun <init> (Lelide/tooling/testing/TestResult;ILelide/tooling/testing/TestStats;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lelide/tooling/testing/TestResult;ILelide/tooling/testing/TestStats;Ljava/util/List;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lelide/tooling/testing/TestResult;
+	public final fun component2-pVg5ArA ()I
+	public final fun component3 ()Lelide/tooling/testing/TestStats;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Z
+	public final fun copy-roUYKiI (Lelide/tooling/testing/TestResult;ILelide/tooling/testing/TestStats;Ljava/util/List;Z)Lelide/tooling/testing/TestRunResult;
+	public static synthetic fun copy-roUYKiI$default (Lelide/tooling/testing/TestRunResult;Lelide/tooling/testing/TestResult;ILelide/tooling/testing/TestStats;Ljava/util/List;ZILjava/lang/Object;)Lelide/tooling/testing/TestRunResult;
+	public final fun earlyExit ()Z
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun exitCode ()I
+	public fun hashCode ()I
+	public final fun result ()Lelide/tooling/testing/TestResult;
+	public final fun results ()Ljava/util/List;
+	public final fun stats ()Lelide/tooling/testing/TestStats;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class elide/tooling/testing/TestScope : java/lang/Comparable {
+	public fun compareTo (Lelide/tooling/testing/TestScope;)I
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public abstract fun getQualifiedName ()Ljava/lang/String;
+	public abstract fun getSimpleName ()Ljava/lang/String;
+	public fun qualifiedNameFor (Ljava/lang/String;)Ljava/lang/String;
+	public fun qualifiedNameFor (Lorg/graalvm/polyglot/Value;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class elide/tooling/testing/TestStats : java/lang/Record {
+	public synthetic fun <init> (IIIIIJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-pVg5ArA ()I
+	public final fun component2-pVg5ArA ()I
+	public final fun component3-pVg5ArA ()I
+	public final fun component4-pVg5ArA ()I
+	public final fun component5-pVg5ArA ()I
+	public final fun component6-UwyO8pc ()J
+	public final fun copy-NqIEkfQ (IIIIIJ)Lelide/tooling/testing/TestStats;
+	public static synthetic fun copy-NqIEkfQ$default (Lelide/tooling/testing/TestStats;IIIIIJILjava/lang/Object;)Lelide/tooling/testing/TestStats;
+	public final fun duration ()J
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun executions ()I
+	public final fun fails ()I
+	public fun hashCode ()I
+	public final fun passes ()I
+	public final fun skips ()I
+	public final fun tests ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class elide/tooling/testing/ViolatedAssumption : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun reasonMessage ()Ljava/lang/String;
+}
+
 public abstract interface class elide/tooling/web/Browsers {
 	public static final field Companion Lelide/tooling/web/Browsers$Companion;
 	public abstract fun asSequence ()Lkotlin/sequences/Sequence;

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/AssumptionState.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/AssumptionState.kt
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under the License.
  */
-package elide.runtime.intrinsics.testing
+package elide.tooling.testing
 
 /**
  * ## Assumption State

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/GlobalTestScope.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/GlobalTestScope.kt
@@ -10,16 +10,14 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under the License.
  */
-package elide.runtime.intrinsics.testing
+package elide.tooling.testing
 
 /**
- * ## Violated Assumption
+ * ## Global Test Scope
  *
- * Describes a condition where an assumption was violated while processing a test, or while registering a test; when
- * this occurs, the test is disabled within a given run. Reasoning is included for assumption violations.
+ * Fallback singleton scope for all tests which have no other scope.
  */
-public class ViolatedAssumption(message: String?, cause: Throwable? = null): RuntimeException(message, cause) {
-  public fun reasonMessage(): String {
-    return message ?: cause?.message ?: "No reason provided (type: ${this::class.java.simpleName})"
-  }
+public data object GlobalTestScope: TestScope<GlobalTestScope> {
+  override val qualifiedName: String get() = ""
+  override val simpleName: String get() = ""
 }

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/Reason.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/Reason.kt
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under the License.
  */
-package elide.runtime.intrinsics.testing
+package elide.tooling.testing
 
 /**
  * ## Reason

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/TestCaseResult.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/TestCaseResult.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.testing
+
+import kotlin.time.Duration
+
+/**
+ * Results of an individual test case run.
+ *
+ * @property scope The scope in which the test was a member.
+ * @property result The result of the test case execution.
+ * @property duration The duration of the test case execution.
+ */
+@JvmRecord public data class TestCaseResult(
+  public val scope: TestScope<*>,
+  public val result: TestResult,
+  public val duration: Duration,
+)

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/TestPostProcessingOptions.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/TestPostProcessingOptions.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.testing
+
+/**
+ * ## Test Post-Processing Options
+ *
+ * @property coverageEnabled Whether code coverage instrumentation and reporting is enabled.
+ * @property reportingEnabled Whether test and flaw reporting is enabled.
+ */
+@JvmRecord public data class TestPostProcessingOptions(
+  public val coverageEnabled: Boolean = false,
+  public val reportingEnabled: Boolean = false,
+)

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/TestPostProcessor.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/TestPostProcessor.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.testing
+
+import elide.tooling.Tool
+
+/**
+ * ## Test Post-Processor
+ */
+public interface TestPostProcessor {
+  /**
+   * Consume the provided [options] and [results] and perform any processing needed.
+   *
+   * @param options Options governing test post-processing steps.
+   * @param results Test results.
+   */
+  public suspend operator fun invoke(options: TestPostProcessingOptions, results: TestRunResult): Tool.Result
+}

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/TestPostProcessorFactory.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/TestPostProcessorFactory.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.testing
+
+/**
+ * ## Test Post-Processor Factory
+ */
+public fun interface TestPostProcessorFactory<T> where T: TestPostProcessor {
+  /**
+   * Decide whether this processor factory is eligible for processing based on the provided [options].
+   *
+   * This method is consulted by outside classes instead of [create], just in case [create] is expensive; the default
+   * implementation runs [create] and checks `null` state. When using this default, processors should cache their
+   * constructed state into a singleton.
+   *
+   * @param options Test post-processing options to evaluate.
+   */
+  public fun eligible(options: TestPostProcessingOptions): Boolean = create(options) != null
+
+  /**
+   * Create an instance of the [TestPostProcessor] managed by this factory, if the provided [options] explain a test
+   * context where this post-processor is relevant.
+   *
+   * @param options Test post-processing options.
+   * @return Test post-processor, or `null` to opt-out of processing.
+   */
+  public fun create(options: TestPostProcessingOptions): TestPostProcessor?
+}

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/TestPostProcessors.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/TestPostProcessors.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.testing
+
+import java.util.ServiceLoader
+
+/**
+ * Typealias for a sequence of test post-processor factories.
+ */
+public typealias TestPostProcessorFactories = Sequence<TestPostProcessorFactory<TestPostProcessor>>
+
+/**
+ * # Test Post-Processing
+ */
+public object TestPostProcessors {
+  /**
+   * Gather all [TestPostProcessor] from the classpath.
+   *
+   * @return Sequence of test-post-processor factories.
+   */
+  @JvmStatic public fun all(): TestPostProcessorFactories {
+    @Suppress("UNCHECKED_CAST")
+    return ServiceLoader.load(TestPostProcessorFactory::class.java).asSequence() as TestPostProcessorFactories
+  }
+
+  /**
+   * Gather all [TestPostProcessor] from the classpath matching the provided [options].
+   *
+   * @return Sequence of matching test-post-processor factories.
+   */
+  @JvmStatic public fun matching(options: TestPostProcessingOptions): TestPostProcessorFactories {
+    return all().filter { it.eligible(options) }
+  }
+
+  /**
+   * Gather all [TestPostProcessor] from the classpath matching the provided [options].
+   *
+   * @return Sequence of matching test-post-processor factories.
+   */
+  @JvmStatic public fun suite(options: TestPostProcessingOptions): Sequence<TestPostProcessor> {
+    return matching(options).mapNotNull { it.create(options) }
+  }
+}

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/TestResult.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/TestResult.kt
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under the License.
  */
-package elide.runtime.intrinsics.testing
+package elide.tooling.testing
 
 /**
  * ## Test Result

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/TestRunResult.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/TestRunResult.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.testing
+
+/**
+ * Results of a test run.
+ *
+ * @property result The overall result of the test run.
+ * @property exitCode The exit code of the test run.
+ * @property stats Statistics about the test run.
+ * @property results Results of individual test cases.
+ * @property earlyExit Whether the test run exited early (e.g. due to a failure during `failFast` mode).
+ */
+@JvmRecord public data class TestRunResult(
+  public val result: TestResult,
+  public val exitCode: UInt,
+  public val stats: TestStats,
+  public val results: List<TestCaseResult>,
+  public val earlyExit: Boolean = false,
+)

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/TestScope.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/TestScope.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.testing
+
+import org.graalvm.polyglot.Value as PolyglotValue
+
+/**
+ * ## Test Scope
+ *
+ * Describes, in a sealed hierarchy, all scopes which apply to testing; this includes [RegisteredScope] instances
+ * which describe logical groupings of tests, and also tests themselves, via [RegisteredTest].
+ */
+public interface TestScope<T>: Comparable<T> where T: TestScope<T> {
+  /**
+   * ### Simple name.
+   *
+   * Every test and test scope provides a simple display name.
+   */
+  public val simpleName: String
+
+  /**
+   * ### Qualified name.
+   *
+   * Every test and test scope provides a well-qualified name.
+   */
+  public val qualifiedName: String
+
+  /**
+   * Return a generated qualified test name based on this scope and any parent scopes.
+   *
+   * @param block Block to generate a qualified name for.
+   * @param label Optional label to append to the qualified name.
+   * @return Qualified name for the test.
+   */
+  public fun qualifiedNameFor(block: PolyglotValue, label: String?): String {
+    if (qualifiedName.isEmpty() || qualifiedName.isBlank()) {
+      val srcfile = block.sourceLocation.source.name
+      return "$srcfile > ${label ?: block.metaSimpleName}"
+    }
+    return qualifiedName + (label?.let { " > $it" } ?: "")
+  }
+
+  /**
+   * Return a generated qualified test name based on this scope and any parent scopes.
+   *
+   * @param label Optional label to append to the qualified name.
+   * @return Qualified name for the test.
+   */
+  public fun qualifiedNameFor(label: String?): String? {
+    if (qualifiedName.isNotEmpty() && label?.isNotEmpty() == true) {
+      return qualifiedName + label.let { " > $it" }
+    }
+    return null
+  }
+
+  override fun compareTo(other: T): Int {
+    return qualifiedName.compareTo(other.qualifiedName)
+  }
+}

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/TestStats.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/TestStats.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.testing
+
+import kotlin.time.Duration
+
+/**
+ * Stats describing a test run.
+ *
+ * @property tests Total number of tests seen.
+ * @property executions Total number of tests ran.
+ * @property passes Total number of tests that passed.
+ * @property fails Total number of tests that failed.
+ * @property skips Total number of tests that were skipped.
+ * @property duration Total duration of the test run.
+ */
+@JvmRecord public data class TestStats(
+  public val tests: UInt,
+  public val executions: UInt,
+  public val passes: UInt,
+  public val fails: UInt,
+  public val skips: UInt,
+  public val duration: Duration,
+)

--- a/packages/tooling/src/main/kotlin/elide/tooling/testing/ViolatedAssumption.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/testing/ViolatedAssumption.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.testing
+
+/**
+ * ## Violated Assumption
+ *
+ * Describes a condition where an assumption was violated while processing a test, or while registering a test; when
+ * this occurs, the test is disabled within a given run. Reasoning is included for assumption violations.
+ */
+public class ViolatedAssumption(message: String?, cause: Throwable? = null): RuntimeException(message, cause) {
+  public fun reasonMessage(): String {
+    return message ?: cause?.message ?: "No reason provided (type: ${this::class.java.simpleName})"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a concept of `TestPostProcessor` instances; such instances are suspending consumers of `TestRunResult`s after a test run, and are loaded via a `TestPostProcessorFactory` type which is mapped in through SPI.

The first two `TestPostProcessor` implementations will likely be coverage (#1484) and test reporting (#1483).

Additionally, test result types (i.e. `TestResult` and `TestRunResult`, etc.), have been decoupled from polyglot types and moved from `graalvm` and `builder` to `tooling`, where they can be used for things like IDE integration. This refactor is precursor work for our JVM runner compat stuff.

## Changelog
```
feat(cli): add `TestingOptions` and consolidate coverage flags
feat(cli): load and run test-post-processors after test runs
chore(graalvm): unwind coupling between test runner and results
chore(builder): move test result classes to `tooling`
chore: re-pin modules `tooling`, `builder`, `graalvm`
```