### PR TITLE
fix(graalvm-kt): offset of kotlinc diagnostics

### DIFF
--- a/packages/builder/src/main/kotlin/elide/tooling/kotlin/KotlinCompiler.kt
+++ b/packages/builder/src/main/kotlin/elide/tooling/kotlin/KotlinCompiler.kt
@@ -247,9 +247,9 @@ public val kotlinc: Tool.CommandLineTool = Tool.describe(
           }
           appendLine("   ${TextStyles.dim("at")}: ${relativeFileAsLink ?: "<no file>"}:${ctx.first}:${ctx.second}")
           if (lineSrc != null) {
-            val leftpad = " ".repeat((location.columnEnd - location.column) + 2)
             val spaceIndentSize = lineSrc.takeWhile { it == ' ' }.length
             val spaceIndent = " ".repeat(spaceIndentSize)
+            val leftpad = " ".repeat(location.column + 3 + spaceIndentSize)
             appendLine("  ${(ctx.first - 1).toString().padStart(maxLineNumberSize, ' ')} ⋮ ${spaceIndent}...")
             appendLine("  ${(ctx.first).toString().padStart(maxLineNumberSize, ' ')} ⋮ $lineSrc")
             appendLine("${leftpad}${severityColor("↑")}")


### PR DESCRIPTION
## Summary

Fixes offset of `kotlinc` diagnostic messages.

- [x] Fixes elide-dev/elide#1590

| **Before** | **After** |
| ----------- | ---------- |
| <img alt="image" src="https://github.com/user-attachments/assets/023dc29c-a164-4933-beb5-07bee73d153b" /> | <img alt="image" src="https://github.com/user-attachments/assets/ac7d7b45-60e9-4492-9dde-1688b29693fe" />  |
