### PR TITLE
feat: highlighting for error context

### DIFF
--- a/packages/builder/api/builder.api
+++ b/packages/builder/api/builder.api
@@ -2394,11 +2394,11 @@ public final synthetic class elide/tooling/kotlin/$KotlinCompiler$Introspection 
 
 public final class elide/tooling/kotlin/KotlinCompiler : elide/tooling/AbstractTool {
 	public static final field Companion Lelide/tooling/kotlin/KotlinCompiler$Companion;
-	public fun <init> (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Lkotlin/jvm/functions/Function1;Ljava/nio/file/Path;Z)V
-	public synthetic fun <init> (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Lkotlin/jvm/functions/Function1;Ljava/nio/file/Path;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Lkotlin/jvm/functions/Function1;Ljava/nio/file/Path;ZLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Lkotlin/jvm/functions/Function1;Ljava/nio/file/Path;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun classesDir (Ljava/nio/file/Path;)Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;
 	public static final fun configureDefaultPlugins (Lorg/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments;ZZZ)Ljava/util/Set;
-	public static final fun create (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Ljava/nio/file/Path;ZLkotlin/jvm/functions/Function1;)Lelide/tooling/kotlin/KotlinCompiler;
+	public static final fun create (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Ljava/nio/file/Path;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lelide/tooling/kotlin/KotlinCompiler;
 	public final fun getInputs ()Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;
 	public final fun getOutputs ()Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;
 	public fun invoke (Lelide/tooling/AbstractTool$EmbeddedToolState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2406,16 +2406,18 @@ public final class elide/tooling/kotlin/KotlinCompiler : elide/tooling/AbstractT
 	public static final fun resolveCompilerServices$builder ()Lorg/jetbrains/kotlin/config/Services;
 	public static final fun sources (Lkotlin/sequences/Sequence;)Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;
 	public fun supported ()Z
+	public static final fun terminalHighlight (Ljava/lang/String;)Lorg/jline/utils/AttributedString;
 }
 
 public final class elide/tooling/kotlin/KotlinCompiler$Companion {
 	public final fun classesDir (Ljava/nio/file/Path;)Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;
 	public final fun configureDefaultPlugins (Lorg/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments;ZZZ)Ljava/util/Set;
 	public static synthetic fun configureDefaultPlugins$default (Lelide/tooling/kotlin/KotlinCompiler$Companion;Lorg/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments;ZZZILjava/lang/Object;)Ljava/util/Set;
-	public final fun create (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Ljava/nio/file/Path;ZLkotlin/jvm/functions/Function1;)Lelide/tooling/kotlin/KotlinCompiler;
-	public static synthetic fun create$default (Lelide/tooling/kotlin/KotlinCompiler$Companion;Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Ljava/nio/file/Path;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lelide/tooling/kotlin/KotlinCompiler;
+	public final fun create (Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Ljava/nio/file/Path;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lelide/tooling/kotlin/KotlinCompiler;
+	public static synthetic fun create$default (Lelide/tooling/kotlin/KotlinCompiler$Companion;Lelide/tooling/Arguments;Lelide/tooling/Environment;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;Ljava/nio/file/Path;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lelide/tooling/kotlin/KotlinCompiler;
 	public final fun outputJar (Ljava/nio/file/Path;)Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerOutputs;
 	public final fun sources (Lkotlin/sequences/Sequence;)Lelide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs;
+	public final fun terminalHighlight (Ljava/lang/String;)Lorg/jline/utils/AttributedString;
 }
 
 public abstract interface class elide/tooling/kotlin/KotlinCompiler$KotlinCompilerInputs : elide/tooling/Inputs$Files {

--- a/packages/builder/api/builder.api
+++ b/packages/builder/api/builder.api
@@ -58,6 +58,7 @@ public final class elide/tooling/cli/Statics {
 	public final fun getResourcesPath ()Ljava/nio/file/Path;
 	public final fun getServerLogger ()Lelide/runtime/Logger;
 	public final fun getTerminal ()Lcom/github/ajalt/mordant/terminal/Terminal;
+	public final fun getTrueColor ()Z
 	public final fun mountArgs (Ljava/lang/String;[Ljava/lang/String;)V
 }
 

--- a/packages/builder/build.gradle.kts
+++ b/packages/builder/build.gradle.kts
@@ -75,6 +75,8 @@ dependencies {
   ksp(mn.micronaut.inject.kotlin)
   api(libs.kotlin.stdlib.jdk8)
   api(libs.jetbrains.annotations)
+  api(libs.jline.reader)
+  api(libs.jline.builtins)
   api(projects.packages.tooling)
   api(projects.packages.exec)
   api(projects.packages.engine)

--- a/packages/builder/src/main/kotlin/elide/tooling/cli/Statics.kt
+++ b/packages/builder/src/main/kotlin/elide/tooling/cli/Statics.kt
@@ -50,6 +50,11 @@ public object Statics {
     }
   }
 
+  /** Whether to use true-color; if `false`, 256-color mode is used (`noColor` overrides). */
+  public val trueColor: Boolean by lazy {
+    !noColor
+  }
+
   @Volatile private var execBinPath: String = ""
 
   @Volatile private var initialArgs = emptyArray<String>()

--- a/packages/cli/detekt-baseline.xml
+++ b/packages/cli/detekt-baseline.xml
@@ -5,6 +5,7 @@
     <ID>ComplexCondition:RuntimeWorkdirManager.kt$RuntimeWorkdirManager$(base != null &amp;&amp; (base.parentFile == null || base.absolutePath == "/")) || files.isEmpty()</ID>
     <ID>CyclomaticComplexMethod:ToolShellCommand.kt$ToolShellCommand$override fun PolyglotEngineConfiguration.configureEngine(langs: Set&lt;GuestLanguage>)</ID>
     <ID>CyclomaticComplexMethod:ToolShellCommand.kt$ToolShellCommand$override suspend fun CommandContext.invoke(state: ToolContext&lt;ToolState>): CommandResult</ID>
+    <ID>CyclomaticComplexMethod:ToolShellCommand.kt$ToolShellCommand$private fun displayFormattedError( exc: Throwable, message: String, advice: String? = null, internal: Boolean = false, stacktrace: Boolean = internal, withCause: Boolean = true, )</ID>
     <ID>EmptyFunctionBlock:BuildOutput.kt$BaseOutput${ }</ID>
     <ID>EmptyFunctionBlock:BuildOutput.kt$BaseOutput.&lt;no name provided>${ }</ID>
     <ID>ForbiddenComment:DelegatedToolCommand.kt$DelegatedToolCommand$// @TODO: delegated error handling</ID>
@@ -13,6 +14,7 @@
     <ID>LongMethod:InitCommand.kt$InitCommand$@Suppress("ReturnCount", "CyclomaticComplexMethod") override suspend fun CommandContext.invoke(state: ToolContext&lt;ToolState>): CommandResult</ID>
     <ID>LongMethod:ToolShellCommand.kt$ToolShellCommand$override fun PolyglotEngineConfiguration.configureEngine(langs: Set&lt;GuestLanguage>)</ID>
     <ID>LongMethod:ToolShellCommand.kt$ToolShellCommand$override suspend fun CommandContext.invoke(state: ToolContext&lt;ToolState>): CommandResult</ID>
+    <ID>LongMethod:ToolShellCommand.kt$ToolShellCommand$private fun displayFormattedError( exc: Throwable, message: String, advice: String? = null, internal: Boolean = false, stacktrace: Boolean = internal, withCause: Boolean = true, )</ID>
     <ID>LoopWithTooManyJumpStatements:ToolShellCommand.kt$ToolShellCommand$while</ID>
     <ID>MagicNumber:RuntimeWorkdirManager.kt$RuntimeWorkdirManager$15</ID>
     <ID>MagicNumber:SubprocessRunner.kt$100</ID>
@@ -21,10 +23,10 @@
     <ID>MagicNumber:ToolShellCommand.kt$ToolShellCommand$40</ID>
     <ID>MagicNumber:ToolShellCommand.kt$ToolShellCommand$80</ID>
     <ID>MatchingDeclarationName:SanityTests.kt$SanitySelfTest : SelfTest</ID>
-    <ID>PrintStackTrace:main.kt$err</ID>
     <ID>ReturnCount:ExecutionController.kt$ExecutionController$private fun toHost(polyglotException: PolyglotException): Throwable</ID>
     <ID>ReturnCount:RuntimeWorkdirManager.kt$RuntimeWorkdirManager$private fun nearestDirectoryWithAnyOfTheseFiles( files: Array&lt;String>, base: File? = null, depth: Int? = null, ): File?</ID>
     <ID>ReturnCount:ToolShellCommand.kt$ToolShellCommand$override suspend fun CommandContext.invoke(state: ToolContext&lt;ToolState>): CommandResult</ID>
+    <ID>ReturnCount:ToolShellCommand.kt$ToolShellCommand$private fun highlightLineMaybe(line: String, langId: String?): Pair&lt;String, Int></ID>
     <ID>SpreadOperator:ToolInvokeCommand.kt$ToolInvokeCommand$(*selectedTools.map { it to buildArgs(action, it) }.toTypedArray())</ID>
     <ID>SwallowedException:PersistedError.kt$PersistedError.RuntimeInfo$err: Throwable</ID>
     <ID>TooGenericExceptionCaught:AbstractToolCommand.kt$AbstractToolCommand$err: Throwable</ID>

--- a/packages/cli/src/main/resources/nanorc/jnanorc
+++ b/packages/cli/src/main/resources/nanorc/jnanorc
@@ -1,0 +1,12 @@
+set tabstospaces
+set autoindent
+set tempfile
+include "./args.nanorc"
+include "./command.nanorc"
+include "./java.nanorc"
+include "./javascript.nanorc"
+include "./json.nanorc"
+include "./kotlin.nanorc"
+include "./python.nanorc"
+include "./ruby.nanorc"
+include "./ts.nanorc"

--- a/packages/cli/src/main/resources/nanorc/kotlin.nanorc
+++ b/packages/cli/src/main/resources/nanorc/kotlin.nanorc
@@ -6,6 +6,9 @@
 # Copyright (c) 2014, Bjarne Holen
 
 syntax "Kotlin" "\.kt$" "\.kts$"
+$BALANCED_DELIMITERS:  """
+$LINE_COMMENT:         "//"
+$BLOCK_COMMENT:        "/*, */"
 color magenta "\b(([1-9][0-9]+)|0+)\.[0-9]+\b" "\b[1-9][0-9]*\b" "\b0[0-7]*\b" "\b0x[1-9a-f][0-9a-f]*\b"
 color yellow "[.:;,+*|=!\%@]" "<" ">" "/" "-" "&"
 color green "\<(namespace|as|type|class|this|super|val|var|fun|is|in|object|when|trait|import|where|by|get|set|abstract|enum|open|annotation|override|private|public|internal|protected|out|vararg|inline|final|package|lateinit|constructor|companion|const|suspend|sealed)\>"

--- a/packages/tooling/api/tooling.api
+++ b/packages/tooling/api/tooling.api
@@ -6389,6 +6389,12 @@ public final class elide/tooling/project/mcp/ModelContextProtocol$McpServingMode
 	public static fun values ()[Lelide/tooling/project/mcp/ModelContextProtocol$McpServingMode;
 }
 
+public final class elide/tooling/term/TerminalUtil {
+	public static final field INSTANCE Lelide/tooling/term/TerminalUtil;
+	public final fun to256ColorAnsiString (Lorg/jline/utils/AttributedString;)Ljava/lang/String;
+	public final fun toTrueColorAnsiString (Lorg/jline/utils/AttributedString;)Ljava/lang/String;
+}
+
 public abstract interface class elide/tooling/testing/AssumptionState {
 }
 

--- a/packages/tooling/build.gradle.kts
+++ b/packages/tooling/build.gradle.kts
@@ -56,6 +56,8 @@ dependencies {
   api(libs.pkl.config.java) { pklExclusions() }
   api(libs.pkl.config.kotlin) { pklExclusions() }
   api(libs.bundles.maven.model)
+  api(libs.jline.reader)
+  api(libs.jline.builtins)
 
   implementation(libs.ktoml)
   implementation(libs.kotlinx.io.bytestring)

--- a/packages/tooling/src/main/kotlin/elide/tooling/term/TerminalUtil.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/term/TerminalUtil.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.tooling.term
+
+import org.jline.utils.AttributedCharSequence
+import org.jline.utils.AttributedString
+
+/**
+ * ## Terminal Utilities
+ *
+ * General terminal utilities and extension functions.
+ */
+public object TerminalUtil {
+  private const val COLOR_256 = 256
+  private const val COLOR_TRUE = 16777216
+
+  /**
+   * Force this [AttributedString] to render in 256-color ANSI, returning a string.
+   *
+   * @receiver Attributed string.
+   * @return Rendered string, in true-color.
+   */
+  public fun AttributedString.to256ColorAnsiString(): String {
+    return toAnsi(
+      COLOR_256,
+      AttributedCharSequence.ForceMode.Force256Colors,
+    )
+  }
+
+  /**
+   * Force this [AttributedString] to render in true-color ANSI, returning a string.
+   *
+   * @receiver Attributed string.
+   * @return Rendered string, in true-color.
+   */
+  public fun AttributedString.toTrueColorAnsiString(): String {
+    return toAnsi(
+      COLOR_TRUE,
+      AttributedCharSequence.ForceMode.ForceTrueColors,
+    )
+  }
+}


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds syntax highlighting, via our REPL tools, for code emitted in other circumstances by the CLI.

- [x] **Extended Syntax Highlighting**
  - [x] Fixes: elide-dev/elide#1592
  - [x] Kotlin: Diagnostics/errors from `kotlinc`
  - [x] Guest-side errors (JavaScript, Python, et al)

### Examples

| **Before** | **After** |
| ----------- | ---------- |
| <img alt="image" src="https://github.com/user-attachments/assets/9142db2a-464d-4968-a973-81b51e29c975" /> | <img alt="Screenshot 2025-07-26 162623" src="https://github.com/user-attachments/assets/82fb55e4-071b-4ff7-ab26-7a542dc21c85" /> |
| <img alt="image" src="https://github.com/user-attachments/assets/5bb8f783-28fb-4345-955c-1948c80e1425" /> | <img alt="image" src="https://github.com/user-attachments/assets/50092fa2-5003-4d8f-b422-5ea19763aeb3" /> |
