### PR TITLE
fix: add explicit lifetime parameters to build_printer_options and css_options function signatures

### DIFF
--- a/crates/web/src/css.rs
+++ b/crates/web/src/css.rs
@@ -75,11 +75,11 @@ pub(crate) struct ScssBuilderError {
 }
 
 /// Build minification options from JVM-side flags.
-fn build_printer_options(
+fn build_printer_options<'a>(
   minify: bool,
-  source_map: Option<&mut SourceMap>,
+  source_map: Option<&'a mut SourceMap>,
   targets: Targets,
-) -> Result<PrinterOptions, BrowserslistError> {
+) -> Result<PrinterOptions<'a>, BrowserslistError> {
   Ok(PrinterOptions {
     minify,
     source_map,
@@ -89,11 +89,11 @@ fn build_printer_options(
 }
 
 /// Build CSS options from JVM-side flags.
-pub(crate) fn css_options(
+pub(crate) fn css_options<'a>(
   do_minify: bool,
   use_targets: Option<Targets>,
-  source_map: Option<&mut SourceMap>,
-) -> Result<CssBuilderOptions, BrowserslistError> {
+  source_map: Option<&'a mut SourceMap>,
+) -> Result<CssBuilderOptions<'a>, BrowserslistError> {
   let targets = use_targets.or(Some(Targets::default())).unwrap_or_default();
   let minify = match do_minify {
     true => Some(MinifyOptions {


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

fix: add explicit lifetime parameters to build_printer_options and css_options function signatures

## Summary

This removes "mistmatched lifetime syntax" warnings.

## Changelog
- fix: add explicit lifetime parameters to build_printer_options and css_options function signatures