### PR TITLE
fix(cli): robust path/working-dir detection for native image on Linux/WSL

### DIFF
--- a/packages/cli/src/main/kotlin/elide/tool/cli/main.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/main.kt
@@ -223,6 +223,9 @@ private fun safeWorkingDirectory(): String {
   }
 }
 
+// Visible for tests in the same module.
+internal fun safeWorkingDirectoryForTest(): String = safeWorkingDirectory()
+
 fun initializeEntry(args: Array<String>, installStatics: Boolean = true) {
   if (entryInitialized) return
   entryInitialized = true

--- a/packages/cli/src/test/kotlin/elide/tool/cli/WorkingDirectoryFallbackTest.kt
+++ b/packages/cli/src/test/kotlin/elide/tool/cli/WorkingDirectoryFallbackTest.kt
@@ -12,12 +12,8 @@ import kotlin.test.assertTrue
   @Test fun returnsNonEmptyWhenUserDirMissingOrBlank() {
     val orig = System.getProperty("user.dir")
     try {
-      // Remove user.dir so the fallback logic engages
       System.clearProperty("user.dir")
-      val cls = Class.forName("elide.tool.cli.MainKt")
-      val m = cls.getDeclaredMethod("safeWorkingDirectory")
-      m.isAccessible = true
-      val result = m.invoke(null) as String
+      val result = safeWorkingDirectoryForTest()
       assertTrue(result.isNotBlank(), "safeWorkingDirectory should return a non-blank path")
     } finally {
       if (orig == null) System.clearProperty("user.dir") else System.setProperty("user.dir", orig)


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary
Fixes an issue where `elide mcp` (and other CLI entrypoints) could fail on WSL/Ubuntu with:

> Error: Properties init: Could not determine current working directory.

Tracking: Fixes #1583

## Root cause
In GraalVM native images, initialization of `user.dir` can throw if `getcwd(2)` fails in certain directories/configurations (seen on WSL). Our CLI startup referenced `System.getProperty("user.dir")` during early initialization and also relied on the process command path, which may be relative; together, this could surface the native image error on WSL when invoked from particular directories (e.g., `~/elide`).

## What changed
- Add `resolveBinaryPathForNative()`:
  - Prefer `ProcessHandle.current().info().command()` when absolute; resolve symlinks
  - If the command is relative or unavailable, fallback to `/proc/self/exe` (absolute, stable)
- Add `safeWorkingDirectory()`:
  - Try `System.getProperty("user.dir")`
  - On failure, fallback to `/proc/self/cwd`; then `PWD`; then `HOME`; finally `.`
- Use the above in `initializeEntry(...)` when in native-image runtime code:
  - Compute `binPath` via `resolveBinaryPathForNative()`
  - Pass `safeWorkingDirectory()` to `installStatics(...)`

These fallbacks are only engaged when running as a native image on Linux/WSL; JVM behavior remains unchanged.

## Why this works
- `/proc/self/exe` gives a canonical absolute path to the running binary on Linux/WSL, independent of `user.dir`.
- `/proc/self/cwd` provides an absolute working directory path even if `user.dir` initialization encountered issues inside SVM, avoiding the "Could not determine current working directory" failure mode.

## Verification
- Built and compiled `:packages:cli` successfully
- Existing tests remain unaffected
- Behavioral change is limited to native image path resolution and only when the standard properties are not safely available

## Risk
Low. Changes are guarded for native image runtime and rely on standard Linux `/proc` fallbacks only when needed. No behavioral change for JVM runs.

— Augment Code