### PR TITLE
fix(cli): correct JS error source location for host exceptions (#1595)

### DIFF
--- a/packages/cli/src/test/kotlin/elide/tool/cli/ElideToolErrorLocationTest.kt
+++ b/packages/cli/src/test/kotlin/elide/tool/cli/ElideToolErrorLocationTest.kt
@@ -1,0 +1,48 @@
+package elide.tool.cli
+
+import org.apache.commons.io.output.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import elide.testing.annotations.Test
+import elide.testing.annotations.TestCase
+import kotlin.test.assertTrue
+
+@TestCase class ElideToolErrorLocationTest : AbstractEntryTest() {
+  @Test fun testGuestErrorHighlightsCorrectLine() {
+    val temp = Files.createTempFile("elide-js-error-test", ".js").toFile()
+    temp.writeText(
+      """
+      const a = 1;
+      const b = 2;
+      throw new Error("boom");
+      """.trimIndent(),
+      Charsets.UTF_8
+    )
+
+    // capture stdout and stderr
+    val stubbedOut = ByteArrayOutputStream()
+    val stubbedErr = ByteArrayOutputStream()
+    val originalOut = System.out
+    val originalErr = System.err
+    System.setOut(PrintStream(stubbedOut))
+    System.setErr(PrintStream(stubbedErr))
+
+    val code = try {
+      Elide.exec(arrayOf("run", temp.absolutePath))
+    } finally {
+      System.setOut(originalOut)
+      System.setErr(originalErr)
+    }
+
+    val stderr = stubbedErr.toString("UTF-8")
+    // Should have failed with a non-zero code
+    assertTrue(code != 0, "expected non-zero exit code, got $code; stderr=\n$stderr")
+    // Should point to line 3 where the error occurs
+    assertTrue(
+      stderr.contains("→ 3┊") || stderr.contains("\u2192 3┊"),
+      "expected error marker on line 3; stderr=\n$stderr"
+    )
+  }
+}
+


### PR DESCRIPTION
Summary
- Prefer the top guest JS frame's SourceSection when rendering error context, especially for host exceptions raised via Polyglot (e.g., invokeMember failures). This aligns the highlighted line with the actual call site in guest code.
- Fix context math in errorContextLines (proper base offset and inclusive range length), preventing off-by-one and unrelated line highlights.
- Keep polyglot context in the renderer for host exceptions (avoid converting to plain host Throwable for display), so we can still show guest code context and language-aware highlighting.
- Add a test validating error line mapping for guest-thrown Error (ensures no regressions on guest exceptions).

Why
Issue #1595: JS errors surfaced from host code were showing incorrect source locations (e.g., pointing to an unrelated previous line). The polyglot stack already contains the correct guest frame; we were not using it for context selection.

Details
- ToolShellCommand.kt
  - Introduce errorContextLines(SourceSection?) and delegate from the existing overload.
  - Compute bestSection = top guest frame's sourceLocation or fallback to exc.sourceLocation.
  - Use bestSection for context extraction and line-range computation.
  - Correct base/total range calculations (0-based slicing, inclusive end).
  - In processUserCodeError, for non-GuestError host exceptions, keep and render the original PolyglotException so the code box is shown with proper guest context.
- Tests
  - New test ElideToolErrorLocationTest validates that a guest-side thrown Error highlights the correct line, guarding against regressions in the refactor.

Notes
- A follow-up test specifically for a host-exception path can be added using a module call that intentionally fails at the host (e.g., Node http.createServer); this depends on test runtime availability of the module. The structural changes here fix that path by selecting the top guest frame.

Closes #1595.
