### PR TITLE
build(elide-build): use File.toURI for local stage Maven repo to fix Windows file:// parsing

### DIFF
--- a/tools/elide-build/src/main/kotlin/elide/internal/conventions/publishing/PublishingConventions.kt
+++ b/tools/elide-build/src/main/kotlin/elide/internal/conventions/publishing/PublishingConventions.kt
@@ -138,7 +138,8 @@ internal fun Project.configurePublishingRepositories() {
       // GitHub Maven registry
       maven {
         name = "stage"
-        url = uri("file://${rootProject.layout.buildDirectory.dir("m2").get().asFile.absolutePath}")
+        // Use a proper file URI to avoid Windows-specific URI parsing issues
+        url = rootProject.layout.buildDirectory.dir("m2").get().asFile.toURI()
       }
     }
   }


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Summary:
- Replace manual string-based file:// URI construction with File.toURI() for the local "stage" Maven repo in elide-build
- Fixes Windows path authority parsing (e.g., file://D:\) that caused Gradle to fail converting URI to file during publishing/resolve steps

Context:
- This change is unrelated to #1616 (Maven classifier). Splitting into its own PR to keep the other branch focused.
- Verified locally on Windows + WSL that Gradle no longer errors on URI->File conversion with this change.

Change:
- tools/elide-build/src/main/kotlin/elide/internal/conventions/publishing/PublishingConventions.kt
  - url = rootProject.layout.buildDirectory.dir("m2").get().asFile.toURI()

Notes:
- No behavior change on non-Windows platforms; File.toURI is canonical and safe.
- If desired, we can add a tiny functional test later to assert the repo URL is a file: URI.