### PR TITLE
fix: enforce host environment access rules and correct process.env formatting

### DIFF
--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
@@ -2431,7 +2431,7 @@ internal class ToolShellCommand : ProjectAwareSubcommand<ToolState, CommandConte
     appEnvironment.apply(
       project,
       this,
-      host = accessControl.allowEnv,
+      host = accessControl.allowAll || accessControl.allowEnv,
       dotenv = appEnvironment.dotenv,
     )
 

--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -3806,7 +3806,7 @@ public abstract interface class elide/runtime/intrinsics/js/node/ProcessAPI : el
 	public abstract fun exit (Lorg/graalvm/polyglot/Value;)V
 	public abstract fun getArch ()Ljava/lang/String;
 	public abstract fun getArgv ()[Ljava/lang/String;
-	public abstract fun getEnv ()Lelide/runtime/intrinsics/js/node/process/ProcessEnvironmentAPI;
+	public abstract fun getEnv ()Lorg/graalvm/polyglot/Value;
 	public synthetic fun getMemberKeys ()Ljava/lang/Object;
 	public fun getMemberKeys ()[Ljava/lang/String;
 	public abstract fun getPid ()J
@@ -9804,10 +9804,14 @@ public final class elide/runtime/plugins/env/Environment {
 	public static final field Plugin Lelide/runtime/plugins/env/Environment$Plugin;
 	public synthetic fun <init> (Lelide/runtime/plugins/env/EnvConfig;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun configure (Lelide/runtime/core/EnginePlugin$InstallationScope;Lelide/runtime/core/PolyglotContext;Lelide/runtime/core/GuestLanguage;)V
+	public static final fun forLanguage (Lelide/runtime/core/GuestLanguage;Lorg/graalvm/polyglot/Context;)Lorg/graalvm/polyglot/Value;
+	public static final fun forLanguage (Ljava/lang/String;Lorg/graalvm/polyglot/Context;)Lorg/graalvm/polyglot/Value;
 	public final fun getConfig ()Lelide/runtime/plugins/env/EnvConfig;
 }
 
 public final class elide/runtime/plugins/env/Environment$Plugin : elide/runtime/core/EnginePlugin {
+	public final fun forLanguage (Lelide/runtime/core/GuestLanguage;Lorg/graalvm/polyglot/Context;)Lorg/graalvm/polyglot/Value;
+	public final fun forLanguage (Ljava/lang/String;Lorg/graalvm/polyglot/Context;)Lorg/graalvm/polyglot/Value;
 	public fun getKey-wLvarY0 ()Ljava/lang/String;
 	public fun install (Lelide/runtime/core/EnginePlugin$InstallationScope;Lkotlin/jvm/functions/Function1;)Lelide/runtime/plugins/env/Environment;
 	public synthetic fun install (Lelide/runtime/core/EnginePlugin$InstallationScope;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/ProcessAPI.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/node/ProcessAPI.kt
@@ -15,6 +15,7 @@ package elide.runtime.intrinsics.js.node
 import org.graalvm.polyglot.Value
 import org.graalvm.polyglot.proxy.ProxyObject
 import elide.annotations.API
+import elide.runtime.core.PolyglotValue
 import elide.runtime.gvm.js.JsError
 import elide.runtime.intrinsics.js.node.process.ProcessEnvironmentAPI
 import elide.runtime.intrinsics.js.node.process.ProcessStandardInputStream
@@ -85,12 +86,11 @@ private val NODE_PROCESS_PROPS = arrayOf(
   /**
    * ## Process Environment
    *
-   * Access the environment variables of the current process.
+   * Access the environment variables of the current process as an arbitrary guest value.
    *
    * See also: [Node Process API: `env`](https://nodejs.org/api/process.html#process_process_env).
-   * @see ProcessEnvironmentAPI for details about how Elide handles Node-style environment access.
    */
-  @get:Polyglot public val env: ProcessEnvironmentAPI
+  @get:Polyglot public val env: PolyglotValue
 
   /**
    * ## Process Arguments

--- a/packages/graalvm/src/main/kotlin/elide/runtime/node/process/NodeProcess.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/node/process/NodeProcess.kt
@@ -17,6 +17,7 @@ package elide.runtime.node.process
 
 import org.graalvm.nativeimage.ImageInfo
 import org.graalvm.nativeimage.ProcessProperties
+import org.graalvm.polyglot.Context
 import org.graalvm.polyglot.Value
 import org.graalvm.polyglot.proxy.ProxyExecutable
 import java.util.concurrent.atomic.AtomicReference
@@ -26,6 +27,7 @@ import kotlin.system.exitProcess
 import elide.annotations.Inject
 import elide.annotations.Singleton
 import elide.runtime.core.DelicateElideApi
+import elide.runtime.core.PolyglotValue
 import elide.runtime.gvm.api.Intrinsic
 import elide.runtime.gvm.internals.ProcessManager
 import elide.runtime.gvm.internals.intrinsics.js.AbstractNodeBuiltinModule
@@ -37,6 +39,8 @@ import elide.runtime.intrinsics.js.node.ProcessAPI
 import elide.runtime.intrinsics.js.node.process.*
 import elide.runtime.lang.javascript.NodeModuleName
 import elide.runtime.plugins.env.EnvConfig
+import elide.runtime.plugins.env.Environment
+import elide.runtime.plugins.js.JavaScript
 import elide.vm.annotations.Polyglot
 
 // Installs the Node process module into the intrinsic bindings.
@@ -277,7 +281,8 @@ internal object NodeProcess {
     // Process title/program name override.
     private val programNameOverride: AtomicReference<String> = AtomicReference()
 
-    @get:Polyglot override val env: ProcessEnvironmentAPI get() = EnvironmentAccessMediator(envApi)
+    @get:Polyglot override val env: PolyglotValue get() = Environment.forLanguage(JavaScript, Context.getCurrent())
+
     @get:Polyglot override val argv: Array<String> get() = argvMediator.all()
     @get:Polyglot override val pid: Long get() = pidAccessor.pid()
     @get:Polyglot override val arch: String get() = activeArch.symbol

--- a/packages/graalvm/src/main/kotlin/elide/runtime/plugins/env/EnvPlugin.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/plugins/env/EnvPlugin.kt
@@ -12,6 +12,7 @@
  */
 package elide.runtime.plugins.env
 
+import org.graalvm.polyglot.Context
 import org.graalvm.polyglot.Value
 import org.graalvm.polyglot.proxy.ProxyHashMap
 import org.graalvm.polyglot.proxy.ProxyIterable
@@ -120,6 +121,23 @@ import elide.vm.annotations.Polyglot
       scope.lifecycle.on(ContextCreated, instance::onContextCreate)
 
       return instance
+    }
+
+    /**
+     * Returns the value providing access to the environment map installed in the given [context] for a specific
+     * [language].
+     */
+    @JvmStatic public fun forLanguage(language: GuestLanguage, context: Context): PolyglotValue {
+      return forLanguage(language.languageId, context)
+    }
+
+
+    /**
+     * Returns the value providing access to the environment map installed in the given [context] for a specific
+     * [language].
+     */
+    @JvmStatic public fun forLanguage(languageId: String, context: Context): PolyglotValue {
+      return context.getBindings(languageId).getMember(APP_ENV_BIND_PATH)
     }
   }
 }

--- a/packages/graalvm/src/test/kotlin/elide/runtime/gvm/internals/AbstractDualTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/gvm/internals/AbstractDualTest.kt
@@ -36,6 +36,7 @@ import elide.runtime.core.PolyglotContext
 import elide.runtime.core.PolyglotEngine
 import elide.runtime.core.PolyglotEngineConfiguration
 import elide.runtime.gvm.internals.AbstractDualTest.CodeGenerator
+import elide.runtime.plugins.env.Environment
 import elide.runtime.plugins.vfs.VfsListener
 import elide.runtime.plugins.vfs.vfs
 import elide.vm.annotations.Polyglot
@@ -315,6 +316,7 @@ abstract class AbstractDualTest<Generator : CodeGenerator> {
   /** A [PolyglotEngine] used to acquire context instances for testing, configurable trough [configureEngine]. */
   protected val engine: PolyglotEngine by lazy {
     PolyglotEngine {
+      configure(Environment)
       configureEngine(this) // provided by implementations
 
       // register event listeners

--- a/packages/graalvm/src/test/kotlin/elide/runtime/plugins/EnvPluginTest.kt
+++ b/packages/graalvm/src/test/kotlin/elide/runtime/plugins/EnvPluginTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.plugins
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import elide.runtime.core.PolyglotEngine
+import elide.runtime.core.PolyglotEngineConfiguration.HostAccess
+import elide.runtime.plugins.env.Environment
+import elide.runtime.plugins.env.environment
+import elide.runtime.plugins.js.JavaScript
+import elide.testing.annotations.Test
+
+class EnvPluginTest {
+  @Test fun `should prevent host env access by default`() {
+    assert(System.getenv().isNotEmpty()) { "A non-empty host env is required" }
+
+    val engine = PolyglotEngine {
+      configure(Environment)
+      configure(JavaScript)
+    }
+
+    val context = engine.acquire()
+    val guestEnv = Environment.forLanguage(JavaScript, context.unwrap())
+
+    System.getenv().forEach {
+      assertFalse(guestEnv.hasMember(it.key), "expected host env variable to be inaccessible")
+    }
+  }
+
+  @Test fun `should allow host env access when configured`() {
+    assert(System.getenv().isNotEmpty()) { "A non-empty host env is required" }
+
+    val engine = PolyglotEngine {
+      configure(Environment) {
+        System.getenv().forEach { mapToHostEnv(it.key) }
+      }
+
+      configure(JavaScript)
+    }
+
+    val context = engine.acquire()
+    val guestEnv = Environment.forLanguage(JavaScript, context.unwrap())
+
+    System.getenv().forEach {
+      assertTrue(guestEnv.hasMember(it.key), "expected host env variable to be accessible")
+      assertEquals(it.value, guestEnv.getMember(it.key).asString(), "expected env variable value to match host")
+    }
+  }
+}


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

This PR adds a couple of fixes related to host environment variable access from guest code:

Node's `process.env` now returns the environment map installed by the `Environment` plugin, which correctly enforces host access configuration and supports loading `.env` files, etc. This fixes #1664, which was not a failure of the env map itself, but instead an issue with formatting when writing to console or using `JSON.stringify`

Additionally, Node `process` tests now verify that `env` matches the map installed by the env plugin instead of checking against host env directly. Tests have been added to verify that the `Environment` plugin correctly handles host access settings.