### PR TITLE
fix: `--js:strict` and benchmark symbols

### DIFF
--- a/packages/cli/src/main/kotlin/elide/tool/cli/options/EngineJavaScriptOptions.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/options/EngineJavaScriptOptions.kt
@@ -93,6 +93,7 @@ import elide.runtime.plugins.js.JavaScriptVersion
     config.language = JavaScriptVersion.valueOf(ecma.name)
     config.wasm = wasm
     config.esm = esm
+    config.strict = strict
     if (experimentalDisableVfs || experimentalDisablePolyfills) {
       config.experimental {
         disableVfs = experimentalDisableVfs

--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -1205,7 +1205,6 @@ public synthetic class elide/runtime/gvm/internals/js/$JsTimersIntrinsic$Definit
 	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
 	public fun <init> ()V
 	protected fun <init> (Ljava/lang/Class;Lio/micronaut/context/AbstractInitializableBeanDefinition$MethodOrFieldReference;)V
-	public fun inject (Lio/micronaut/context/BeanResolutionContext;Lio/micronaut/context/BeanContext;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun instantiate (Lio/micronaut/context/BeanResolutionContext;Lio/micronaut/context/BeanContext;)Ljava/lang/Object;
 	public fun isContextScope ()Z
 	public fun isEnabled (Lio/micronaut/context/BeanContext;)Z
@@ -1217,7 +1216,6 @@ public final synthetic class elide/runtime/gvm/internals/js/$JsTimersIntrinsic$I
 	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
 	public fun <init> ()V
 	public fun hasBuilder ()Z
-	public fun instantiate ()Ljava/lang/Object;
 	public fun isBuildable ()Z
 }
 
@@ -7491,6 +7489,16 @@ public final class elide/runtime/intrinsics/testing/TestingRegistrar$TestInfo : 
 	public fun toString ()Ljava/lang/String;
 }
 
+public synthetic class elide/runtime/javascript/$BrowserStubs$Definition : io/micronaut/context/AbstractInitializableBeanDefinitionAndReference {
+	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
+	public fun <init> ()V
+	protected fun <init> (Ljava/lang/Class;Lio/micronaut/context/AbstractInitializableBeanDefinition$MethodOrFieldReference;)V
+	public fun instantiate (Lio/micronaut/context/BeanResolutionContext;Lio/micronaut/context/BeanContext;)Ljava/lang/Object;
+	public fun isEnabled (Lio/micronaut/context/BeanContext;)Z
+	public fun isEnabled (Lio/micronaut/context/BeanContext;Lio/micronaut/context/BeanResolutionContext;)Z
+	public fun load ()Lio/micronaut/inject/BeanDefinition;
+}
+
 public synthetic class elide/runtime/javascript/$MessageChannelBuiltin$Definition : io/micronaut/context/AbstractInitializableBeanDefinitionAndReference {
 	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
 	public fun <init> ()V
@@ -7560,6 +7568,11 @@ public final synthetic class elide/runtime/javascript/$StructuredCloneBuiltin$In
 	public fun hasBuilder ()Z
 	public fun instantiate ()Ljava/lang/Object;
 	public fun isBuildable ()Z
+}
+
+public final class elide/runtime/javascript/BrowserStubs : elide/runtime/gvm/internals/intrinsics/js/AbstractJsIntrinsic {
+	public fun <init> ()V
+	public fun install (Lelide/runtime/intrinsics/GuestIntrinsic$MutableIntrinsicBindings;)V
 }
 
 public final class elide/runtime/javascript/MessageChannelBuiltin : elide/runtime/gvm/internals/intrinsics/js/AbstractJsIntrinsic, org/graalvm/polyglot/proxy/ProxyInstantiable {
@@ -9843,6 +9856,7 @@ public final class elide/runtime/plugins/js/JavaScriptConfig : elide/runtime/plu
 	public final fun getLanguage ()Lelide/runtime/plugins/js/JavaScriptVersion;
 	public final fun getLocale ()Ljava/util/Locale;
 	public final fun getSourceMaps ()Z
+	public final fun getStrict ()Z
 	public final fun getTimezone ()Ljava/time/ZoneId;
 	public final fun getTypescript ()Z
 	public final fun getV8 ()Z
@@ -9856,6 +9870,7 @@ public final class elide/runtime/plugins/js/JavaScriptConfig : elide/runtime/plu
 	public final fun setLanguage (Lelide/runtime/plugins/js/JavaScriptVersion;)V
 	public final fun setLocale (Ljava/util/Locale;)V
 	public final fun setSourceMaps (Z)V
+	public final fun setStrict (Z)V
 	public final fun setTimezone (Ljava/time/ZoneId;)V
 	public final fun setTypescript (Z)V
 	public final fun setV8 (Z)V

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/js/JsTimers.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/js/JsTimers.kt
@@ -85,8 +85,9 @@ private const val SHUTDOWN_WAIT: Long = 10L
 }
 
 // Mounts JavaScript timer intrinsics.
-@Intrinsic @Factory internal class JsTimersIntrinsic : AbstractJsIntrinsic() {
-  @Inject private lateinit var execProvider: JsTimerExecutorProvider
+@Intrinsic @Factory internal class JsTimersIntrinsic @Inject constructor (
+  private val execProvider: JsTimerExecutorProvider,
+) : AbstractJsIntrinsic() {
   @Singleton fun provide(): Timers = manager
 
   private val manager: JsTimerManager by lazy {

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/intrinsics/BuildTimeIntrinsicsResolver.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/intrinsics/BuildTimeIntrinsicsResolver.kt
@@ -37,6 +37,7 @@ import elide.runtime.gvm.internals.intrinsics.js.url.URLSearchParamsIntrinsic
 import elide.runtime.gvm.internals.intrinsics.js.webstreams.ReadableStreamIntrinsic
 import elide.runtime.gvm.internals.intrinsics.js.webstreams.TransformStreamIntrinsic
 import elide.runtime.gvm.internals.intrinsics.js.webstreams.WritableStreamIntrinsic
+import elide.runtime.gvm.internals.js.JsTimerExecutorProviderImpl
 import elide.runtime.gvm.internals.js.JsTimersIntrinsic
 import elide.runtime.gvm.internals.sqlite.ElideSqliteModule
 import elide.runtime.gvm.internals.testing.ElideTestingModule
@@ -105,6 +106,7 @@ import elide.runtime.plugins.env.EnvConfig
     @CompilerDirectives.CompilationFinal @Volatile private lateinit var listener: VfsInitializerListener
     @CompilerDirectives.CompilationFinal @Volatile private lateinit var registrar: TestingRegistrar
     @JvmStatic private val execProvider = GuestExecutorProvider { exec }
+    @JvmStatic private val timerExecutor = JsTimerExecutorProviderImpl()
     @JvmStatic private val vfsListenerProvider = Provider { listener }
     @JvmStatic private val registrarProvider = Provider { registrar }
     @JvmStatic private val assert = NodeAssertModule()
@@ -121,7 +123,7 @@ import elide.runtime.plugins.env.EnvConfig
     @JvmStatic private val nodeStreams = NodeStreamModule()
     @JvmStatic private val streamsPromises = NodeStreamPromisesModule()
     @JvmStatic private val streamsConsumers = NodeStreamConsumersModule()
-    @JvmStatic private val timers = JsTimersIntrinsic()
+    @JvmStatic private val timers = JsTimersIntrinsic(timerExecutor)
     @JvmStatic private val buffer = NodeBufferModule()
     @JvmStatic private val querystring = NodeQuerystringModule()
     @JvmStatic private val http = NodeHttpModule()

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/intrinsics/BuildTimeIntrinsicsResolver.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/intrinsics/BuildTimeIntrinsicsResolver.kt
@@ -46,6 +46,7 @@ import elide.runtime.intrinsics.IntrinsicsResolver
 import elide.runtime.intrinsics.ai.ElideLLMModule
 import elide.runtime.intrinsics.js.err.ValueErrorIntrinsic
 import elide.runtime.intrinsics.testing.TestingRegistrar
+import elide.runtime.javascript.BrowserStubs
 import elide.runtime.javascript.MessageChannelBuiltin
 import elide.runtime.javascript.NavigatorBuiltin
 import elide.runtime.javascript.QueueMicrotaskCallable
@@ -163,6 +164,7 @@ import elide.runtime.plugins.env.EnvConfig
     @JvmStatic private val readableStream = ReadableStreamIntrinsic()
     @JvmStatic private val writableStream = WritableStreamIntrinsic()
     @JvmStatic private val transformStream = TransformStreamIntrinsic()
+    @JvmStatic private val browserStubs = BrowserStubs()
 
     // All built-ins and intrinsics.
     @JvmStatic private val all = arrayOf(
@@ -220,6 +222,7 @@ import elide.runtime.plugins.env.EnvConfig
       elideTesting,
       elideLlm,
       util,
+      browserStubs,
     )
   }
 

--- a/packages/graalvm/src/main/kotlin/elide/runtime/javascript/BrowserStubs.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/javascript/BrowserStubs.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.javascript
+
+import org.graalvm.polyglot.proxy.ProxyExecutable
+import jakarta.inject.Singleton
+import elide.runtime.gvm.internals.intrinsics.js.AbstractJsIntrinsic
+import elide.runtime.gvm.js.JsSymbol.JsSymbols.asPublicJsSymbol
+import elide.runtime.intrinsics.GuestIntrinsic
+
+// Name of the `alert` function in the global scope.
+private const val ALERT_NAME = "alert"
+
+/**
+ * ## Browser Stubs
+ *
+ * Adds support for various browser or browser-related JS methods; each method is stubbed to be a no-op or a method
+ * which prints its arguments.
+ */
+@Singleton
+public class BrowserStubs: AbstractJsIntrinsic() {
+  private companion object {
+    // Callable function which does nothing and returns nothing.
+    private val NO_OP_STUB = ProxyExecutable { /* */ }
+  }
+
+  override fun install(bindings: GuestIntrinsic.MutableIntrinsicBindings) {
+    bindings[ALERT_NAME.asPublicJsSymbol()] = NO_OP_STUB
+  }
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/plugins/js/JavaScript.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/plugins/js/JavaScript.kt
@@ -29,7 +29,6 @@ import elide.runtime.core.plugin
 import elide.runtime.lang.javascript.JavaScriptLang
 import elide.runtime.plugins.AbstractLanguagePlugin
 import elide.runtime.plugins.AbstractLanguagePlugin.LanguagePluginManifest
-import elide.runtime.plugins.defaultPolyglotContext
 import elide.runtime.plugins.env.Environment
 import elide.runtime.plugins.js.JavaScriptVersion.*
 
@@ -72,6 +71,7 @@ import elide.runtime.plugins.js.JavaScriptVersion.*
       "js.lazy-translation",
       "js.new-set-methods",
       "js.performance",
+      "js.print",
       "js.shared-array-buffer",
       "js.temporal",
       "js.top-level-await",
@@ -99,7 +99,6 @@ import elide.runtime.plugins.js.JavaScriptVersion.*
     disableOptions(
       "js.console",
       "js.interop-complete-promises",
-      "js.print",
       "js.regexp-static-result",
       "js.scripting",
       "js.syntax-extensions",

--- a/packages/graalvm/src/main/kotlin/elide/runtime/plugins/js/JavaScript.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/plugins/js/JavaScript.kt
@@ -73,7 +73,6 @@ import elide.runtime.plugins.js.JavaScriptVersion.*
       "js.new-set-methods",
       "js.performance",
       "js.shared-array-buffer",
-      "js.strict",
       "js.temporal",
       "js.top-level-await",
       "js.webassembly",
@@ -124,6 +123,7 @@ import elide.runtime.plugins.js.JavaScriptVersion.*
     )
 
     setOptions(
+      "js.strict" to config.strict,
       "js.commonjs-require" to config.npmConfig.enabled,
       "js.esm-bare-specifier-relative-lookup" to config.esm,
       "js.shell" to config.interactive,

--- a/packages/graalvm/src/main/kotlin/elide/runtime/plugins/js/JavaScriptConfig.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/plugins/js/JavaScriptConfig.kt
@@ -142,6 +142,9 @@ import elide.runtime.plugins.js.JavaScriptVersion.ES2022
   /** Whether to enable source-maps support, which enhances stack-traces, logs, and other system features. */
   public var sourceMaps: Boolean = true
 
+  /** Whether JS strict mode is active by default. */
+  public var strict: Boolean = true
+
   /**  Whether to enable V8 compatibility mode. */
   public var v8: Boolean = true
 


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds necessary support infra to be able to run [`js-benchmarks`](https://github.com/elide-dev/js-benchmarks) on Elide.

- [x] Fixes: elide-dev/elide#1667
- [x] Fixes: elide-dev/elide#1665