### PR TITLE
fix: crash on http server use

### DIFF
--- a/packages/cli/src/main/kotlin/elide/tool/cli/AbstractSubcommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/AbstractSubcommand.kt
@@ -508,6 +508,7 @@ fun AbstractTool.EmbeddedToolError.render(logging: Logger, ctx: AbstractSubcomma
   protected fun resolvePolyglotContext(
     langs: Set<GuestLanguage>,
     shared: Boolean = false,
+    detached: Boolean = true,
     cfg: (PolyglotContextBuilder.(VMEngine) -> Unit) = {},
   ): PolyglotContext {
     logging.debug("Resolving context for current thread")
@@ -520,7 +521,7 @@ fun AbstractTool.EmbeddedToolError.render(logging: Logger, ctx: AbstractSubcomma
 
     // not initialized yet, acquire a new one and store it
     logging.debug("No cached context found for current thread, acquiring new context")
-    return resolveEngine(langs).acquire(shared = shared, cfg).also { created ->
+    return resolveEngine(langs).acquire(shared = shared, detached, cfg).also { created ->
       contextHandle.set(created)
     }
   }
@@ -681,10 +682,11 @@ fun AbstractTool.EmbeddedToolError.render(logging: Logger, ctx: AbstractSubcomma
     langs: Set<GuestLanguage>,
     cfg: PolyglotContextBuilder.(VMEngine) -> Unit = {},
     shared: Boolean = true,
+    detached: Boolean = false,
     block: (() -> PolyglotContext) -> Unit,
   ) {
     block.invoke {
-      resolvePolyglotContext(langs, shared, cfg)
+      resolvePolyglotContext(langs, shared, detached, cfg)
     }
   }
 

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/dev/LspCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/dev/LspCommand.kt
@@ -373,6 +373,7 @@ internal class LspCommand : ProjectAwareSubcommand<ToolState, CommandContext>() 
     langs: Set<GuestLanguage>,
     cfg: PolyglotContextBuilder.(Engine) -> Unit,
     shared: Boolean,
+    detached: Boolean,
     block: (() -> PolyglotContext) -> Unit,
   ) {
     val engine = Engine.newBuilder().apply {

--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/repl/ToolShellCommand.kt
@@ -1695,7 +1695,7 @@ internal class ToolShellCommand : ProjectAwareSubcommand<ToolState, CommandConte
       logging.trace("Entered VM for server application (language: ${language.id}). Consuming script from: '$label'")
 
       // initialize the server intrinsic and run using the provided source
-      serverAgent.run(source, execProvider) { resolvePolyglotContext(langs) }
+      serverAgent.run(source, execProvider) { resolvePolyglotContext(langs, detached = false) }
       phaser.value.register()
       serverRunning.value = true
     } catch (exc: PolyglotException) {

--- a/packages/engine/api/engine.api
+++ b/packages/engine/api/engine.api
@@ -222,9 +222,9 @@ public final class elide/runtime/core/PolyglotContextKt {
 
 public abstract interface class elide/runtime/core/PolyglotEngine {
 	public fun acquire (Lkotlin/jvm/functions/Function2;)Lelide/runtime/core/PolyglotContext;
-	public abstract fun acquire (ZLkotlin/jvm/functions/Function2;)Lelide/runtime/core/PolyglotContext;
+	public abstract fun acquire (ZZLkotlin/jvm/functions/Function2;)Lelide/runtime/core/PolyglotContext;
 	public static synthetic fun acquire$default (Lelide/runtime/core/PolyglotEngine;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lelide/runtime/core/PolyglotContext;
-	public static synthetic fun acquire$default (Lelide/runtime/core/PolyglotEngine;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lelide/runtime/core/PolyglotContext;
+	public static synthetic fun acquire$default (Lelide/runtime/core/PolyglotEngine;ZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lelide/runtime/core/PolyglotContext;
 	public abstract fun unwrap ()Lorg/graalvm/polyglot/Engine;
 }
 

--- a/packages/engine/src/main/kotlin/elide/runtime/core/PolyglotEngine.kt
+++ b/packages/engine/src/main/kotlin/elide/runtime/core/PolyglotEngine.kt
@@ -31,9 +31,9 @@ public interface PolyglotEngine {
 
   /** Acquire a new [PolyglotContext]. The returned context has all plugins applied on creation. */
   public fun acquire(cfg: Context.Builder.(Engine) -> Unit = {}): PolyglotContext {
-    return acquire(shared = true, cfg = cfg)
+    return acquire(shared = true, detached = false, cfg = cfg)
   }
 
   /** Acquire a new [PolyglotContext]. The returned context has all plugins applied on creation. */
-  public fun acquire(shared: Boolean, cfg: Context.Builder.(Engine) -> Unit = {}): PolyglotContext
+  public fun acquire(shared: Boolean, detached: Boolean, cfg: Context.Builder.(Engine) -> Unit = {}): PolyglotContext
 }

--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -42,7 +42,7 @@ public final class elide/runtime/core/internals/graalvm/GraalVMContext : elide/r
 public final class elide/runtime/core/internals/graalvm/GraalVMEngine : elide/runtime/core/PolyglotEngine {
 	public static final field Companion Lelide/runtime/core/internals/graalvm/GraalVMEngine$Companion;
 	public synthetic fun <init> (Lelide/runtime/core/internals/MutableEngineLifecycle;Lelide/runtime/core/internals/graalvm/GraalVMConfiguration;Lorg/graalvm/polyglot/Engine;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun acquire (ZLkotlin/jvm/functions/Function2;)Lelide/runtime/core/PolyglotContext;
+	public fun acquire (ZZLkotlin/jvm/functions/Function2;)Lelide/runtime/core/PolyglotContext;
 	public static final fun create (Lelide/runtime/core/internals/graalvm/GraalVMConfiguration;Lelide/runtime/core/internals/MutableEngineLifecycle;)Lelide/runtime/core/internals/graalvm/GraalVMEngine;
 	public fun unwrap ()Lorg/graalvm/polyglot/Engine;
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMEngine.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/core/internals/graalvm/GraalVMEngine.kt
@@ -75,6 +75,7 @@ import elide.runtime.plugins.initializeDefaultContext
   /** Create a new [GraalVMContext], triggering lifecycle events to allow customization. */
   private fun createContext(
     shared: Boolean,
+    detached: Boolean,
     cfg: Builder.(Engine) -> Unit,
     finalizer: Builder.(Engine) -> Context = { build() },
   ): GraalVMContext {
@@ -88,7 +89,7 @@ import elide.runtime.plugins.initializeDefaultContext
 
     builder.allowEnvironmentAccess(config.hostAccess.toEnvAccess())
 
-    if (shared) {
+    if (!detached) {
       builder.engine(engine)
     }
 
@@ -150,8 +151,8 @@ import elide.runtime.plugins.initializeDefaultContext
     }
   }
 
-  override fun acquire(shared: Boolean, cfg: Builder.(Engine) -> Unit): PolyglotContext {
-    return createContext(shared, cfg)
+  override fun acquire(shared: Boolean, detached: Boolean, cfg: Builder.(Engine) -> Unit): PolyglotContext {
+    return createContext(shared, detached, cfg)
   }
 
   public companion object {

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/server/http/internal/PipelineRouter.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/server/http/internal/PipelineRouter.kt
@@ -122,21 +122,10 @@ import elide.vm.annotations.Polyglot
         if (pattern == null) return@matcher true
 
         // otherwise return true when the pattern matches the requested path
-        val urlStr = request.url.toString()
-        val (matchString, params) = if (urlStr.contains("?")) {
-          // strip query string from the request URI
-          urlStr.substringBefore("?") to urlStr.substringAfter("?")
-        } else {
-          request.url.toString() to null
-        }
-        val jsParams = params?.split("&")?.associate {
-          val (key, value) = it.split("=")
-          key to value
-        }
-        pattern.matchEntire(matchString)?.also { match ->
+        pattern.matchEntire(request.url.path)?.also { match ->
           val requestParams = JsProxy.build {
-            jsParams?.forEach { (key, value) ->
-              put(key, value)
+            request.url.params.keys.forEach { key ->
+              put(key, request.url.params[key])
             }
           }
 

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/server/http/netty/NettyHttpResponse.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/server/http/netty/NettyHttpResponse.kt
@@ -234,7 +234,9 @@ private val NETTY_HTTP_RESPONSE_PROPS_AND_METHODS = arrayOf(
 
   companion object {
     @JvmStatic fun from(res: Response, ctx: ChannelHandlerContext, includeDefaults: Boolean = true): NettyHttpResponse {
-      TODO("not yet implemented")
+      // temporary implementation; the response parameter can be safely ignored for now because it's always a new
+      // empty response, there is nothing that needs to be copied over to the new response
+      return NettyHttpResponse(ctx)
     }
   }
 }

--- a/packages/http/api/http.api
+++ b/packages/http/api/http.api
@@ -537,6 +537,7 @@ public abstract interface class elide/http/Params {
 	public abstract fun contains (Ljava/lang/String;)Z
 	public abstract fun get (Lelide/http/ParamName;)Lelide/http/ParamValue;
 	public abstract fun get (Ljava/lang/String;)Lelide/http/ParamValue;
+	public abstract fun getKeys ()Lkotlin/sequences/Sequence;
 	public abstract fun getSize-pVg5ArA ()I
 	public abstract fun getSizeDistinct-pVg5ArA ()I
 	public static fun parse (Ljava/lang/String;)Lelide/http/Params;
@@ -553,6 +554,7 @@ public final class elide/http/Params$Empty : elide/http/Params {
 	public fun equals (Ljava/lang/Object;)Z
 	public fun get (Lelide/http/ParamName;)Lelide/http/ParamValue;
 	public fun get (Ljava/lang/String;)Lelide/http/ParamValue;
+	public fun getKeys ()Lkotlin/sequences/Sequence;
 	public fun getSize-pVg5ArA ()I
 	public fun getSizeDistinct-pVg5ArA ()I
 	public fun hashCode ()I

--- a/packages/http/src/commonMain/kotlin/elide/http/DefaultUrlParams.kt
+++ b/packages/http/src/commonMain/kotlin/elide/http/DefaultUrlParams.kt
@@ -20,6 +20,7 @@ internal expect fun String.decodeUrlSegment(): String
 @JvmRecord internal data class DefaultUrlParams (private val pairs: Sequence<Pair<String, String>>): Params {
   override val size: UInt get() = pairs.count().toUInt()
   override val sizeDistinct: UInt get() = pairs.groupBy { it.first }.count().toUInt()
+  override val keys: Sequence<String> get() = pairs.map { it.first }
   override fun contains(key: ParamName): Boolean = pairs.firstOrNull { it.first == key.name } != null
   override fun contains(key: String): Boolean = pairs.firstOrNull { it.first == key } != null
   override fun get(key: ParamName): ParamValue? = ParamValue.ofNullable(

--- a/packages/http/src/commonMain/kotlin/elide/http/Params.kt
+++ b/packages/http/src/commonMain/kotlin/elide/http/Params.kt
@@ -31,6 +31,9 @@ public sealed interface Params {
   /** Count of parameters within this URL params container, ignoring duplicated keys. */
   public val sizeDistinct: UInt
 
+  /** A sequence of all the parameter keys in this map. */
+  public val keys: Sequence<String>
+
   /**
    * Indicate whether these parameters contain the provided [key].
    *
@@ -66,6 +69,7 @@ public sealed interface Params {
   /** Represents an empty suite of URL params. */
   public data object Empty : Params {
     override fun toString(): String = "Params.Empty"
+    override val keys: Sequence<String> = emptySequence()
     override val size: UInt get() = 0u
     override val sizeDistinct: UInt get() = 0u
     override fun contains(key: ParamName): Boolean = false


### PR DESCRIPTION
![Draft](https://badgen.net/badge/Status/Draft/gray) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

This PR fixes #1670 and restores minimal functionality to Elide's HTTP server intrinsics:

- New GraalVM `Context` instances are now correctly attached to an `Engine`. This behavior is disabled by default when acquiring a new context from a CLI command using `resolvePolyglotContext()`, to avoid breaking existing code; it can be enabled by passing `detached = false`.
- The `NettyHttpResponse.from(...)` builder function now returns a new empty mutable response; it was previously unimplemented.

In general, the `serve` command should now work again, though some features are still unimplemented (coming soon). 

> [!IMPORTANT]
> The old `express` intrinsics are no longer available, `Elide.http` should be used instead. Support for express-like APIs and a drop-in express.js replacement may be added in the near future.