### PR TITLE
fix: add reflection metadata for netty transport channels

### DIFF
--- a/packages/transport/transport-epoll/src/main/resources/META-INF/native-image/dev/elide/transport-epoll/reflect-config.json
+++ b/packages/transport/transport-epoll/src/main/resources/META-INF/native-image/dev/elide/transport-epoll/reflect-config.json
@@ -1,0 +1,14 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.ReflectiveChannelFactory"
+    },
+    "name": "io.netty.channel.epoll.EpollServerSocketChannel",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/packages/transport/transport-kqueue/src/main/resources/META-INF/native-image/dev/elide/transport-kqueue/reflect-config.json
+++ b/packages/transport/transport-kqueue/src/main/resources/META-INF/native-image/dev/elide/transport-kqueue/reflect-config.json
@@ -1,0 +1,14 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.ReflectiveChannelFactory"
+    },
+    "name": "io.netty.channel.kqueue.KQueueServerSocketChannel",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/packages/transport/transport-uring/src/main/resources/META-INF/native-image/dev/elide/transport-uring/reflect-config.json
+++ b/packages/transport/transport-uring/src/main/resources/META-INF/native-image/dev/elide/transport-uring/reflect-config.json
@@ -1,0 +1,14 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.ReflectiveChannelFactory"
+    },
+    "name": "io.netty.incubator.channel.uring.IOUringServerSocketChannel",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]


### PR DESCRIPTION
![Draft](https://badgen.net/badge/Status/Draft/gray) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Fixes #1719, where metadata for Netty's `KQueueServerSocketChannel` seems to be missing when running `elide serve`. Also added reflection configs for `IOUringServerSocketChannel` and `EpollServerSocketChannel`.