### PR TITLE
fix: `linux-aarch64` in ci

### DIFF
--- a/.github/workflows/job.build.yml
+++ b/.github/workflows/job.build.yml
@@ -247,7 +247,7 @@ jobs:
         with:
           version: "10.6.2"
       - name: "Setup: Elide"
-        uses: elide-dev/setup-elide@990b915b2974a70e7654acb1303607b4cd1d3538 # v2
+        uses: elide-dev/setup-elide@cc5ca312ef6df23b07967bba9308bfa77dfec6f8
         with:
           version: "1.0.0-beta10"
       - name: "Setup: uv"

--- a/.github/workflows/job.native-image.yml
+++ b/.github/workflows/job.native-image.yml
@@ -249,6 +249,10 @@ jobs:
           distribution: "graalvm"
           java-version: "25"
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Setup: Elide"
+        uses: elide-dev/setup-elide@cc5ca312ef6df23b07967bba9308bfa77dfec6f8
+        with:
+          version: "1.0.0-beta10"
       - name: "Setup: PNPM"
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Fixes CI installation of Elide for `linux-aarch64` with an update to the GHA setup action.