### PR TITLE
feat(secrets): allow changing remote superuser credentials

### DIFF
--- a/packages/cli/src/main/kotlin/elide/tool/cli/cmd/secrets/ToolSecretsCommand.kt
+++ b/packages/cli/src/main/kotlin/elide/tool/cli/cmd/secrets/ToolSecretsCommand.kt
@@ -245,6 +245,7 @@ internal class ToolSecretsCommand : ProjectAwareSubcommand<ToolState, CommandCon
         ManageRemoteOptions.CREATE -> createAccess(remote)
         ManageRemoteOptions.LIST -> println(remote.listAccesses())
         ManageRemoteOptions.SELECT -> selectAccess(remote)
+        ManageRemoteOptions.CHANGE -> remote.changeSuperEncryption()
         ManageRemoteOptions.REMOVE -> removeAccess(remote)
         ManageRemoteOptions.REKEY -> rekeyProfiles(remote)
         ManageRemoteOptions.DELETE -> deleteProfile(remote)
@@ -379,6 +380,7 @@ internal class ToolSecretsCommand : ProjectAwareSubcommand<ToolState, CommandCon
     CREATE("Create an access file"),
     LIST("List access files"),
     SELECT("Select an access file"),
+    CHANGE("Change superuser encryption details"),
     REMOVE("Remove an access file"),
     REKEY("Regenerate profile keys"),
     DELETE("Delete a profile"),

--- a/packages/secrets/api/secrets.api
+++ b/packages/secrets/api/secrets.api
@@ -1,6 +1,7 @@
 public abstract interface class elide/secrets/RemoteManagement {
 	public abstract fun addProfile (Ljava/lang/String;)V
 	public abstract fun changeEncryption ()V
+	public abstract fun changeSuperEncryption ()V
 	public abstract fun createAccess (Ljava/lang/String;)V
 	public abstract fun deleteAccess (Ljava/lang/String;)V
 	public abstract fun deleteProfile (Ljava/lang/String;)V

--- a/packages/secrets/src/main/kotlin/elide/secrets/RemoteManagement.kt
+++ b/packages/secrets/src/main/kotlin/elide/secrets/RemoteManagement.kt
@@ -48,6 +48,9 @@ public interface RemoteManagement {
   /** Deselects the selected access file. */
   public fun deselectAccess()
 
+  /** Prompts user on a new encryption mode for superuser access. */
+  public fun changeSuperEncryption()
+
   /** Generates new keys for specified profiles. */
   public fun rekeyProfile(profile: String)
 

--- a/packages/secrets/src/main/kotlin/elide/secrets/SecretValues.kt
+++ b/packages/secrets/src/main/kotlin/elide/secrets/SecretValues.kt
@@ -87,6 +87,7 @@ internal object SecretValues {
   const val DELETE_PROFILES_MESSAGE = "Deleting the profile will also delete it from your local secrets!"
   const val GPG_KEY_REVOKED_MISSING_MESSAGE =
     "GPG private key is expired, revoked or not present. If secrets load correctly, please update your encryption mode!"
+  const val INVALID_SUPER_CREDENTIALS_MESSAGE = "Invalid superuser credentials."
 
   fun accessesWithProfileMessage(accesses: String) =
     "The following access files contain the profile:\n$accesses\n" +

--- a/packages/secrets/src/test/kotlin/elide/secrets/ManagementTest.kt
+++ b/packages/secrets/src/test/kotlin/elide/secrets/ManagementTest.kt
@@ -254,6 +254,11 @@ class ManagementTest : AbstractSecretTest() {
     // regenerate profile key
     remote.rekeyProfile("test")
 
+    // change superuser access passphrase
+    // remote.changeSuperEncryption() asks for encryption mode and passphrase twice.
+    queuePrompts(EncryptionMode.PASSPHRASE, "seus", "seus")
+    remote.changeSuperEncryption()
+
     // push changes and check for files
     remote.push()
     assertTrue(path.resolve(SecretValues.PROJECT_REMOTE_DEFAULT_PATH).resolve(SecretValues.METADATA_FILE).exists())


### PR DESCRIPTION
![Ready for review](https://badgen.net/badge/Status/Ready%20for%20review/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

The superuser credentials for managing all remote secret access files could not be changed. Now they can.