### PR TITLE
fix: jar resources packaged incorrectly

### DIFF
--- a/packages/tooling/api/tooling.api
+++ b/packages/tooling/api/tooling.api
@@ -4106,24 +4106,24 @@ public final class elide/tooling/project/manifest/ElidePackageManifest$GradleCat
 public final class elide/tooling/project/manifest/ElidePackageManifest$Jar : elide/tooling/project/manifest/ElidePackageManifest$Artifact {
 	public static final field Companion Lelide/tooling/project/manifest/ElidePackageManifest$Jar$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$JarOptions;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$JarOptions;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$JarOptions;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$JarOptions;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/Map;
 	public final fun component4 ()Ljava/util/Map;
 	public final fun component5 ()Lelide/tooling/project/manifest/ElidePackageManifest$JarOptions;
 	public final fun component6 ()Ljava/util/List;
 	public final fun component7 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$JarOptions;Ljava/util/List;Ljava/util/List;)Lelide/tooling/project/manifest/ElidePackageManifest$Jar;
-	public static synthetic fun copy$default (Lelide/tooling/project/manifest/ElidePackageManifest$Jar;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$JarOptions;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lelide/tooling/project/manifest/ElidePackageManifest$Jar;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$JarOptions;Ljava/util/List;Ljava/util/List;)Lelide/tooling/project/manifest/ElidePackageManifest$Jar;
+	public static synthetic fun copy$default (Lelide/tooling/project/manifest/ElidePackageManifest$Jar;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lelide/tooling/project/manifest/ElidePackageManifest$JarOptions;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lelide/tooling/project/manifest/ElidePackageManifest$Jar;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getDependsOn ()Ljava/util/List;
 	public fun getFrom ()Ljava/util/List;
 	public final fun getManifest ()Ljava/util/Map;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOptions ()Lelide/tooling/project/manifest/ElidePackageManifest$JarOptions;
-	public final fun getResources ()Ljava/util/List;
+	public final fun getResources ()Ljava/util/Map;
 	public final fun getSources ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -4177,14 +4177,12 @@ public final class elide/tooling/project/manifest/ElidePackageManifest$JarOption
 
 public final class elide/tooling/project/manifest/ElidePackageManifest$JarResource {
 	public static final field Companion Lelide/tooling/project/manifest/ElidePackageManifest$JarResource$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lelide/tooling/project/manifest/ElidePackageManifest$JarResource;
-	public static synthetic fun copy$default (Lelide/tooling/project/manifest/ElidePackageManifest$JarResource;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lelide/tooling/project/manifest/ElidePackageManifest$JarResource;
+	public final fun copy (Ljava/lang/String;)Lelide/tooling/project/manifest/ElidePackageManifest$JarResource;
+	public static synthetic fun copy$default (Lelide/tooling/project/manifest/ElidePackageManifest$JarResource;Ljava/lang/String;ILjava/lang/Object;)Lelide/tooling/project/manifest/ElidePackageManifest$JarResource;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPath ()Ljava/lang/String;
-	public final fun getPosition ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/packages/tooling/src/main/kotlin/elide/tooling/project/codecs/ElidePackageManifestCodec.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/project/codecs/ElidePackageManifestCodec.kt
@@ -219,6 +219,11 @@ public class ElidePackageManifestCodec : PackageManifestCodec<ElidePackageManife
           )
         })
       ).addConversion(
+        // convert string jar resource target path
+        Conversion.of(PClassInfo.String, JarResource::class.java, StrConverter {
+          JarResource(path = it)
+        })
+      ).addConversion(
         // convert flag defaults as booleans
         Conversion.of(PClassInfo.Boolean, ProjectFlagValue::class.java,
                       Converter<Boolean, ProjectFlagValue> { value, mapper ->

--- a/packages/tooling/src/main/kotlin/elide/tooling/project/manifest/ElidePackageManifest.kt
+++ b/packages/tooling/src/main/kotlin/elide/tooling/project/manifest/ElidePackageManifest.kt
@@ -83,7 +83,6 @@ public data class ElidePackageManifest(
 
   @Serializable public data class JarResource(
     val path: String,
-    val position: String,
   )
 
   @Serializable public data class ProjectSourceSpec(
@@ -139,7 +138,7 @@ public data class ElidePackageManifest(
   @Serializable public data class Jar(
     val name: String? = null,
     val sources: List<String> = emptyList(),
-    val resources: List<JarResource> = emptyList(),
+    val resources: Map<String, JarResource> = emptyMap(),
     val manifest: Map<String, String> = emptyMap(),
     val options: JarOptions = JarOptions(),
     override val from: List<String> = emptyList(),

--- a/packages/tooling/src/main/pkl/Jvm.pkl
+++ b/packages/tooling/src/main/pkl/Jvm.pkl
@@ -85,7 +85,7 @@ open class Jar extends artifacts.Artifact {
   }
 
   /// Which resources to add to the JAR.
-  resources: Listing<common.FilePath | JarResource> = new {}
+  resources: Mapping<common.FilePath, common.FilePath | JarResource> = new {}
 
   /// Keys and values to include in the JAR's manifest.
   manifest: Mapping<JarManifestKey, JarManifestValue> = new {}


### PR DESCRIPTION
![Ready for review](https://img.shields.io/badge/Status-Ready_for_review-green?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Converts the JAR `resources { ... }` block into a mapping of resource paths to their paths relative to the root project.

- [x] Fixes: elide-dev/elide#1725