### PR TITLE
fix(deps): pin llama-cpp-2 to =0.1.102 to fix CI build failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4093,9 +4093,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.127"
+version = "0.1.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd787c2dbc148c521ad5b326672e5e4e7186d658f8949b6e045ad53acbffedd9"
+checksum = "a419bb48efa0f8389a82301f1f64e2874568a3fbf6f62f8ddab5324382b82768"
 dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ umbrella = { path = "tools/umbrella" }
 ## Dependencies
 lazy_static = { version = "1.5.0" }
 anyhow = { version = "1.0.97" }
-llama-cpp-2 = { version = "0.1.102", default-features = false }
+llama-cpp-2 = { version = "=0.1.102", default-features = false }
 bindgen = { version = "0.72.0" }
 build_const = { version = "0.2.2", default-features = false }
 bytemuck = { version = "1.23.1" }


### PR DESCRIPTION
![Ready for review](https://img.shields.io/badge/Status-Ready_for_review-green?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Pins `llama-cpp-2` crate to exact version `0.1.102` to fix CI build failures on all PRs.

## Problem

After the recent `cargo update` (commit b774aa9), `llama-cpp-2` was upgraded from `0.1.102` to `0.1.127`. Version `0.1.126+` introduced a breaking API change where the `c_char` type changed from `*const i8` to `*const u8`, causing type mismatch errors:

```
error[E0308]: mismatched types
  --> llama-cpp-2-0.1.126/src/lib.rs:416:35
    |
416 |         let name = cstr_to_string(props.name);
    |                    -------------- ^^^^^^^^^^ expected `*const i8`, found `*const u8`
```

This affects all PRs during the `:packages:graalvm:buildRustNativesForHost` task in the `local-ai` package.

## Solution

Pin the version exactly using `=0.1.102` in `Cargo.toml` to prevent cargo from resolving to incompatible newer versions.

## Changes

- `Cargo.toml`: Changed `version = "0.1.102"` to `version = "=0.1.102"`
- `Cargo.lock`: Downgraded from `0.1.127` to `0.1.102`

## Fixes

Fixes #1796