### PR TITLE
fix(sqlite): Statement.run() and Database.exec() now return Changes object

### DIFF
--- a/packages/graalvm/api/graalvm.api
+++ b/packages/graalvm/api/graalvm.api
@@ -7773,6 +7773,12 @@ public synthetic class elide/runtime/intrinsics/sqlite/$SQLiteAPI$ReflectConfig 
 	public fun getAnnotationMetadata ()Lio/micronaut/core/annotation/AnnotationMetadata;
 }
 
+public synthetic class elide/runtime/intrinsics/sqlite/$SQLiteChanges$ReflectConfig : io/micronaut/core/graal/GraalReflectionConfigurer {
+	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
+	public fun <init> ()V
+	public fun getAnnotationMetadata ()Lio/micronaut/core/annotation/AnnotationMetadata;
+}
+
 public synthetic class elide/runtime/intrinsics/sqlite/$SQLiteDatabase$Defaults$ReflectConfig : io/micronaut/core/graal/GraalReflectionConfigurer {
 	public static final field $ANNOTATION_METADATA Lio/micronaut/core/annotation/AnnotationMetadata;
 	public fun <init> ()V
@@ -7836,6 +7842,11 @@ public synthetic class elide/runtime/intrinsics/sqlite/$SQLiteTransactor$Reflect
 public abstract interface class elide/runtime/intrinsics/sqlite/SQLiteAPI : org/graalvm/polyglot/proxy/ProxyObject {
 }
 
+public abstract interface class elide/runtime/intrinsics/sqlite/SQLiteChanges {
+	public abstract fun getChanges ()J
+	public abstract fun getLastInsertRowid ()J
+}
+
 public abstract interface class elide/runtime/intrinsics/sqlite/SQLiteDatabase : elide/runtime/interop/ReadOnlyProxyObject, elide/runtime/intrinsics/js/Disposable, java/io/Closeable, java/lang/AutoCloseable {
 	public static final field DEFAULT_CREATE Z
 	public static final field DEFAULT_READONLY Z
@@ -7847,8 +7858,8 @@ public abstract interface class elide/runtime/intrinsics/sqlite/SQLiteDatabase :
 	public abstract fun connection ()Lorg/sqlite/SQLiteConnection;
 	public abstract fun deserialize ([BLjava/lang/String;)V
 	public static synthetic fun deserialize$default (Lelide/runtime/intrinsics/sqlite/SQLiteDatabase;[BLjava/lang/String;ILjava/lang/Object;)V
-	public abstract fun exec (Lelide/runtime/intrinsics/sqlite/SQLiteStatement;[Ljava/lang/Object;)Lcom/oracle/truffle/js/runtime/objects/JSDynamicObject;
-	public abstract fun exec (Ljava/lang/String;[Ljava/lang/Object;)Lcom/oracle/truffle/js/runtime/objects/JSDynamicObject;
+	public abstract fun exec (Lelide/runtime/intrinsics/sqlite/SQLiteStatement;[Ljava/lang/Object;)Lelide/runtime/intrinsics/sqlite/SQLiteChanges;
+	public abstract fun exec (Ljava/lang/String;[Ljava/lang/Object;)Lelide/runtime/intrinsics/sqlite/SQLiteChanges;
 	public abstract fun getActive ()Z
 	public synthetic fun getMemberKeys ()Ljava/lang/Object;
 	public fun getMemberKeys ()[Ljava/lang/String;
@@ -7902,7 +7913,7 @@ public abstract interface class elide/runtime/intrinsics/sqlite/SQLiteStatement 
 	public abstract fun get ([Ljava/lang/Object;)Lelide/runtime/intrinsics/sqlite/SQLiteObject;
 	public abstract fun prepare ([Ljava/lang/Object;)Ljava/sql/PreparedStatement;
 	public static synthetic fun prepare$default (Lelide/runtime/intrinsics/sqlite/SQLiteStatement;[Ljava/lang/Object;ILjava/lang/Object;)Ljava/sql/PreparedStatement;
-	public abstract fun run ([Ljava/lang/Object;)V
+	public abstract fun run ([Ljava/lang/Object;)Lelide/runtime/intrinsics/sqlite/SQLiteChanges;
 	public abstract fun unwrap ()Ljava/sql/Statement;
 	public abstract fun values ([Ljava/lang/Object;)Ljava/util/List;
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/sqlite/SQLiteChanges.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/sqlite/SQLiteChanges.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.intrinsics.sqlite
+
+import io.micronaut.core.annotation.ReflectiveAccess
+import elide.annotations.API
+import elide.vm.annotations.Polyglot
+
+/**
+ * # SQLite Changes
+ *
+ * Represents the result of a write operation (INSERT, UPDATE, DELETE) on a SQLite database.
+ * This matches the Bun SQLite API's `Changes` interface.
+ *
+ * @see SQLiteStatement.run
+ * @see SQLiteDatabase.exec
+ */
+@API @ReflectiveAccess public interface SQLiteChanges {
+  /**
+   * The number of rows changed by the last `run` or `exec` call.
+   */
+  @get:Polyglot public val changes: Long
+
+  /**
+   * The rowid of the last inserted row, or 0 if no row was inserted.
+   * If `safeIntegers` is enabled, this should be treated as a bigint.
+   */
+  @get:Polyglot public val lastInsertRowid: Long
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/sqlite/SQLiteDatabase.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/sqlite/SQLiteDatabase.kt
@@ -196,12 +196,11 @@ private val SQLITE_DATABASE_PROPS_AND_METHODS = arrayOf(
    * Parse, prepare, and then execute an SQL query [statement] with the provided [args] (if any), against the current
    * SQLite database.
    *
-   * This method does not return a value.
-   *
    * @param statement SQL query to execute.
    * @param args Arguments to bind to the statement.
+   * @return Changes object containing the number of affected rows and last insert rowid.
    */
-  @Polyglot public fun exec(@Language("sql") statement: String, vararg args: Any?): JSDynamicObject
+  @Polyglot public fun exec(@Language("sql") statement: String, vararg args: Any?): SQLiteChanges
 
   /**
    * ## Execute (Statement)
@@ -209,12 +208,11 @@ private val SQLITE_DATABASE_PROPS_AND_METHODS = arrayOf(
    * Execute the provided [statement], preparing it if necessary, with the provided [args] (if any), against the current
    * SQLite database.
    *
-   * This method does not return a value.
-   *
    * @param statement Prepared statement to execute.
    * @param args Arguments to bind to the statement.
+   * @return Changes object containing the number of affected rows and last insert rowid.
    */
-  @Polyglot public fun exec(statement: SQLiteStatement, vararg args: Any?): JSDynamicObject
+  @Polyglot public fun exec(statement: SQLiteStatement, vararg args: Any?): SQLiteChanges
 
   /**
    * ## Execute Transaction

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/sqlite/SQLiteStatement.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/sqlite/SQLiteStatement.kt
@@ -119,8 +119,11 @@ import elide.vm.annotations.Polyglot
    *
    * Repeated calls to this method with unchanging [args] will cache the underlying rendered query, but will not cache
    * execution of the query (in other words, the query is executed each time [run] is called).
+   *
+   * @param args Arguments to render into the query.
+   * @return Changes object containing the number of affected rows and last insert rowid.
    */
-  @Polyglot public fun run(vararg args: Any?)
+  @Polyglot public fun run(vararg args: Any?): SQLiteChanges
 
   /**
    * ## Finalize Statement


### PR DESCRIPTION
![Ready for review](https://img.shields.io/badge/Status-Ready_for_review-green?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Updates `Statement.run()` and `Database.exec()` to return a `Changes` object instead of `undefined`, matching the Bun SQLite API.

## Problem

Per the TypeScript types and Bun compatibility, `run()` and `exec()` should return a `Changes` object:

```typescript
interface Changes {
  changes: number;        // rows affected
  lastInsertRowid: number | bigint;
}
```

Previously:
- `Statement.run()` returned `Unit` (undefined in JS)
- `Database.exec()` returned `Undefined.instance`

## Solution

1. **New `SQLiteChanges` interface** - Defines the contract matching Bun's `Changes`
2. **`SQLiteChangesImpl`** - Internal implementation as a `ProxyObject` for JS interop
3. **Updated `exec()`** - Now captures update count and last insert rowid from JDBC
4. **Updated `run()`** - Returns the result from `exec()`

## Changes

| File | Change |
|------|--------|
| `SQLiteChanges.kt` | New interface |
| `SQLiteStatement.kt` | `run()` returns `SQLiteChanges` |
| `SQLiteDatabase.kt` | `exec()` returns `SQLiteChanges` |
| `SqliteModule.kt` | Implementation |

## Usage

```typescript
const db = new Database(":memory:");
db.run("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)");

const result = db.run("INSERT INTO users (name) VALUES (?)", ["Alice"]);
console.log(result.changes);        // 1
console.log(result.lastInsertRowid); // 1
```

## Fixes

Fixes #1791