### PR TITLE
feat(url): implement URL.searchParams property

### DIFF
--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/url/URLIntrinsic.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/url/URLIntrinsic.kt
@@ -360,7 +360,12 @@ private const val GLOBAL_URL = "URL"
       // Calculate a spec-compliant value for the `searchParams` property.
       @Suppress("UNUSED_PARAMETER")
       @JvmStatic private fun computeSearchParams(uri: NativeURL, proto: KnownProtocol?) = cachedParse<URLSearchParams> {
-        TODO("not yet implemented")
+        val query = uri.query
+        if (query.isNullOrBlank()) {
+          URLSearchParamsIntrinsic.URLSearchParams()
+        } else {
+          URLSearchParamsIntrinsic.URLSearchParams(query)
+        }
       }
 
       // Calculate a spec-compliant value for the `host` property.


### PR DESCRIPTION
![Ready for review](https://img.shields.io/badge/Status-Ready_for_review-green?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Implements the `searchParams` property on URL objects by parsing the query string into a `URLSearchParams` instance.

Previously, accessing `url.searchParams` threw `NotImplementedError`. Now it returns a properly populated `URLSearchParams` object.

## Example

```typescript
const url = new URL('http://example.com?foo=bar&baz=qux');
url.searchParams.get('foo');  // 'bar'
url.searchParams.has('baz');  // true

for (const [key, value] of url.searchParams) {
  console.log(`${key} = ${value}`);
}
```

## Why This Matters

Server-side code using the fetch handler pattern needs to parse query parameters from incoming requests:

```typescript
export default {
  async fetch(request: Request): Promise<Response> {
    const url = new URL(request.url);
    const text = url.searchParams.get('text');  // ❌ Was throwing NotImplementedError
    // ...
  }
}
```

Without `searchParams.get()`, developers must manually parse the query string, which is error-prone and inconsistent with the URL spec.

## Changes

- `URLIntrinsic.kt`: Implement `computeSearchParams()` to parse query string into `URLSearchParams`

## Testing

Tested locally with Elide beta11-rc3:
```typescript
const url = new URL("http://localhost:8080/analyze?text=hello&foo=bar");
console.log(url.searchParams.get('text'));  // Now works!
```

cc @darvld - this is a simple 6-line fix for a TODO that was blocking server-side URL parsing.