### PR TITLE
feat(fetch): add Body mixin interface for Request

### DIFF
--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchRequestIntrinsic.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchRequestIntrinsic.kt
@@ -301,8 +301,7 @@ internal class FetchRequestIntrinsic internal constructor(
   /**
    * Read the body as FormData.
    *
-   * Supports application/x-www-form-urlencoded content type.
-   * Multipart/form-data is not yet supported.
+   * Supports both application/x-www-form-urlencoded and multipart/form-data content types.
    *
    * @return A promise that resolves with FormData.
    */
@@ -316,30 +315,43 @@ internal class FetchRequestIntrinsic internal constructor(
 
     val contentType = headers.get("content-type") ?: ""
 
-    text().then(
-      onFulfilled = { bodyText ->
-        try {
-          when {
-            contentType.contains("application/x-www-form-urlencoded") -> {
-              promise.resolve(FormData.parseUrlEncoded(bodyText))
+    when {
+      contentType.contains("multipart/form-data") -> {
+        // Multipart needs raw bytes
+        arrayBuffer().then(
+          onFulfilled = { buffer ->
+            try {
+              val byteBuffer = buffer as ByteBuffer
+              val bytes = ByteArray(byteBuffer.remaining())
+              byteBuffer.get(bytes)
+              val boundary = FormData.extractBoundary(contentType)
+                ?: throw IllegalArgumentException("Missing boundary in Content-Type")
+              promise.resolve(FormData.parseMultipart(bytes, boundary))
+            } catch (e: Exception) {
+              promise.reject(JsError.typeError("Failed to parse multipart form data: ${e.message}"))
             }
-            contentType.contains("multipart/form-data") -> {
-              // Multipart parsing not yet implemented
-              promise.reject(NotImplementedError("multipart/form-data parsing not yet implemented"))
-            }
-            else -> {
-              // Try URL-encoded as fallback
-              promise.resolve(FormData.parseUrlEncoded(bodyText))
-            }
+          },
+          onCatch = { error ->
+            promise.reject(error as? Throwable ?: RuntimeException(error.toString()))
           }
-        } catch (e: Exception) {
-          promise.reject(JsError.typeError("Failed to parse form data: ${e.message}"))
-        }
-      },
-      onCatch = { error ->
-        promise.reject(error as? Throwable ?: RuntimeException(error.toString()))
+        )
       }
-    )
+      else -> {
+        // URL-encoded or fallback
+        text().then(
+          onFulfilled = { bodyText ->
+            try {
+              promise.resolve(FormData.parseUrlEncoded(bodyText))
+            } catch (e: Exception) {
+              promise.reject(JsError.typeError("Failed to parse form data: ${e.message}"))
+            }
+          },
+          onCatch = { error ->
+            promise.reject(error as? Throwable ?: RuntimeException(error.toString()))
+          }
+        )
+      }
+    }
     return promise
   }
 

--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchRequestIntrinsic.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchRequestIntrinsic.kt
@@ -31,6 +31,7 @@ import elide.runtime.gvm.internals.intrinsics.js.url.URLIntrinsic
 import elide.runtime.gvm.js.JsError
 import elide.runtime.interop.ReadOnlyProxyObject
 import elide.runtime.intrinsics.js.*
+import elide.runtime.gvm.internals.intrinsics.js.JsPromiseImpl
 import elide.vm.annotations.Polyglot
 
 /** Implements an intrinsic for the Fetch API `Request` object. */
@@ -83,6 +84,12 @@ internal class FetchRequestIntrinsic internal constructor(
     private const val MEMBER_REFERRER = "referrer"
     private const val MEMBER_REFERRER_POLICY = "referrerPolicy"
     private const val MEMBER_MEMBER_URL = "url"
+    // Body mixin methods
+    private const val MEMBER_ARRAY_BUFFER = "arrayBuffer"
+    private const val MEMBER_BLOB = "blob"
+    private const val MEMBER_FORM_DATA = "formData"
+    private const val MEMBER_JSON = "json"
+    private const val MEMBER_TEXT = "text"
 
     private val MemberKeys = arrayOf(
       MEMBER_BODY,
@@ -99,6 +106,12 @@ internal class FetchRequestIntrinsic internal constructor(
       MEMBER_REFERRER,
       MEMBER_REFERRER_POLICY,
       MEMBER_MEMBER_URL,
+      // Body mixin methods
+      MEMBER_ARRAY_BUFFER,
+      MEMBER_BLOB,
+      MEMBER_FORM_DATA,
+      MEMBER_JSON,
+      MEMBER_TEXT,
     )
 
     @JvmStatic override fun forRequest(request: HttpRequest<*>): FetchMutableRequest {
@@ -197,6 +210,99 @@ internal class FetchRequestIntrinsic internal constructor(
       return bodyData
     }
 
+  // -- Interface: Body Mixin -- //
+
+  /**
+   * Read the body as an ArrayBuffer.
+   *
+   * @return A promise that resolves with an ArrayBuffer.
+   */
+  @Polyglot override fun arrayBuffer(): JsPromise<Any> {
+    val promise = JsPromiseImpl<Any>()
+    try {
+      val stream = body
+      if (stream == null) {
+        promise.resolve(ByteArray(0))
+      } else {
+        // TODO(@darvld): Implement proper ArrayBuffer conversion from ReadableStream
+        // For now, read all bytes and return as byte array
+        throw NotImplementedError("arrayBuffer() not yet implemented - need ArrayBuffer intrinsic")
+      }
+    } catch (e: Exception) {
+      promise.reject(e)
+    }
+    return promise
+  }
+
+  /**
+   * Read the body as a Blob.
+   *
+   * @return A promise that resolves with a Blob.
+   */
+  @Polyglot override fun blob(): JsPromise<Blob> {
+    val promise = JsPromiseImpl<Blob>()
+    // TODO(@darvld): Implement Blob conversion from ReadableStream
+    promise.reject(NotImplementedError("blob() not yet implemented"))
+    return promise
+  }
+
+  /**
+   * Read the body as FormData.
+   *
+   * @return A promise that resolves with FormData.
+   */
+  @Polyglot override fun formData(): JsPromise<Any> {
+    val promise = JsPromiseImpl<Any>()
+    // TODO(@darvld): Implement FormData parsing from body
+    promise.reject(NotImplementedError("formData() not yet implemented"))
+    return promise
+  }
+
+  /**
+   * Read the body as JSON.
+   *
+   * @return A promise that resolves with the parsed JSON value.
+   */
+  @Polyglot override fun json(): JsPromise<Any> {
+    val promise = JsPromiseImpl<Any>()
+    try {
+      val stream = body
+      if (stream == null) {
+        promise.reject(JsError.typeError("Cannot read body: no body present"))
+      } else {
+        // TODO(@darvld): Need to integrate with JSON.parse intrinsic
+        // For now, read text and parse manually
+        // This is a placeholder - actual implementation needs GraalJS JSON.parse
+        throw NotImplementedError("json() not yet implemented - need JSON.parse integration")
+      }
+    } catch (e: Exception) {
+      promise.reject(e)
+    }
+    return promise
+  }
+
+  /**
+   * Read the body as text.
+   *
+   * @return A promise that resolves with the body text.
+   */
+  @Polyglot override fun text(): JsPromise<String> {
+    val promise = JsPromiseImpl<String>()
+    try {
+      val stream = body
+      if (stream == null) {
+        promise.resolve("")
+      } else {
+        // TODO(@darvld): Implement proper text reading from ReadableStream
+        // Need to consume the stream and decode as UTF-8
+        throw NotImplementedError("text() not yet implemented - need stream consumption")
+      }
+    } catch (e: Exception) {
+      promise.reject(e)
+    }
+    return promise
+  }
+
   override fun toString(): String {
     return "$method $url"
   }
@@ -218,6 +324,12 @@ internal class FetchRequestIntrinsic internal constructor(
     MEMBER_REFERRER -> referrer
     MEMBER_REFERRER_POLICY -> referrerPolicy
     MEMBER_MEMBER_URL -> url
+    // Body mixin methods - return executable proxies
+    MEMBER_ARRAY_BUFFER -> org.graalvm.polyglot.proxy.ProxyExecutable { arrayBuffer() }
+    MEMBER_BLOB -> org.graalvm.polyglot.proxy.ProxyExecutable { blob() }
+    MEMBER_FORM_DATA -> org.graalvm.polyglot.proxy.ProxyExecutable { formData() }
+    MEMBER_JSON -> org.graalvm.polyglot.proxy.ProxyExecutable { json() }
+    MEMBER_TEXT -> org.graalvm.polyglot.proxy.ProxyExecutable { text() }
     else -> null
   }
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/Blob.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/Blob.kt
@@ -12,7 +12,12 @@
  */
 package elide.runtime.intrinsics.js
 
-/** TBD. */
-public interface Blob {
-  // Not yet implemented.
-}
+import elide.runtime.intrinsics.js.node.BufferAPI
+
+/**
+ * Represents a Blob object - an immutable, raw data file-like object.
+ *
+ * This interface extends the Node.js BufferAPI.Blob to provide compatibility
+ * with both Web API and Node.js Blob implementations.
+ */
+public interface Blob : BufferAPI.Blob

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/FetchBody.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/FetchBody.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.intrinsics.js
+
+import elide.annotations.API
+import elide.vm.annotations.Polyglot
+
+/**
+ * # Fetch: Body Mixin
+ *
+ * Defines the Body mixin from the Fetch API specification, which provides methods for reading
+ * the body of a Request or Response as various formats.
+ *
+ * From MDN:
+ * "The Body mixin of the Fetch API represents the body of the response/request, allowing you to
+ * declare what its content type is and how it should be handled."
+ *
+ * Both [FetchRequest] and [FetchResponse] implement this mixin to provide consistent body
+ * reading capabilities.
+ *
+ * ## Why This Matters
+ *
+ * While `fetch()` works for outbound requests, server-side code receiving requests via the
+ * fetch handler pattern (`export default { fetch(request) { ... } }`) needs to parse incoming
+ * request bodies. Without `request.json()`, developers must manually read the body stream
+ * and parse JSON, which is error-prone and inconsistent with the Fetch API spec.
+ *
+ * Similarly, `url.searchParams.get()` is essential for parsing query parameters in GET requests,
+ * which is the primary way to pass data in REST APIs.
+ *
+ * &nbsp;
+ *
+ * ## Specification
+ *
+ * See also:
+ * - [MDN: Body](https://developer.mozilla.org/en-US/docs/Web/API/Body)
+ * - [Fetch Standard: Body mixin](https://fetch.spec.whatwg.org/#body-mixin)
+ */
+@API public interface FetchBody {
+  /**
+   * ## Body: body
+   *
+   * A [ReadableStream] of the body contents.
+   *
+   * From MDN:
+   * "The body read-only property of the Request/Response interface contains a ReadableStream
+   * with the body contents that have been added to the request/response."
+   */
+  @get:Polyglot public val body: ReadableStream?
+
+  /**
+   * ## Body: bodyUsed
+   *
+   * A boolean indicating whether the body has been read.
+   *
+   * From MDN:
+   * "The bodyUsed read-only property of the Request/Response interface is a boolean value that
+   * indicates whether the request/response body has been read yet."
+   */
+  @get:Polyglot public val bodyUsed: Boolean
+
+  /**
+   * ## Body: arrayBuffer()
+   *
+   * Returns a promise that resolves with an ArrayBuffer representation of the body.
+   *
+   * From MDN:
+   * "The arrayBuffer() method of the Request/Response interface takes a Request/Response stream
+   * and reads it to completion. It returns a promise that resolves with an ArrayBuffer."
+   *
+   * @return A JsPromise that resolves to an ArrayBuffer containing the body data.
+   */
+  @Polyglot public fun arrayBuffer(): JsPromise<Any>
+
+  /**
+   * ## Body: blob()
+   *
+   * Returns a promise that resolves with a Blob representation of the body.
+   *
+   * From MDN:
+   * "The blob() method of the Request/Response interface takes a Request/Response stream and
+   * reads it to completion. It returns a promise that resolves with a Blob."
+   *
+   * @return A JsPromise that resolves to a Blob containing the body data.
+   */
+  @Polyglot public fun blob(): JsPromise<Blob>
+
+  /**
+   * ## Body: formData()
+   *
+   * Returns a promise that resolves with a FormData representation of the body.
+   *
+   * From MDN:
+   * "The formData() method of the Request/Response interface takes a Request/Response stream
+   * and reads it to completion. It returns a promise that resolves with a FormData object."
+   *
+   * @return A JsPromise that resolves to a FormData object.
+   */
+  @Polyglot public fun formData(): JsPromise<Any>
+
+  /**
+   * ## Body: json()
+   *
+   * Returns a promise that resolves with the result of parsing the body text as JSON.
+   *
+   * From MDN:
+   * "The json() method of the Request/Response interface takes a Request/Response stream and
+   * reads it to completion. It returns a promise which resolves with the result of parsing
+   * the body text as JSON."
+   *
+   * @return A JsPromise that resolves to the parsed JSON value.
+   */
+  @Polyglot public fun json(): JsPromise<Any>
+
+  /**
+   * ## Body: text()
+   *
+   * Returns a promise that resolves with a text representation of the body.
+   *
+   * From MDN:
+   * "The text() method of the Request/Response interface takes a Request/Response stream and
+   * reads it to completion. It returns a promise that resolves with a String."
+   *
+   * @return A JsPromise that resolves to a String containing the body text.
+   */
+  @Polyglot public fun text(): JsPromise<String>
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/FetchRequest.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/FetchRequest.kt
@@ -43,7 +43,7 @@ import elide.vm.annotations.Polyglot
  * constructor, available globally. An instantiated `Request` can then be passed to `fetch` to initiate an HTTP request
  * (host permissions permitting).
  */
-@API public interface FetchRequest {
+@API public interface FetchRequest : FetchBody {
   /** Default values applied to [FetchRequest] interfaces. */
   public object Defaults {
     /** Default `cache` value. */
@@ -71,34 +71,7 @@ import elide.vm.annotations.Polyglot
     public const val DEFAULT_REFERRER_POLICY: String = "no-referrer"
   }
 
-  /**
-   * ## Request: Body.
-   *
-   * Specifies, if any, a [ReadableStream] which holds the body of a [FetchRequest]. Body data may only be provided when
-   * the [method] for the request allows a body, such as `POST`, `PUT`, and so forth.
-   *
-   * From MDN:
-   * "The read-only body property of the Request interface contains a ReadableStream with the body contents that have
-   * been added to the request. Note that a request using the GET or HEAD method cannot have a body and null is returned
-   * in these cases."
-   *
-   * See also: [MDN, Request.body](https://developer.mozilla.org/en-US/docs/Web/API/Request/body).
-   */
-  @get:Polyglot public val body: ReadableStream?
-
-  /**
-   * ## Request: Body usage.
-   *
-   * If the [body] for this request has already been consumed, this property must return `true`; if `false`, the [body]
-   * is still buffered and may be queried.
-   *
-   * From MDN:
-   * "The read-only bodyUsed property of the Request interface is a boolean value that indicates whether the request
-   * body has been read yet."
-   *
-   * See also: [MDN, Request.bodyUsed](https://developer.mozilla.org/en-US/docs/Web/API/Request/bodyUsed).
-   */
-  @get:Polyglot public val bodyUsed: Boolean
+  // Note: `body` and `bodyUsed` are inherited from FetchBody
 
   /**
    * ## Request: Caching.

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/FormData.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/FormData.kt
@@ -121,5 +121,205 @@ public class FormData : ProxyObject, ProxyIterable {
       }
       return formData
     }
+
+    /**
+     * Parse multipart/form-data content.
+     *
+     * @param body The raw body bytes
+     * @param boundary The boundary string from Content-Type header
+     * @return Parsed FormData with fields and files
+     */
+    @JvmStatic
+    public fun parseMultipart(body: ByteArray, boundary: String): FormData {
+      val formData = FormData()
+      val boundaryBytes = "--$boundary".toByteArray(Charsets.UTF_8)
+      val endBoundaryBytes = "--$boundary--".toByteArray(Charsets.UTF_8)
+
+      // Split body by boundary
+      val parts = splitByBoundary(body, boundaryBytes)
+
+      for (part in parts) {
+        if (part.isEmpty() || part.contentEquals(endBoundaryBytes)) continue
+
+        // Parse headers and content from each part
+        val parsed = parseMultipartPart(part)
+        if (parsed != null) {
+          formData.append(parsed.first, parsed.second)
+        }
+      }
+
+      return formData
+    }
+
+    /**
+     * Extract boundary from Content-Type header.
+     * Example: "multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW"
+     */
+    @JvmStatic
+    public fun extractBoundary(contentType: String): String? {
+      val boundaryMatch = Regex("""boundary=([^\s;]+)""").find(contentType)
+      return boundaryMatch?.groupValues?.get(1)?.trim('"')
+    }
+
+    private fun splitByBoundary(body: ByteArray, boundary: ByteArray): List<ByteArray> {
+      val parts = mutableListOf<ByteArray>()
+      var start = 0
+
+      while (start < body.size) {
+        val boundaryIndex = indexOf(body, boundary, start)
+        if (boundaryIndex == -1) {
+          // No more boundaries, add remaining content
+          if (start < body.size) {
+            parts.add(body.copyOfRange(start, body.size))
+          }
+          break
+        }
+
+        if (boundaryIndex > start) {
+          // Add content before boundary (skip leading CRLF)
+          var contentStart = start
+          if (body.size > contentStart + 1 && body[contentStart] == '\r'.code.toByte() && body[contentStart + 1] == '\n'.code.toByte()) {
+            contentStart += 2
+          }
+          if (boundaryIndex > contentStart) {
+            // Remove trailing CRLF before boundary
+            var contentEnd = boundaryIndex
+            if (contentEnd >= 2 && body[contentEnd - 2] == '\r'.code.toByte() && body[contentEnd - 1] == '\n'.code.toByte()) {
+              contentEnd -= 2
+            }
+            if (contentEnd > contentStart) {
+              parts.add(body.copyOfRange(contentStart, contentEnd))
+            }
+          }
+        }
+
+        start = boundaryIndex + boundary.size
+      }
+
+      return parts
+    }
+
+    private fun indexOf(haystack: ByteArray, needle: ByteArray, start: Int = 0): Int {
+      outer@ for (i in start..(haystack.size - needle.size)) {
+        for (j in needle.indices) {
+          if (haystack[i + j] != needle[j]) continue@outer
+        }
+        return i
+      }
+      return -1
+    }
+
+    private fun parseMultipartPart(part: ByteArray): Pair<String, Any>? {
+      // Find the blank line separating headers from content (CRLFCRLF)
+      val headerEndIndex = findHeaderEnd(part)
+      if (headerEndIndex == -1) return null
+
+      val headerBytes = part.copyOfRange(0, headerEndIndex)
+      val contentBytes = part.copyOfRange(headerEndIndex + 4, part.size) // +4 for CRLFCRLF
+
+      val headers = String(headerBytes, Charsets.UTF_8)
+      val headerMap = parsePartHeaders(headers)
+
+      val contentDisposition = headerMap["content-disposition"] ?: return null
+      val name = extractDispositionParam(contentDisposition, "name") ?: return null
+      val filename = extractDispositionParam(contentDisposition, "filename")
+      val contentType = headerMap["content-type"]
+
+      return if (filename != null) {
+        // This is a file field
+        name to FormDataFile(
+          bytes = contentBytes,
+          name = filename,
+          type = contentType,
+          lastModified = System.currentTimeMillis()
+        )
+      } else {
+        // This is a text field
+        name to String(contentBytes, Charsets.UTF_8)
+      }
+    }
+
+    private fun findHeaderEnd(data: ByteArray): Int {
+      for (i in 0..(data.size - 4)) {
+        if (data[i] == '\r'.code.toByte() &&
+            data[i + 1] == '\n'.code.toByte() &&
+            data[i + 2] == '\r'.code.toByte() &&
+            data[i + 3] == '\n'.code.toByte()) {
+          return i
+        }
+      }
+      return -1
+    }
+
+    private fun parsePartHeaders(headers: String): Map<String, String> {
+      return headers.split("\r\n")
+        .filter { it.contains(":") }
+        .associate { line ->
+          val colonIndex = line.indexOf(':')
+          val key = line.substring(0, colonIndex).trim().lowercase()
+          val value = line.substring(colonIndex + 1).trim()
+          key to value
+        }
+    }
+
+    private fun extractDispositionParam(disposition: String, param: String): String? {
+      val regex = Regex("""$param="([^"]+)"""")
+      return regex.find(disposition)?.groupValues?.get(1)
+    }
+  }
+}
+
+/**
+ * Represents a file from multipart form data.
+ * Implements the File interface from the Web API.
+ */
+public class FormDataFile(
+  private val bytes: ByteArray,
+  /** The name of the file. */
+  @get:Polyglot public val name: String,
+  @get:Polyglot public override val type: String?,
+  /** An epoch timestamp indicating the last modification to this file. */
+  @get:Polyglot public val lastModified: Long
+) : Blob, ProxyObject {
+
+  @get:Polyglot
+  public override val size: Int = bytes.size
+
+  @Polyglot
+  public override fun arrayBuffer(): JsPromise<org.graalvm.polyglot.Value> {
+    return JsPromise.resolved(org.graalvm.polyglot.Value.asValue(java.nio.ByteBuffer.wrap(bytes)))
+  }
+
+  @Polyglot
+  public override fun slice(start: Int?, end: Int?, type: String?): Blob {
+    val slicedBytes = bytes.copyOfRange(start ?: 0, end ?: bytes.size)
+    return FormDataFile(slicedBytes, name, type ?: this.type, lastModified)
+  }
+
+  @Polyglot
+  public override fun text(): JsPromise<String> {
+    return JsPromise.resolved(bytes.toString(Charsets.UTF_8))
+  }
+
+  @Polyglot
+  public override fun stream(): ReadableStream {
+    return ReadableStream.wrap(bytes)
+  }
+
+  // ProxyObject implementation
+  override fun getMemberKeys(): Any = arrayOf("name", "size", "type", "lastModified", "arrayBuffer", "slice", "text", "stream")
+
+  override fun hasMember(key: String?): Boolean = key in arrayOf("name", "size", "type", "lastModified", "arrayBuffer", "slice", "text", "stream")
+
+  override fun getMember(key: String?): Any? = when (key) {
+    "name" -> name
+    "size" -> size
+    "type" -> type
+    "lastModified" -> lastModified
+    else -> null
+  }
+
+  override fun putMember(key: String?, value: org.graalvm.polyglot.Value?) {
+    // File is immutable
   }
 }

--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/FormData.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/FormData.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024-2025 Elide Technologies, Inc.
+ *
+ * Licensed under the MIT license (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   https://opensource.org/license/mit/
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+package elide.runtime.intrinsics.js
+
+import org.graalvm.polyglot.proxy.ProxyIterable
+import org.graalvm.polyglot.proxy.ProxyObject
+import elide.vm.annotations.Polyglot
+
+/**
+ * Implements the FormData Web API interface.
+ *
+ * FormData provides a way to construct a set of key/value pairs representing form fields
+ * and their values, which can be sent using fetch() or XMLHttpRequest.
+ */
+public class FormData : ProxyObject, ProxyIterable {
+  private val entries: MutableMap<String, MutableList<Any>> = mutableMapOf()
+
+  /** Appends a new value onto an existing key, or adds the key if it doesn't exist. */
+  @Polyglot
+  public fun append(name: String, value: Any) {
+    entries.getOrPut(name) { mutableListOf() }.add(value)
+  }
+
+  /** Deletes a key and all its values. */
+  @Polyglot
+  public fun delete(name: String) {
+    entries.remove(name)
+  }
+
+  /** Returns an iterator of all key/value pairs. */
+  @Polyglot
+  public fun entries(): Iterator<Array<Any>> = iterator {
+    for ((key, values) in entries) {
+      for (value in values) {
+        yield(arrayOf(key, value))
+      }
+    }
+  }
+
+  /** Returns the first value associated with a given key. */
+  @Polyglot
+  public fun get(name: String): Any? = entries[name]?.firstOrNull()
+
+  /** Returns all values associated with a given key. */
+  @Polyglot
+  public fun getAll(name: String): List<Any> = entries[name] ?: emptyList()
+
+  /** Returns whether a key exists. */
+  @Polyglot
+  public fun has(name: String): Boolean = entries.containsKey(name)
+
+  /** Returns an iterator of all keys. */
+  @Polyglot
+  public fun keys(): Iterator<String> = entries.keys.iterator()
+
+  /** Sets a new value for an existing key, or adds the key/value if it doesn't exist. */
+  @Polyglot
+  public fun set(name: String, value: Any) {
+    entries[name] = mutableListOf(value)
+  }
+
+  /** Returns an iterator of all values. */
+  @Polyglot
+  public fun values(): Iterator<Any> = iterator {
+    for (values in entries.values) {
+      for (value in values) {
+        yield(value)
+      }
+    }
+  }
+
+  // ProxyObject implementation
+  override fun getMemberKeys(): Any = arrayOf("append", "delete", "entries", "get", "getAll", "has", "keys", "set", "values")
+
+  override fun hasMember(key: String?): Boolean = key in arrayOf("append", "delete", "entries", "get", "getAll", "has", "keys", "set", "values")
+
+  override fun getMember(key: String?): Any? = when (key) {
+    "append" -> { name: String, value: Any -> append(name, value) }
+    "delete" -> { name: String -> delete(name) }
+    "entries" -> entries()
+    "get" -> { name: String -> get(name) }
+    "getAll" -> { name: String -> getAll(name) }
+    "has" -> { name: String -> has(name) }
+    "keys" -> keys()
+    "set" -> { name: String, value: Any -> set(name, value) }
+    "values" -> values()
+    else -> null
+  }
+
+  override fun putMember(key: String?, value: org.graalvm.polyglot.Value?) {
+    // FormData is not directly mutable via property access
+  }
+
+  // ProxyIterable implementation - iterates over entries
+  override fun getIterator(): Any = entries()
+
+  public companion object {
+    /**
+     * Parse URL-encoded form data (application/x-www-form-urlencoded).
+     */
+    @JvmStatic
+    public fun parseUrlEncoded(body: String): FormData {
+      val formData = FormData()
+      if (body.isBlank()) return formData
+
+      for (pair in body.split("&")) {
+        val parts = pair.split("=", limit = 2)
+        val key = java.net.URLDecoder.decode(parts[0], Charsets.UTF_8)
+        val value = if (parts.size > 1) java.net.URLDecoder.decode(parts[1], Charsets.UTF_8) else ""
+        formData.append(key, value)
+      }
+      return formData
+    }
+  }
+}

--- a/packages/graalvm/src/main/kotlin/elide/runtime/node/buffer/NodeBlob.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/node/buffer/NodeBlob.kt
@@ -20,6 +20,7 @@ import java.io.OutputStream
 import java.nio.ByteBuffer
 import elide.runtime.core.DelicateElideApi
 import elide.runtime.core.PolyglotValue
+import elide.runtime.intrinsics.js.Blob
 import elide.runtime.intrinsics.js.JsPromise
 import elide.runtime.intrinsics.js.ReadableStream
 import elide.runtime.intrinsics.js.node.BufferAPI
@@ -32,7 +33,7 @@ import elide.vm.annotations.Polyglot
 @DelicateElideApi @Implementable public open class NodeBlob internal constructor(
   internal val bytes: ByteArray,
   @Polyglot override val type: String?
-) : BufferAPI.Blob, ProxyObject {
+) : Blob, ProxyObject {
   /** Creates a new empty buffer. */
   @Polyglot public constructor() : this(sources = null, options = null)
 


### PR DESCRIPTION
![Draft](https://img.shields.io/badge/Status-Draft-gray?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Adds the `FetchBody` interface implementing the Fetch API Body mixin, which provides methods for reading request/response bodies:

- `arrayBuffer()` - Read body as ArrayBuffer
- `blob()` - Read body as Blob
- `formData()` - Read body as FormData
- `json()` - Read body as parsed JSON
- `text()` - Read body as string

`FetchRequest` now extends `FetchBody` to inherit these methods.

## ⚠️ Draft Status - Need Guidance

This PR is a **draft** - the implementation is stubbed with TODOs. I need guidance on:

1. **ReadableStream consumption** - How to properly consume the body stream and collect bytes
2. **JSON.parse integration** - How to invoke the GraalJS JSON.parse from Kotlin
3. **ArrayBuffer intrinsic** - How to create ArrayBuffer instances for guest code
4. **Blob intrinsic** - How to create Blob instances

@darvld - Would appreciate your guidance on the best approach for these integrations. Happy to implement once I understand the patterns.

## Why This Matters

While `fetch()` works for outbound requests, server-side code receiving requests via the fetch handler pattern needs to parse incoming request bodies:

```typescript
export default {
  async fetch(request: Request): Promise<Response> {
    // ❌ Currently throws "Unknown identifier: json"
    const body = await request.json();
    
    // Workaround requires manual stream reading + JSON parsing
    // which is error-prone and inconsistent with Fetch API spec
  }
}
```

This is blocking real-world server applications in elide-showcases.

## Changes

- **New:** `FetchBody.kt` - Interface defining Body mixin methods with full JSDoc
- **Modified:** `FetchRequest.kt` - Now extends `FetchBody`
- **Modified:** `FetchRequestIntrinsic.kt` - Stub implementations with TODOs

## Related

- Discovered while testing elide-showcases server examples
- Related to #1803 (URL.searchParams - separate PR, ready to merge)