### PR TITLE
fix(fetch): implement Request.text(), json(), arrayBuffer() methods

### DIFF
--- a/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/FetchRequest.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/intrinsics/js/FetchRequest.kt
@@ -270,4 +270,43 @@ import elide.vm.annotations.Polyglot
    * See also: [MDN, Request.url](https://developer.mozilla.org/en-US/docs/Web/API/Request/url).
    */
   @get:Polyglot public val url: String
+
+  /**
+   * ## Request: text()
+   *
+   * Returns a promise that resolves with a text representation of the request body.
+   *
+   * From MDN:
+   * "The text() method of the Request interface reads the request body and returns it as a promise that resolves with
+   * a String. The response is always decoded using UTF-8."
+   *
+   * See also: [MDN, Request.text()](https://developer.mozilla.org/en-US/docs/Web/API/Request/text).
+   */
+  @Polyglot public fun text(): Any
+
+  /**
+   * ## Request: json()
+   *
+   * Returns a promise that resolves with the result of parsing the request body as JSON.
+   *
+   * From MDN:
+   * "The json() method of the Request interface reads the request body and returns it as a promise that resolves with
+   * the result of parsing the body text as JSON."
+   *
+   * See also: [MDN, Request.json()](https://developer.mozilla.org/en-US/docs/Web/API/Request/json).
+   */
+  @Polyglot public fun json(): Any
+
+  /**
+   * ## Request: arrayBuffer()
+   *
+   * Returns a promise that resolves with an ArrayBuffer representation of the request body.
+   *
+   * From MDN:
+   * "The arrayBuffer() method of the Request interface reads the request body and returns it as a promise that
+   * resolves with an ArrayBuffer."
+   *
+   * See also: [MDN, Request.arrayBuffer()](https://developer.mozilla.org/en-US/docs/Web/API/Request/arrayBuffer).
+   */
+  @Polyglot public fun arrayBuffer(): Any
 }


### PR DESCRIPTION
![Ready for review](https://img.shields.io/badge/Status-Ready_for_review-green?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Implements the missing body-reading methods on `FetchRequest` interface:

- `text()`: Returns body as string (UTF-8)
- `json()`: Parses body as JSON  
- `arrayBuffer()`: Returns body as byte array

## Changes

### `FetchRequest.kt` (Interface)
- Added interface method declarations for `text()`, `json()`, `arrayBuffer()`

### `FetchRequestIntrinsic.kt` (Implementation)
- Added `rawBodyBytes` constructor parameter for storing request body
- Implemented `readBodyBytes()` helper method
- Added `text()`, `json()`, `arrayBuffer()` implementations
- Added `ProxyExecutable` wrappers in `getMember()` for GraalVM interop
- Modified `forRequest()` factories to capture raw bytes

### `JsServerRequestExecutionInputs.kt` (Server integration)
- Added `cachedBodyBytes` field with lazy body reading
- Implemented `text()`, `json()`, `arrayBuffer()` methods

## Notes

- Implementation is **synchronous** (returns values directly, not Promises)
- A full async Promise implementation would need additional GraalVM integration
- This unblocks basic MCP server and REST API use cases that need POST body parsing

## Testing

Build verified: `./gradlew :packages:graalvm:compileKotlin` passes

Fixes #1805