### PR TITLE
Fix Makefile to properly display Java version on `make info` invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1022,7 +1022,7 @@ info:  ## Show info about the current codebase and toolchain.
 	@echo "- PNPM: $(PNPM)"
 	@echo "" && echo "---- Toolchain Versions -----------------------------------"
 	@echo "Java:"
-	$(CMD)$(JAVA) --version
+	$(CMD)$(JAVA) -version
 	@echo ""
 	@echo "Native Image:"
 	$(CMD)$(NATIVE_IMAGE) --version


### PR DESCRIPTION
![Ready for review](https://img.shields.io/badge/Status-Ready_for_review-green?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Intended command:
```
$ java -version
```
Intended output:
```
java version "1.8.0_471"
Java(TM) SE Runtime Environment (build 1.8.0_471-b09)
Java HotSpot(TM) 64-Bit Server VM (build 25.471-b09, mixed mode)
```
Actual command:
```
$ java --version
```
Actual output:
```
Unrecognized option: --version
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

This shows up when you run `make info` at the bottom

## Changelog

- feat(cli): added a thing
- fix(dev): fixed a thing
- chore: updated → `1.0`