### PR TITLE
fix: preserve user-specified Content-Type header in Response

### DIFF
--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchIntrinsic.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchIntrinsic.kt
@@ -153,21 +153,24 @@ import elide.vm.annotations.Polyglot
     value.isString -> {
       val bytes = value.asString().toByteArray(StandardCharsets.UTF_8)
 
-      headers.set("Content-Type", "text/plain")
+      // Only set Content-Type if not already specified by user
+      if (!headers.has("Content-Type")) headers.set("Content-Type", "text/plain")
       headers.set("Content-Length", bytes.size.toString())
 
       ReadableStream.wrap(bytes)
     }
     // buffer-like objects are wrapped as-is, the consumer can choose to use the bytes
     value.hasBufferElements() -> {
-      headers.set("Content-Type", "application/octet-stream")
+      // Only set Content-Type if not already specified by user
+      if (!headers.has("Content-Type")) headers.set("Content-Type", "application/octet-stream")
       headers.set("Content-Length", value.bufferSize.toString())
 
       ReadableStream.from(listOf(value))
     }
     // array buffer views can be unwrapped and sent as plain buffers
     ArrayBufferViews.getViewTypeOrNull(value) != null -> {
-      headers.set("Content-Type", "application/octet-stream")
+      // Only set Content-Type if not already specified by user
+      if (!headers.has("Content-Type")) headers.set("Content-Type", "application/octet-stream")
       headers.set("Content-Length", ArrayBufferViews.getLength(value).toString())
 
       ReadableStream.wrap(ArrayBufferViews.readViewedBytes(value))
@@ -176,7 +179,8 @@ import elide.vm.annotations.Polyglot
     else -> {
       val json = Json.encodeToString(GuestValueSerializer, value)
 
-      headers.set("Content-Type", "application/json")
+      // Only set Content-Type if not already specified by user
+      if (!headers.has("Content-Type")) headers.set("Content-Type", "application/json")
       headers.set("Content-Length", json.length.toString())
 
       ReadableStream.wrap(json.toByteArray(StandardCharsets.UTF_8))


### PR DESCRIPTION
![Ready for review](https://img.shields.io/badge/Status-Ready_for_review-green?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

Fixes #1817 - Response `Content-Type` header is overwritten by `mapResponseBody()`

## Problem

When using `elide serve` with a fetch handler that returns a `Response` with a custom `Content-Type` header, the header was being unconditionally overwritten based on body type:

```typescript
// User code
return new Response("<h1>Hello</h1>", { 
  headers: { "Content-Type": "text/html; charset=utf-8" }
});

// Actual response: Content-Type: text/plain (wrong!)
```

**Note:** This only affects the declarative fetch handler pattern (`elide serve`). The `node:http` imperative pattern (used by apps like compare-gpt-elide) is not affected.

## Regression Source

Bug introduced in PR #1736 ("feat: new server engine"). The `mapResponseBody()` function was added with unconditional `headers.set("Content-Type", ...)` calls.

## Solution

Modified `mapResponseBody()` to check if `Content-Type` is already set before applying defaults:

```kotlin
// Before (bug):
headers.set("Content-Type", "text/plain")

// After (fix):
if (!headers.has("Content-Type")) headers.set("Content-Type", "text/plain")
```

This preserves user-specified Content-Type headers while still providing sensible defaults when none is specified.

## Testing

Added regression tests in `FetchIntrinsicTest.kt`:
- ✅ `response should preserve user-specified Content-Type header`
- ✅ `response should use default Content-Type when not specified`
- ✅ `response should preserve custom headers`

Manual testing:
- Tested with `elide serve` - custom `Content-Type: text/html` now preserved
- Custom headers like `X-Custom` were already working (only Content-Type was affected)

## Changelog

- fix(graalvm): preserve user-specified Content-Type header in Response
- test(graalvm): add regression tests for Content-Type header preservation