### PR TITLE
Fix: preserve user-defined Content-Type in fetch responses

### DIFF
--- a/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchIntrinsic.kt
+++ b/packages/graalvm/src/main/kotlin/elide/runtime/gvm/internals/intrinsics/js/fetch/FetchIntrinsic.kt
@@ -153,7 +153,10 @@ import elide.vm.annotations.Polyglot
     value.isString -> {
       val bytes = value.asString().toByteArray(StandardCharsets.UTF_8)
 
+      if (!headers.has("Content-Type")) {
       headers.set("Content-Type", "text/plain")
+  }
+
       headers.set("Content-Length", bytes.size.toString())
 
       ReadableStream.wrap(bytes)
@@ -176,7 +179,10 @@ import elide.vm.annotations.Polyglot
     else -> {
       val json = Json.encodeToString(GuestValueSerializer, value)
 
+      if (!headers.has("Content-Type")) {
       headers.set("Content-Type", "application/json")
+  }
+
       headers.set("Content-Length", json.length.toString())
 
       ReadableStream.wrap(json.toByteArray(StandardCharsets.UTF_8))


### PR DESCRIPTION
![Ready for review](https://img.shields.io/badge/Status-Ready_for_review-green?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=elide-dev&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR fixes an issue where FetchResponse overwrote user-defined Content-Type headers.

Before, mapResponseBody() always replaced Content-Type based on body type.
After, ensures Content-Type is only set when not already provided.

Fixes #1817